### PR TITLE
Fixed igustibagus2024 analysis benchmark issues

### DIFF
--- a/brainscore_vision/benchmarks/igustibagus2024/domain_transfer_analysis.py
+++ b/brainscore_vision/benchmarks/igustibagus2024/domain_transfer_analysis.py
@@ -85,7 +85,7 @@ class _OOD_AnalysisBenchmark(BenchmarkBase):
 
         center = crossdomain_results.mean(dim='split').mean(dim='domain')
         error = crossdomain_results.mean(dim='split').std(dim='domain')
-        score = Score([center, error], coords={'aggregation': ['center', 'error']}, dims=('aggregation',))
+        score = Score(center)
         score.attrs['error'] = error
         score.attrs[Score.RAW_VALUES_KEY] = crossdomain_results
         return score

--- a/brainscore_vision/benchmarks/igustibagus2024/domain_transfer_analysis.py
+++ b/brainscore_vision/benchmarks/igustibagus2024/domain_transfer_analysis.py
@@ -71,6 +71,9 @@ class _OOD_AnalysisBenchmark(BenchmarkBase):
             # Train the decoder #
             decoder = get_decoder(data=complete_training_data, estimator=self._classifier)
             for crossdomain in crossdomain_test_images_dict.keys():
+                # skip the original domain (we are only interested in OOD scores)
+                if crossdomain == 'hvm':
+                    continue
                 test_accuracy = get_classifier_score_2AFC(classifier=decoder,
                                                           data=crossdomain_test_images_dict[crossdomain])
                 test_accuracy = Score(test_accuracy)
@@ -83,6 +86,7 @@ class _OOD_AnalysisBenchmark(BenchmarkBase):
         center = crossdomain_results.mean(dim='split').mean(dim='domain')
         error = crossdomain_results.mean(dim='split').std(dim='domain')
         score = Score([center, error], coords={'aggregation': ['center', 'error']}, dims=('aggregation',))
+        score.attrs['error'] = error
         score.attrs[Score.RAW_VALUES_KEY] = crossdomain_results
         return score
 


### PR DESCRIPTION
There were 2 issues related to the _Igustibagus2024-domain-transfer-analysis-benchmark_ : 

1. The benchmark was computing the OOD average score taking into account also the original domain (_hvm_) for a total of 13 domains, instead of the 12 out-domains we are interested in;
2. The benchmark was not reporting the error of the final measures.

Below is an example that locally these points are now solved:
![Screenshot 2024-01-30 at 14 45 40](https://github.com/brain-score/vision/assets/111696102/442da97c-c75e-473b-8b26-bd83a6be2c48)
![Screenshot 2024-01-30 at 14 45 49](https://github.com/brain-score/vision/assets/111696102/c540bed5-1452-40e8-9dd3-afddbd008c78)

