### PR TITLE
non-parametric metrics (i.e. RDM) only require two arguments

### DIFF
--- a/brainscore/benchmarks.py
+++ b/brainscore/benchmarks.py
@@ -7,6 +7,7 @@ from caching import store
 
 import brainscore
 from brainscore.assemblies import merge_data_arrays
+from brainscore.metrics import NonparametricWrapper
 from brainscore.metrics.anatomy import ventral_stream, EdgeRatioMetric
 from brainscore.metrics.ceiling import ceilings
 from brainscore.metrics.neural_fit import NeuralFit
@@ -17,7 +18,7 @@ from brainscore.utils import map_fields, combine_fields, fullname
 caching.store.configure_storagedir(os.path.join(os.path.dirname(__file__), '..', 'output'))
 
 metrics = {
-    'rdm': RDMMetric,
+    'rdm': lambda *args, **kwargs: NonparametricWrapper(RDMMetric(*args, **kwargs)),
     'neural_fit': NeuralFit,
     'edge_ratio': EdgeRatioMetric
 }

--- a/brainscore/metrics/rdm.py
+++ b/brainscore/metrics/rdm.py
@@ -12,6 +12,7 @@ class RSA(object):
     """
 
     def __call__(self, assembly):
+        assert len(assembly.dims) == 2
         correlations = np.corrcoef(assembly) if assembly.dims[-1] == 'neuroid' else np.corrcoef(assembly.T).T
         coords = {coord: coord_value for coord, coord_value in assembly.coords.items() if coord != 'neuroid'}
         dims = [dim if dim != 'neuroid' else assembly.dims[(i - 1) % len(assembly.dims)]
@@ -57,14 +58,15 @@ class RDMMetric(NonparametricMetric):
         self._rdm = RDM()
         self._similarity = RDMSimilarity()
 
-    def compute(self, rdm1, rdm2):
+    def _apply(self, assembly1, assembly2):
         """
