### PR TITLE
rename neuroid to neuroid_components after PCA

### DIFF
--- a/mkgu/metrics/neural_fit.py
+++ b/mkgu/metrics/neural_fit.py
@@ -60,7 +60,8 @@ class PCANeuroidCharacterization(Characterization):
         self._logger.debug('PCA from {} to {}'.format(assembly.neuroid.shape[0], self._pca.n_components))
         transformed_values = self._pca.fit_transform(assembly)
 
-        coords = {dim: assembly[dim] if dim != 'neuroid' else assembly.neuroid[:self._pca.n_components]
+        coords = {dim if dim != 'neuroid' else 'neuroid_components':
+                      assembly[dim] if dim != 'neuroid' else assembly.neuroid[:self._pca.n_components]
                   for dim in assembly.coords}
         return mkgu.assemblies.NeuroidAssembly(transformed_values, coords=coords, dims=assembly.dims)
 


### PR DESCRIPTION
I thought it was incorrect to name the PCA components `neuroid`; rather it should be `neuroid_components`.