### PR TITLE
Replace context-dependent event var with non-contextual env var in automerge workflow

### DIFF
--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get test results and ensure automergeable
         id: gettestresults
         run: |
-          echo "test_results=$( python brainscore_vision/submission/check_test_status.py ${{ github.event.pull_request.head.sha }} )"
+          echo "test_results=$( python brainscore_vision/submission/check_test_status.py ${{ GITHUB_SHA }} )"
           echo "::set-output name=TEST_RESULTS::$test_results"
 
 


### PR DESCRIPTION
Now that we trigger the automerge workflow from many event contexts, not all of them have access to the `pull_request` parameter. This replaces `github.event.pull_request.head.sha` with the more general `GITHUB_SHA`, which is a default environment variable encoding the SHA that triggered the action, and should be available in any context.