### PR TITLE
Make SHA in automerge workflow conditional on triggering event

### DIFF
--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -35,7 +35,12 @@ jobs:
       - name: Get test results and ensure automergeable
         id: gettestresults
         run: |
-          echo "test_results=$( python brainscore_vision/submission/check_test_status.py ${{ GITHUB_SHA }} )"
+          if [ [ ${{ github.event_name }} == "status" ]]; then
+            TRIGGER_SHA=$GITHUB_SHA
+          else
+            TRIGGER_SHA=${{ github.event.pull_request.head.sha }}
+          fi
+          echo "test_results=$( python brainscore_vision/submission/check_test_status.py $TRIGGER_SHA )"
           echo "::set-output name=TEST_RESULTS::$test_results"
 
 

--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Get test results and ensure automergeable
         id: gettestresults
         run: |
-          echo "test_results=$( python brainscore_vision/submission/check_test_status.py ${{ github.event.pull_request.head.sha }} )"
+          echo "test_results=$( python brainscore_vision/submission/check_test_status.py ${{ GITHUB_SHA }} )"
           echo "::set-output name=TEST_RESULTS::$test_results"
 
 

--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -35,10 +35,10 @@ jobs:
       - name: Get test results and ensure automergeable
         id: gettestresults
         run: |
-          if [ [ ${{ github.event_name }} == "status" ]]; then
-            TRIGGER_SHA=$GITHUB_SHA
-          else
+          if [ [ ${{ github.event_name }} == "pull_request" ]]; then
             TRIGGER_SHA=${{ github.event.pull_request.head.sha }}
+          else
+            TRIGGER_SHA=$GITHUB_SHA
           fi
           echo "test_results=$( python brainscore_vision/submission/check_test_status.py $TRIGGER_SHA )"
           echo "::set-output name=TEST_RESULTS::$test_results"


### PR DESCRIPTION
The automerge workflow is triggered by `pull_request` events, `status` events, and `check_run` events. The workflow needs access to the last commit SHA of the PR that is modifying plugins, which for `status` and `check_run` events is accessible via the default environment variable `GITHUB_SHA`. However, for `pull_request` events this variable points to the merge commit instead. We therefore use `github.event.pull_request.head.sha` when the workflow is triggered by a `pull_request` event.