### PR TITLE
Use custom workflow token for automerge PR labeling job

### DIFF
--- a/.github/workflows/check_if_pr_is_automergeable.yml
+++ b/.github/workflows/check_if_pr_is_automergeable.yml
@@ -59,7 +59,7 @@ jobs:
           echo "PR_NUMBER=$( python brainscore_vision/submission/actions_helpers.py get_pr_num )" >> $GITHUB_ENV
       - name: Add automerge-approved label to PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ env.PR_NUMBER }}
           LABELS: automerge-approved


### PR DESCRIPTION
Replaces the default `secrets.GITHUB_TOKEN` with the organization PAT for workflows.