### PR TITLE
Make automerge contingent on both Travis and Jenkins

### DIFF
--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -16,6 +16,8 @@ name: Automatically merge plugin-only PRs
 on:
   pull_request:
     types: [labeled]
+  check_run:
+    types: [completed]
   status:
 
 permissions: write-all

--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -4,13 +4,14 @@ name: Automatically merge plugin-only PRs
 # Triggered on all PRs either by
 # - completion of CI checks, OR
 # - tagging with label
-# 1) If PR is labeled "automerge" or "automerge-web" 
+# If PR is labeled "automerge" or "automerge-web" 
 # (all website submissions are tagged "automerge-web"),
-# checks if Travis tests pass. If yes, THEN
-# 2) Checks if PR modifies any code outside plugin dirs. 
-# If no changes are made beyond new or revised plugins
+# checks if Travis and Jenkins tests pass. 
+# A successful status update from Travis also confirms that
+# the PR is plugin-only. Therefore, if all tests pass, this
+# indicates that no changes are made beyond new or revised plugins
 # (subdirs of /benchmarks, /data, /models, or /metrics) 
-# the PR is automatically approved and merged.
+# and the PR is automatically approved and merged.
 
 
 on:
@@ -39,39 +40,30 @@ jobs:
           echo "::set-output name=AUTOMERGE::True"
 
 
-  travis_success:
-    name: Check if Travis build is successful
+  check_test_results:
+    name: Check if all tests (Travis, Jenkins) have passed (confirms PR is plugin-only)
     runs-on: ubuntu-latest
     needs: [isautomerge]
     if: ${{ needs.isautomerge.outputs.AUTOMERGE == 'True' }}
     outputs:
-      TRAVIS_OK: ${{ steps.istravisok.outputs.TRAVIS_OK }}
+      ALL_TESTS_PASS: ${{ steps.gettestresults.outputs.TEST_RESULTS }}
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Get Travis build status
-        id: gettravisstatus
+        id: gettestresults
         run: |
-          echo ${{ github.event.pull_request.head.sha }}
-          echo "TRAVIS_CONCLUSION=$(python -c "import requests; r = requests.get(\"https://api.github.com/repos/brain-score/vision/commits/${{ github.event.pull_request.head.sha }}/check-runs\"); print(next(run['conclusion'] for run in r.json()['check_runs'] if run['name'] == 'Travis CI - Pull Request'))")" >> $GITHUB_ENV
-      - name: Check if Travis was successful
-        id: istravisok
-        run: |
-          if [ "$TRAVIS_CONCLUSION" == "success" ]
-          then
-              travisok=True
-          elif [ "$TRAVIS_CONCLUSION" == "None" ]
-          then
-              travisok=Wait
-          else
-              travisok=False
-          fi
-          echo "::set-output name=TRAVIS_OK::$travisok"
+          echo "test_results=$( python brainscore_vision/submission/check_test_status.py ${{ github.event.pull_request.head.sha }} )"
+          echo "::set-output name=TEST_RESULTS::$test_results"
 
 
   automerge:
     name: If plugin-only, approve and merge
     runs-on: ubuntu-latest
     needs: plugin_only
-    if: ${{ needs.plugin_only.outputs.PLUGIN_ONLY == 'True' }}
+    if: ${{ needs.check_test_results.outputs.ALL_TESTS_PASS == 'True' }}
     steps:
       - name: Auto Approve
         uses: hmarr/auto-approve-action@v3.1.0

--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -67,29 +67,6 @@ jobs:
           echo "::set-output name=TRAVIS_OK::$travisok"
 
 
-  plugin_only:
-    name: Ensure PR ONLY changes plugin files
-    runs-on: ubuntu-latest
-    needs: travis_success
-    if: ${{ needs.travis_success.outputs.TRAVIS_OK == 'True' }}
-    outputs:
-      PLUGIN_ONLY: ${{ steps.ispluginonly.outputs.PLUGIN_ONLY }}
-    steps:
-      - name: Parse plugin_only confirmation from Travis status update
-        id: getpluginonlyvalue
-        run: echo "PLUGIN_ONLY=$(python -c "import requests; r = requests.get(\"https://api.github.com/repos/brain-score/vision/statuses/$github.event.pull_request.head.sha\"); print(next(status['description'].split('- ')[1] for status in r.json() if status['description'].startswith('Run automerge workflow')))")" >> $GITHUB_ENV
-      - name: Check if PR is plugin only
-        id: ispluginonly
-        run: |
-          if [ "$PLUGIN_ONLY" == "True" ]
-          then
-            pluginonly=True
-          else
-            pluginonly=False
-          fi
-          echo "::set-output name=PLUGIN_ONLY::$pluginonly"
-
-
   automerge:
     name: If plugin-only, approve and merge
     runs-on: ubuntu-latest

