### PR TITLE
Fix minor bug in Freemanziemba benchmark code

### DIFF
--- a/brainscore_vision/benchmarks/freemanziemba2013/test.py
+++ b/brainscore_vision/benchmarks/freemanziemba2013/test.py
@@ -51,7 +51,7 @@ def test_FreemanZiemba2013(benchmark, expected):
     filepath = Path(__file__).parent / filename
     s3.download_file_if_not_exists(local_path=filepath,
                                    bucket='brain-score-tests', remote_filepath=f'tests/test_benchmarks/{filename}')
-    precomputed_test.run_test(benchmark=benchmark, precomputed_features_filepath=filename, expected=expected)
+    precomputed_test.run_test(benchmark=benchmark, precomputed_features_filepath=filepath, expected=expected)
 
 
 @pytest.mark.parametrize('benchmark, candidate_degrees, image_id, expected', [


### PR DESCRIPTION
Similar to [MajajHong](https://github.com/brain-score/vision/blob/c3d1df2ecfc3f18270b8947007b90e7a78a5c3f7/brainscore_vision/benchmarks/majajhong2015/test.py#L58) and [Rajalingham](https://github.com/brain-score/vision/blob/c3d1df2ecfc3f18270b8947007b90e7a78a5c3f7/brainscore_vision/benchmarks/rajalingham2020/test.py#L39), the FreemanZiemba benchmark test should reference the full path for the downloaded pre-computed features instead of the file name. Using only the file name will lead to errors since the file is downloaded to the Benchmark's directory (i.e., `vision/benchmarks/freemanziemba2013/`), not the main `vision/` directory, which will lead this unit test to always fail.

This PR fixes this by updating it to use the full path of the downloaded file instead of the file name.