### PR TITLE
Remvoed dashes from Geirhos benchmarks to match database identifiers

### DIFF
--- a/brainscore_vision/benchmarks/geirhos2021/benchmark.py
+++ b/brainscore_vision/benchmarks/geirhos2021/benchmark.py
@@ -59,8 +59,9 @@ class _Geirhos2021ErrorConsistency(BenchmarkBase):
 
         self._number_of_trials = 1
 
+        dataset_nodashes = dataset.replace("-", "")
         super(_Geirhos2021ErrorConsistency, self).__init__(
-            identifier=f'Geirhos2021{dataset}-error_consistency', version=1,
+            identifier=f'Geirhos2021{dataset_nodashes}-error_consistency', version=1,
             ceiling_func=lambda: self._metric.ceiling(self._assembly),
             parent='Geirhos2021',
             bibtex=BIBTEX)
@@ -85,8 +86,9 @@ class _Geirhos2021Accuracy(BenchmarkBase):
     def __init__(self, dataset):
         self._metric = load_metric('accuracy')
         self._stimulus_set = LazyLoad(lambda: load_assembly(dataset).stimulus_set)
+        dataset_nodashes = dataset.replace("-", "")
         super(_Geirhos2021Accuracy, self).__init__(
-            identifier=f'Geirhos2021{dataset}-accuracy', version=1,
+            identifier=f'Geirhos2021{dataset_nodashes}-top1', version=1,
             ceiling_func=lambda: Score(1),
             parent='Geirhos2021-top1',
             bibtex=BIBTEX)

--- a/brainscore_vision/benchmarks/hermann2020/benchmark.py
+++ b/brainscore_vision/benchmarks/hermann2020/benchmark.py
@@ -48,7 +48,7 @@ class Hermann2020cueconflictShapeBias(BenchmarkBase):
         self.shape_benchmark = _Hermann2020Match("shape_match", "original_image_category")
         self.texture_benchmark = _Hermann2020Match("texture_match", "conflict_image_category")
         super(Hermann2020cueconflictShapeBias, self).__init__(
-            identifier=f'Hermann2020-shape_bias', version=1,
+            identifier=f'Hermann2020cueconflict-shape_bias', version=1,
             ceiling_func=lambda: Score(1),
             parent='Hermann2020',
             bibtex=BIBTEX)


### PR DESCRIPTION
https://github.com/brain-score/vision/pull/518 and https://github.com/brain-score/vision/pull/559 Updated benchmark identifiers to remove lab names (e.g. lab.BenchmarkName -> BenchmarkName) but missed removing the dashes from the Geirhos2021 benchmark. This PR updates those identifiers to match the `BenchmarkType` identifiers present in the databases.