--- a/.github/workflows/check_test_status.py
+++ b/.github/workflows/check_test_status.py
@@ -1,0 +1,41 @@
+# Uses GitHub API to check test suite status (Travis, Jenkins)
+
+import requests
+import sys
+
+BASE_URL = "https://api.github.com/repos/brain-score/vision"
+
+
+def get_data(pr_head_sha: str, url: str) -> dict:
+    r = requests.get(url)
+    assert r.status_code == 200
+    return r.json()
+
+def get_check_runs_result(run_name: str, check_runs: dict) -> str:
+    last_run_result = next(run['conclusion'] for run in check_runs['check_runs'] if run['name'] == run_name)
+    return last_run_result
+
+def get_statuses_result(context: str, statuses: dict) -> str:
+    last_status_result = next(status['state'] for status in statuses if status['context'] == context)
+    return last_status_result
+
+def all_tests_passing(test_results: list):
+    if any(result != "success" for result in test_results):
+        print(False)
+    else:
+        print(True)
+
+
+if __name__ == "__main__":
+
+    pr_head_sha = sys.argv[1]
+
+    check_runs_json = get_data(pr_head_sha, f"{BASE_URL}/commits/{pr_head_sha}/check-runs")
+    statuses_json = get_data(pr_head_sha, f"{BASE_URL}/statuses/{pr_head_sha}")
+
+    travis_branch_result = get_check_runs_result('Travis CI - Branch', check_runs_json)
+    travis_pr_result = get_statuses_result('continuous-integration/travis', statuses_json)
+    jenkins_plugintests_result = get_statuses_result('Brain-Score Jenkins CI - plugin tests', statuses_json)
+    jenkins_unittests_result = get_statuses_result('Brain-Score Jenkins CI', statuses_json)
+
+    all_tests_passing([travis_branch_result, travis_pr_result, jenkins_plugintests_result, jenkins_unittests_result])

--- a/.github/workflows/travis_trigger.sh
+++ b/.github/workflows/travis_trigger.sh
@@ -5,6 +5,6 @@ TRAVIS_PULL_REQUEST_SHA=$2
 
 curl -L -X POST \
 -H "Authorization: token $GH_WORKFLOW_TRIGGER" \
--d '{"state": "success", "description": "Run automerge workflow for plugin-only PR", 
+-d '{"state": "success", "description": "Successful Travis PR build for plugin-only PR", 
   "context": "continuous-integration/travis"}' \
   "https://api.github.com/repos/brain-score/brain-score/statuses/$TRAVIS_PULL_REQUEST_SHA"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,8 @@ jobs:
       if: type = pull_request
       script:
         - |