-        :param brainscore.assemblies.NeuroidAssembly rdm1:
-        :param brainscore.assemblies.NeuroidAssembly rdm2:
+        :param brainscore.assemblies.NeuroidAssembly assembly1:
+        :param brainscore.assemblies.NeuroidAssembly assembly2:
         :param str similarity_dims: indicate the dimension along which the RDM/RSA was computed,
             either with a string for a repeated dimension or with a list for two different dimension names
         :return: brainscore.assemblies.DataAssembly
         """
-        rdm1 = self._rdm(rdm1)
-        rdm2 = self._rdm(rdm2)
-        return self._similarity(rdm1, rdm2)
+        rdm1 = self._rdm(assembly1)
+        rdm2 = self._rdm(assembly2)
+        similarity = self._similarity(rdm1, rdm2)
+        return similarity

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,8 +5,12 @@ import os
 
 import numpy as np
 import pandas as pd
+from pytest import approx
 
 from brainscore import benchmarks
+from brainscore.assemblies import NeuroidAssembly
+from brainscore.benchmarks import SplitBenchmark, metrics
+from brainscore.metrics.ceiling import SplitNoCeiling
 
 
 def test_score_precomputed_alexnet_activations():
@@ -28,3 +32,84 @@ def test_score_precomputed_alexnet_activations():
     for region in scores.region:
         max_region_score = scores[scores['region'] == region].max()
         assert max_region_score['layer'] == region_best_layers[region]
+
+
+class TestRDMBenchmark(object):
+    class TestBenchmark(SplitBenchmark):
+        def __init__(self, assembly):
+            metric = metrics['rdm']()
+            ceiling = SplitNoCeiling()
+            super().__init__(assembly, metric, ceiling, target_splits=())
+
+    def _build_benchmark(self, assembly):
+        return self.TestBenchmark(assembly)
+
+    def _score(self, source_assembly, target_assembly):
+        benchmark = self._build_benchmark(target_assembly)
+        return benchmark(source_assembly)
+
+    def test_2d_equal(self):
+        values = np.random.rand(60, 30)
+        assembly = NeuroidAssembly(values, coords={
+            'image_id': ('presentation', list(range(60))), 'object_name': ('presentation', ['A', 'B'] * 30),
+            'neuroid_id': ('neuroid', list(range(30)))},
+                                   dims=['presentation', 'neuroid'])
+        score = self._score(assembly, assembly)
+        assert score.aggregation.sel(aggregation='center') == approx(1.)
+
+    def test_3d_equal(self):
+        # presentation x neuroid
+        values = np.broadcast_to(np.random.rand(60, 30, 1), [60, 30, 3]).copy()
+        # can't stack because xarray gets confused with repeated dimensions
+        assembly1 = NeuroidAssembly(values, coords={
+            'image_id': ('presentation', list(range(60))), 'object_name': ('presentation', ['A', 'B'] * 30),
+            'neuroid_id': ('neuroid', list(range(30))),
+            'dim1': list(range(3))},
+                                    dims=['presentation', 'neuroid', 'dim1'])
+        assembly2 = NeuroidAssembly(values, coords={
+            'image_id': ('presentation', list(range(60))), 'object_name': ('presentation', ['A', 'B'] * 30),
+            'neuroid_id': ('neuroid', list(range(30))),
+            'dim2': list(range(3))},
+                                    dims=['presentation', 'neuroid', 'dim2'])
+        score = self._score(assembly1, assembly2)
+        score = score.aggregation.sel(aggregation='center')
+        np.testing.assert_array_equal(score.shape, [3, 3])
+        np.testing.assert_array_almost_equal(score, np.broadcast_to(1, [3, 3]))
+
+    def test_3d_diag(self):
+        # presentation x neuroid
+        values = np.random.rand(60, 30, 3)
+        assembly1 = NeuroidAssembly(values, coords={
+            'image_id': ('presentation', list(range(60))), 'object_name': ('presentation', ['A', 'B'] * 30),
+            'neuroid_id': ('neuroid', list(range(30))),
+            'dim1': list(range(3))},
+                                    dims=['presentation', 'neuroid', 'dim1'])
+        assembly2 = NeuroidAssembly(values, coords={
+            'image_id': ('presentation', list(range(60))), 'object_name': ('presentation', ['A', 'B'] * 30),
+            'neuroid_id': ('neuroid', list(range(30))),
+            'dim2': list(range(3))},
+                                    dims=['presentation', 'neuroid', 'dim2'])
+        score = self._score(assembly1, assembly2)
+        center = score.aggregation.sel(aggregation='center')
+        np.testing.assert_array_equal(center.shape, [3, 3])
+        assert len(score.values['split']) * 3 == (score.values == approx(1)).sum()
+        diags_indexer = center['dim1'] == center['dim2']
+        diag_values = center.values[diags_indexer.values]
+        np.testing.assert_array_almost_equal(diag_values, 1)
+
+    def test_3d_equal_presentation_last(self):
+        values = np.broadcast_to(np.random.rand(60, 30, 1), [60, 30, 3]).copy()
+        assembly1 = NeuroidAssembly(values.T, coords={
+            'image_id': ('presentation', list(range(60))), 'object_name': ('presentation', ['A', 'B'] * 30),
+            'neuroid_id': ('neuroid', list(range(30))),
+            'dim1': list(range(3))},
+                                    dims=['dim1', 'neuroid', 'presentation'])
+        assembly2 = NeuroidAssembly(values.T, coords={
+            'image_id': ('presentation', list(range(60))), 'object_name': ('presentation', ['A', 'B'] * 30),
+            'neuroid_id': ('neuroid', list(range(30))),
+            'dim2': list(range(3))},
+                                    dims=['dim2', 'neuroid', 'presentation'])
+        scores = self._score(assembly1, assembly2)
+        scores = scores.aggregation.sel(aggregation='center')
+        np.testing.assert_array_equal(scores.shape, [3, 3])
+        np.testing.assert_array_almost_equal(scores, 1)

--- a/tests/test_metrics/test___init__.py
+++ b/tests/test_metrics/test___init__.py
@@ -34,7 +34,7 @@ class NonparametricPlaceholder(NonparametricMetric):
         self.source_assemblies = []
         self.target_assemblies = []
 
-    def compute(self, source_assembly, target_assembly):
+    def _apply(self, source_assembly, target_assembly):
         self.source_assemblies.append(source_assembly)
         self.target_assemblies.append(target_assembly)
         return 0

--- a/tests/test_metrics/test_rdm.py
+++ b/tests/test_metrics/test_rdm.py
@@ -10,6 +10,12 @@ from tests.test_metrics import load_hvm
 
 
 class TestRSA(object):
+    def test_equal_hvm(self):
+        hvm = load_hvm().sel(region='IT')
+        metric = RDMMetric()
+        score = metric(hvm, hvm)
+        assert score == approx(1.)
+
     def test_hvm(self):
         hvm_it_v6_obj = self._load_neural_data()
         assert hvm_it_v6_obj.shape == (64, 168)
@@ -56,75 +62,7 @@ class TestRDMSimilarity(object):
         assert score == approx(1.)
 
 
-class TestRDMMetric(object):
-    @pytest.yield_fixture(autouse=True)
-    def run_around_tests(self):
-        self.metric = RDMMetric()
-        yield  # run test function
-
-    def test_equal_hvm(self):
-        hvm = load_hvm().sel(region='IT')
-        score = self.metric(hvm, hvm)
-        assert score.center == approx(1.)
-
-    def test_3d_equal(self):
-        # presentation x neuroid
-        values = np.broadcast_to(np.random.rand(20, 30, 1), [20, 30, 3]).copy()
-        # can't stack because xarray gets confused with repeated dimensions
-        assembly1 = NeuroidAssembly(values, coords={
-            'image_id': ('presentation', list(range(20))), 'object_name': ('presentation', ['A', 'B'] * 10),
-            'neuroid_id': ('neuroid', list(range(30))),
-            'dim1': list(range(3))},
-                                    dims=['presentation', 'neuroid', 'dim1'])
-        assembly2 = NeuroidAssembly(values, coords={
-            'image_id': ('presentation', list(range(20))), 'object_name': ('presentation', ['A', 'B'] * 10),
-            'neuroid_id': ('neuroid', list(range(30))),
-            'dim2': list(range(3))},
-                                    dims=['presentation', 'neuroid', 'dim2'])
-        score = self.metric(assembly1, assembly2)
-        np.testing.assert_array_equal(score.center.shape, [3, 3])
-        np.testing.assert_array_almost_equal(score.center, np.broadcast_to(1, [3, 3]))
-
-    def test_3d_diag(self):
-        # presentation x neuroid
-        values = np.random.rand(20, 30, 3)
-        assembly1 = NeuroidAssembly(values, coords={
-            'image_id': ('presentation', list(range(20))), 'object_name': ('presentation', ['A', 'B'] * 10),
-            'neuroid_id': ('neuroid', list(range(30))),
-            'dim1': list(range(3))},
-                                    dims=['presentation', 'neuroid', 'dim1'])
-        assembly2 = NeuroidAssembly(values, coords={
-            'image_id': ('presentation', list(range(20))), 'object_name': ('presentation', ['A', 'B'] * 10),
-            'neuroid_id': ('neuroid', list(range(30))),
-            'dim2': list(range(3))},
-                                    dims=['presentation', 'neuroid', 'dim2'])
-        score = self.metric(assembly1, assembly2)
-        np.testing.assert_array_equal(score.center.shape, [3, 3])
-        assert len(score.values['split']) * 3 == (score.values == approx(1)).sum()
-        diags_indexer = score.center['dim1'] == score.center['dim2']
-        diag_values = score.center.values[diags_indexer.values]
-        np.testing.assert_array_almost_equal(diag_values, 1)
-
-    def test_3d_equal_presentation_last(self):
-        values = np.broadcast_to(np.random.rand(20, 30, 1), [20, 30, 3]).copy()
-        assembly1 = NeuroidAssembly(values.T, coords={
-            'image_id': ('presentation', list(range(20))), 'object_name': ('presentation', ['A', 'B'] * 10),
-            'neuroid_id': ('neuroid', list(range(30))),
-            'dim1': list(range(3))},
-                                    dims=['dim1', 'neuroid', 'presentation'])
-        assembly2 = NeuroidAssembly(values.T, coords={
-            'image_id': ('presentation', list(range(20))), 'object_name': ('presentation', ['A', 'B'] * 10),
-            'neuroid_id': ('neuroid', list(range(30))),
-            'dim2': list(range(3))},
-                                    dims=['dim2', 'neuroid', 'presentation'])
-        scores = self.metric(assembly1, assembly2)
-        np.testing.assert_array_equal(scores.center.shape, [3, 3])
-        np.testing.assert_array_almost_equal(scores.center, 1)
-
-
 def test_np_load():
-    print(os.getcwd())
     p_path = os.path.join(os.path.dirname(__file__), "it_rdm.p")
     it_rdm = np.load(p_path, encoding="latin1")
-    print(it_rdm)
     assert it_rdm.shape == (64, 64)


### PR DESCRIPTION
i.e. they don't require training data and instead only require test source and target.
update tests accordingly and extract rdm benchmark tests to test_integration.py