### PR TITLE
fix endpoints test

### DIFF
--- a/tests/test_submission/test_endpoints.py
+++ b/tests/test_submission/test_endpoints.py
@@ -66,9 +66,9 @@ class TestRunScoring:
         assert len(score_entries) == 2
         score_values = [entry.score_ceiled for entry in score_entries]
         assert all(np.array(score_values) > 0)
-        score_MajajHong = database_models.Score.get(benchmark__benchmark_type_id='MajajHong2015.IT.public-pls')
+        score_MajajHong = database_models.Score.get(benchmark__benchmark_type_id='dicarlo.MajajHong2015.IT.public-pls')
         assert score_MajajHong.score_ceiled == approx(.5079817, abs=0.005)
-        score_Rajalingham = database_models.Score.get(benchmark__benchmark_type_id='Rajalingham2018-i2n')
+        score_Rajalingham = database_models.Score.get(benchmark__benchmark_type_id='dicarlo.Rajalingham2018-i2n')
         assert score_Rajalingham.score_ceiled == approx(.3701702, abs=0.005)
 
     def test_two_models_two_benchmarks(self):


### PR DESCRIPTION
fix benchmark identifiers to retrieve scores.

the remaining failing `test_two_models_two_benchmarks` benchmark takes a long time to run, it's possible the database connection closes in the meantime which leads to the test failure.