### PR TITLE
Clean up scoring action

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -74,7 +74,7 @@ jobs:
         id: add_uid_to_pluginfo
         if: contains(github.event.pull_request.labels.*.name, 'automerge-web')
         run: |
-          BS_UID="$(<<<${{ github.event.pull_request.title }} | sed -E 's/.*\(user:([^)]+)\).*/\1/')"
+          BS_UID="$(<<<${{ github.event.pull_request.title }} sed -E 's/.*\(user:([^)]+)\).*/\1/')"
           echo "The Brain-Score user ID is $BS_UID"
           echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {user_id: ${{ steps.getuid.outputs.BS_UID }} }')"" >> $GITHUB_ENV
 

--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Get PR author email from GitHub username
         id: getemail
-        uses: evvanErb/get-github-email-by-username-action@v1.25
+        uses: evvanErb/get-github-email-by-username-action@v2.0
         with:
           github-username: ${{github.event.pull_request.user.login}} # PR author's username
           token: ${{ secrets.GITHUB_TOKEN }} # Including token enables most reliable way to get a user's email

--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -71,12 +71,12 @@ jobs:
     steps:
       - name: Parse user ID from PR title (WEB ONLY where we don't have access to the GitHub user)
         id: getuid
-        if: github.event.pull_request.labels.*.name == 'automerge-web'
+        if: contains(github.event.pull_request.labels.*.name, 'automerge-web')
         run: |
           echo "BS_UID="$(<<<${{ github.event.pull_request.title }} | sed -E 's/.*\(user:([^)]+)\).*/\1/'"" >> $GITHUB_ENV
       - name: Add user ID to PLUGIN_INFO (WEB ONLY)
         id: add_uid_to_pluginfo
-        if: github.event.pull_request.labels.*.name == 'automerge-web'
+        if: contains(github.event.pull_request.labels.*.name, 'automerge-web')
         run: |
           echo "The Brain-Score user ID is ${{ steps.getuid.outputs.BS_UID }}"
           echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {user_id: ${{ steps.getuid.outputs.UID }} }')"" >> $GITHUB_ENV

--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -70,16 +70,12 @@ jobs:
     outputs:
       PLUGIN_INFO: steps.add_email_to_pluginfo.outputs.PLUGIN_INFO
     steps:
-      - name: Parse user ID from PR title (WEB ONLY where we don't have access to the GitHub user)
-        id: getuid
-        if: contains(github.event.pull_request.labels.*.name, 'automerge-web')
-        run: |
-          echo "BS_UID="$(<<<${{ github.event.pull_request.title }} | sed -E 's/.*\(user:([^)]+)\).*/\1/'"" >> $GITHUB_ENV
-      - name: Add user ID to PLUGIN_INFO (WEB ONLY)
+      - name: Parse user ID from PR title and add to PLUGIN_INFO (WEB ONLY where we don't have access to the GitHub user)
         id: add_uid_to_pluginfo
         if: contains(github.event.pull_request.labels.*.name, 'automerge-web')
         run: |
-          echo "The Brain-Score user ID is ${{ steps.getuid.outputs.BS_UID }}"
+          BS_UID="$(<<<${{ github.event.pull_request.title }} | sed -E 's/.*\(user:([^)]+)\).*/\1/'"
+          echo "The Brain-Score user ID is $BS_UID"
           echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {user_id: ${{ steps.getuid.outputs.BS_UID }} }')"" >> $GITHUB_ENV
 
       - name: Get PR author email from GitHub username
@@ -125,4 +121,4 @@ jobs:
 
       - name: Run scoring
         run: |
-          python -c 'from brainscore_core.submission.endpoints import call_jenkins; call_jenkins('\''${{ env.PLUGIN_INFO }}'\'')'
+          python -c "from brainscore_core.submission.endpoints import call_jenkins; call_jenkins('\''${{ env.PLUGIN_INFO }}'\'')"

--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Get plugin info
         id: getpluginfo
         run: |
-          echo "PLUGIN_INFO='$(python -c 'from brainscore_core.plugin_management.parse_plugin_changes import get_scoring_info; get_scoring_info("${{ env.CHANGED_FILES }}", "brainscore_vision")')'"  >> $GITHUB_OUTPUT
+          printf -v PLUGIN_INFO "%s" "$(python -c 'from brainscore_core.plugin_management.parse_plugin_changes import get_scoring_info; get_scoring_info("brainscore_vision/models/regnet/__init__.py brainscore_vision/models/regnet/model.py brainscore_vision/models/regnet/test.py ", "brainscore_vision")')"
+          echo "PLUGIN_INFO=$PLUGIN_INFO" >> $GITHUB_OUTPUT
       
       - name: Run scoring
         id: runscore
@@ -79,7 +80,7 @@ jobs:
         if: contains(github.event.pull_request.labels.*.name, 'automerge-web')
         run: |
           echo "The Brain-Score user ID is ${{ steps.getuid.outputs.BS_UID }}"
-          echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {user_id: ${{ steps.getuid.outputs.UID }} }')"" >> $GITHUB_ENV
+          echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {user_id: ${{ steps.getuid.outputs.BS_UID }} }')"" >> $GITHUB_ENV
 
       - name: Get PR author email from GitHub username
         id: getemail

--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -74,7 +74,7 @@ jobs:
         id: add_uid_to_pluginfo
         if: contains(github.event.pull_request.labels.*.name, 'automerge-web')
         run: |
-          BS_UID="$(<<<${{ github.event.pull_request.title }} | sed -E 's/.*\(user:([^)]+)\).*/\1/'"
+          BS_UID="$(<<<${{ github.event.pull_request.title }} | sed -E 's/.*\(user:([^)]+)\).*/\1/')"
           echo "The Brain-Score user ID is $BS_UID"
           echo "PLUGIN_INFO="$(<<<$PLUGIN_INFO jq '. + {user_id: ${{ steps.getuid.outputs.BS_UID }} }')"" >> $GITHUB_ENV
 


### PR DESCRIPTION
* Ensures `PLUGIN_INFO` is in JSON format for use with `jq` (store var with `printf -v`)
* Fixes broken reference (`UID` -> `BS_UID`)
* Checks all labels for `automerge-web` value
* Upgrades action for retrieving PR author email from GitHub username (`evvanErb/get-github-email-by-username-action`) to 2.0 to avoid set::output deprecation and unexpected input `token` warnings
* General logic cleanup