-          if [ ! -z "$TRAVIS_PULL_REQUEST_BRANCH" ]; then 
-            CHANGED_FILES=$( git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch && echo $(git diff --name-only origin/$TRAVIS_PULL_REQUEST_BRANCH origin/$TRAVIS_BRANCH -C $TRAVIS_BUILD_DIR) | tr '\n' ' ' ) &&
-            PLUGIN_ONLY=$( python -c "from brainscore_core.plugin_management.parse_plugin_changes import is_plugin_only; is_plugin_only(\"${CHANGED_FILES}\", \"brainscore_${DOMAIN}\")" )
-          fi
-        - |
+          CHANGED_FILES=$( git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*" && git fetch && echo $(git diff --name-only origin/$TRAVIS_PULL_REQUEST_BRANCH origin/$TRAVIS_BRANCH -C $TRAVIS_BUILD_DIR) | tr '\n' ' ' ) &&
+          PLUGIN_ONLY=$( python -c "from brainscore_core.plugin_management.parse_plugin_changes import is_plugin_only; is_plugin_only(\"${CHANGED_FILES}\", \"brainscore_${DOMAIN}\")" )
           if [ "$PLUGIN_ONLY" = "True" ]; then 
             bash ${TRAVIS_BUILD_DIR}/.github/workflows/travis_trigger.sh $GH_WORKFLOW_TRIGGER $TRAVIS_PULL_REQUEST_SHA; 
           fi

--- a/brainscore_vision/submission/check_test_status.py
+++ b/brainscore_vision/submission/check_test_status.py
@@ -6,7 +6,7 @@ import sys
 BASE_URL = "https://api.github.com/repos/brain-score/vision"
 
 
-def get_data(pr_head_sha: str, url: str) -> dict:
+def get_data(url: str) -> dict:
     r = requests.get(url)
     assert r.status_code == 200
     return r.json()
@@ -21,21 +21,21 @@ def get_statuses_result(context: str, statuses: dict) -> str:
 
 def all_tests_passing(test_results: list):
     if any(result != "success" for result in test_results):
-        print(False)
+        return False
     else:
-        print(True)
+        return True
 
 
 if __name__ == "__main__":
 
     pr_head_sha = sys.argv[1]
 
-    check_runs_json = get_data(pr_head_sha, f"{BASE_URL}/commits/{pr_head_sha}/check-runs")
-    statuses_json = get_data(pr_head_sha, f"{BASE_URL}/statuses/{pr_head_sha}")
+    check_runs_json = get_data(f"{BASE_URL}/commits/{pr_head_sha}/check-runs")
+    statuses_json = get_data(f"{BASE_URL}/statuses/{pr_head_sha}")
 
     travis_branch_result = get_check_runs_result('Travis CI - Branch', check_runs_json)
     travis_pr_result = get_statuses_result('continuous-integration/travis', statuses_json)
     jenkins_plugintests_result = get_statuses_result('Brain-Score Jenkins CI - plugin tests', statuses_json)
     jenkins_unittests_result = get_statuses_result('Brain-Score Jenkins CI', statuses_json)
 
-    all_tests_passing([travis_branch_result, travis_pr_result, jenkins_plugintests_result, jenkins_unittests_result])
+    print(all_tests_passing([travis_branch_result, travis_pr_result, jenkins_plugintests_result, jenkins_unittests_result]))

--- a/tests/test_submission/test_check_test_status.py
+++ b/tests/test_submission/test_check_test_status.py
@@ -1,0 +1,29 @@
+from brainscore_vision.submission.check_test_status import BASE_URL, get_data, get_check_runs_result, get_statuses_result, all_tests_passing
+
+PR_HEAD_SHA = '209e6c81d39179fd161a1bd3a5845682170abfd2'
+
+def test_get_check_runs_data():
+    data = get_data(f"{BASE_URL}/commits/{PR_HEAD_SHA}/check-runs")
+    assert data['total_count'] == 6
+
+def test_get_statuses_result():
+    data = get_data(f"{BASE_URL}/statuses/{PR_HEAD_SHA}")
+    assert len(data) == 9
+
+def test_get_check_runs_result():
+    data = get_data(f"{BASE_URL}/commits/{PR_HEAD_SHA}/check-runs")
+    travis_branch_result = get_check_runs_result('Travis CI - Branch', data)
+    assert travis_branch_result == 'success'
+
+def test_get_statuses_result():
+    data = get_data(f"{BASE_URL}/statuses/{PR_HEAD_SHA}")
+    jenkins_plugintests_result = get_statuses_result('Brain-Score Jenkins CI - plugin tests', data)
+    assert jenkins_plugintests_result == 'failure'
+
+def test_one_test_failing():
+    success = all_tests_passing(['success', 'success', 'success', 'failure'])
+    assert success == False
+
+def test_all_tests_passing():
+    success = all_tests_passing(['success', 'success', 'success', 'success'])
+    assert success == True


### PR DESCRIPTION
Makes the automerge functionality contingent on all Travis and Jenkins tests successfully passing.

Moves the automerge validation logic out of the `automerge_plugin-only_prs` GitHub Action and into `brainscore_vision/submission/check_test_status.py`, which uses the GitHub API to ensure that all of the following register "success" before automerge is allowed:
* Travis Pull Request Build [`status`] (registered via `travis_trigger.sh` as final stage of successful Travis PR build; also confirms that the PR is plugin-only)
* Travis Branch Build [`check_run`]
* Brain-Score Jenkins CI [`status`]
* Brain-Score Jenkins CI - plugin tests [`status`]