### PR TITLE
[Draft] Removing lab identifiers from stimulus sets

### DIFF
--- a/brainscore_vision/benchmarks/objectnet/benchmark.py
+++ b/brainscore_vision/benchmarks/objectnet/benchmark.py
@@ -33,7 +33,7 @@ class Objectnet(BenchmarkBase):
         self._similarity_metric = load_metric('accuracy')
         ceiling = Score(1)
 
-        super(Objectnet, self).__init__(identifier='BarbuMayo2019-top1', version=1,
+        super(Objectnet, self).__init__(identifier='ObjectNet-top1', version=1,
                                         ceiling_func=lambda: ceiling,
                                         parent='engineering',
                                         bibtex=BIBTEX)

--- a/brainscore_vision/data/marques2020/__init__.py
+++ b/brainscore_vision/data/marques2020/__init__.py
@@ -74,7 +74,16 @@ data_registry['Schiller1976c'] = lambda: load_assembly_from_s3(
 )
 
 # --- stimulus sets ---
-stimulus_set_registry['Marques2020_blank'] = lambda: load_stimulus_set_from_s3(
+def temporary_load_stimulus_set_from_s3(identifier, **kwargs):
+    """
+    Created to remove lab identifiers from stimulus sets to match their registry names.
+    Should be removed once lab identifiers are removed from stimulus set names in S3.
+    """
+    assembly = load_stimulus_set_from_s3(identifier=identifier, **kwargs)
+    assembly.identifier = "".join(identifier.split(".")[1:])
+    return assembly
+
+stimulus_set_registry['Marques2020_blank'] = lambda: temporary_load_stimulus_set_from_s3(
     identifier="dicarlo.Marques2020_blank",
     bucket="brainio-brainscore",
     csv_sha1="c02d44b0d3e157b29c6b96c5c5a478a8b37dc70b",
@@ -82,7 +91,7 @@ stimulus_set_registry['Marques2020_blank'] = lambda: load_stimulus_set_from_s3(
     csv_version_id="TPtJnOoJAKEnWSDrQ_1X9bvx_jUQkTvM",
     zip_version_id="4Zv7Mt0cGuKCV5i0uwGipVa91so_6U.V")
 
-stimulus_set_registry['Marques2020_receptive_field'] = lambda: load_stimulus_set_from_s3(
+stimulus_set_registry['Marques2020_receptive_field'] = lambda: temporary_load_stimulus_set_from_s3(
     identifier="dicarlo.Marques2020_receptive_field",
     bucket="brainio-brainscore",
     csv_sha1="e3681c69122b20ff3dd22486f546a26b3a97e057",
@@ -90,7 +99,7 @@ stimulus_set_registry['Marques2020_receptive_field'] = lambda: load_stimulus_set
     csv_version_id="o6JVmVyn015uKDSqwH1Qfaek8I4AH0A2",
     zip_version_id="wFfNAHvgptFmzn58VdlABHeEPlnh54EO")
 
-stimulus_set_registry['Marques2020_orientation'] = lambda: load_stimulus_set_from_s3(
+stimulus_set_registry['Marques2020_orientation'] = lambda: temporary_load_stimulus_set_from_s3(
     identifier="dicarlo.Marques2020_orientation",
     bucket="brainio-brainscore",
     csv_sha1="b316c6d9c6ddb58f8f21e79ae2b59b03933c0068",
@@ -98,7 +107,7 @@ stimulus_set_registry['Marques2020_orientation'] = lambda: load_stimulus_set_fro
     csv_version_id="FuItfnJQzVkbXuC6oDZYiIa6Ye.ZrtHp",
     zip_version_id="HAlNBCxxrzdFy6g9ofCM1rG49KXMgMjH")
 
-stimulus_set_registry['Marques2020_spatial_frequency'] = lambda: load_stimulus_set_from_s3(
+stimulus_set_registry['Marques2020_spatial_frequency'] = lambda: temporary_load_stimulus_set_from_s3(
     identifier="dicarlo.Marques2020_spatial_frequency",
     bucket="brainio-brainscore",
     csv_sha1="31d0293c8aa1590f4680bb8a9446f56135b8d646",
@@ -106,7 +115,7 @@ stimulus_set_registry['Marques2020_spatial_frequency'] = lambda: load_stimulus_s
     csv_version_id="xtKupFJyMLIqtI64H9bFikeeyycg0esU",
     zip_version_id="cPxm7TfKmFPFigPdzJjOf3gHcdKDkVXi")
 
-stimulus_set_registry['Marques2020_size'] = lambda: load_stimulus_set_from_s3(
+stimulus_set_registry['Marques2020_size'] = lambda: temporary_load_stimulus_set_from_s3(
     identifier="dicarlo.Marques2020_size",
     bucket="brainio-brainscore",
     csv_sha1="0fd0aeea8fa6ff2b30ee9a6a684d4600590d631f",
@@ -114,7 +123,7 @@ stimulus_set_registry['Marques2020_size'] = lambda: load_stimulus_set_from_s3(
     csv_version_id="VQsd1qLhSKqd5Wfz6tmnmypgs038.hoT",
     zip_version_id="RAfJJhR9.KQlwdiuZa6PiEiJTs62Jk.4")
 
-stimulus_set_registry['FreemanZiemba2013_properties'] = lambda: load_stimulus_set_from_s3(
+stimulus_set_registry['FreemanZiemba2013_properties'] = lambda: temporary_load_stimulus_set_from_s3(
     identifier="movshon.FreemanZiemba2013_properties",
     bucket="brainio-brainscore",
     csv_sha1="6f7bcb5d0c01e81c9fbdcec9bf586cbb579a9b02",

--- a/brainscore_vision/data/marques2020/data_packaging/marques_cavanaugh2002a.py
+++ b/brainscore_vision/data/marques2020/data_packaging/marques_cavanaugh2002a.py
@@ -5,8 +5,8 @@ from marques_utils import gen_sample
 from brainio_collection.packaging import package_data_assembly
 from brainio_base.assemblies import DataAssembly
 
-ASSEMBLY_NAME = 'movshon.Cavanaugh2002a'
-SIZE_STIM_NAME = 'dicarlo.Marques2020_size'
+ASSEMBLY_NAME = 'Cavanaugh2002a'
+SIZE_STIM_NAME = 'Marques2020_size'
 
 PROPERTY_NAMES = ['surround_suppression_index', 'strongly_suppressed', 'grating_summation_field', 'surround_diameter',
                   'surround_grating_summation_field_ratio']

--- a/brainscore_vision/data/marques2020/data_packaging/marques_devalois1982a.py
+++ b/brainscore_vision/data/marques2020/data_packaging/marques_devalois1982a.py
@@ -6,7 +6,7 @@ from brainio_collection.packaging import package_data_assembly
 from brainio_base.assemblies import DataAssembly
 
 ASSEMBLY_NAME = 'devalois.DeValois1982a'
-ORIENTATION_STIM_NAME = 'dicarlo.Marques2020_orientation'
+ORIENTATION_STIM_NAME = 'Marques2020_orientation'
 
 
 def collect_data():

--- a/brainscore_vision/data/marques2020/data_packaging/marques_devalois1982b.py
+++ b/brainscore_vision/data/marques2020/data_packaging/marques_devalois1982b.py
@@ -6,7 +6,7 @@ from brainio_collection.packaging import package_data_assembly
 from brainio_base.assemblies import DataAssembly
 
 ASSEMBLY_NAME = 'devalois.DeValois1982b'
-SPATIAL_FREQUENCY_STIM_NAME = 'dicarlo.Marques2020_spatial_frequency'
+SPATIAL_FREQUENCY_STIM_NAME = 'Marques2020_spatial_frequency'
 
 
 def collect_data():

--- a/brainscore_vision/data/marques2020/data_packaging/marques_gen_stim.py
+++ b/brainscore_vision/data/marques2020/data_packaging/marques_gen_stim.py
@@ -4,12 +4,12 @@ from marques_stim_common import gen_grating_stim, gen_blank_stim, gen_texture_st
     load_stim_info
 from brainio_collection.packaging import package_stimulus_set
 
-BLANK_STIM_NAME = 'dicarlo.Marques2020_blank'
-RF_STIM_NAME = 'dicarlo.Marques2020_receptive_field'
-ORIENTATION_STIM_NAME = 'dicarlo.Marques2020_orientation'
-SF_STIM_NAME = 'dicarlo.Marques2020_spatial_frequency'
-SIZE_STIM_NAME = 'dicarlo.Marques2020_size'
-TEXTURE_STIM_NAME = 'movshon.FreemanZiemba2013_properties'
+BLANK_STIM_NAME = 'Marques2020_blank'
+RF_STIM_NAME = 'Marques2020_receptive_field'
+ORIENTATION_STIM_NAME = 'Marques2020_orientation'
+SF_STIM_NAME = 'Marques2020_spatial_frequency'
+SIZE_STIM_NAME = 'Marques2020_size'
+TEXTURE_STIM_NAME = 'FreemanZiemba2013_properties'
 
 DATA_DIR = '/braintree/data2/active/users/tmarques/bs_stimuli'
 DEGREES = 12

--- a/brainscore_vision/data/marques2020/data_packaging/marques_ringach2002.py
+++ b/brainscore_vision/data/marques2020/data_packaging/marques_ringach2002.py
@@ -7,7 +7,7 @@ from brainio_base.assemblies import DataAssembly
 
 DATA_DIR = '/braintree/data2/active/users/tmarques/bs_datasets/Ringach2002.mat'
 ASSEMBLY_NAME = 'shapley.Ringach2002'
-ORIENTATION_STIM_NAME = 'dicarlo.Marques2020_orientation'
+ORIENTATION_STIM_NAME = 'Marques2020_orientation'
 
 PROPERTY_NAMES = ['baseline', 'max_dc', 'min_dc', 'max_ac', 'modulation_ratio', 'circular_variance', 'bandwidth',
                   'orthogonal_preferred_ratio', 'orientation_selective', 'circular_variance_bandwidth_ratio',

--- a/brainscore_vision/data/marques2020/data_packaging/marques_schiller1976c.py
+++ b/brainscore_vision/data/marques2020/data_packaging/marques_schiller1976c.py
@@ -6,7 +6,7 @@ from brainio_collection.packaging import package_data_assembly
 from brainio_base.assemblies import DataAssembly
 
 ASSEMBLY_NAME = 'schiller.Schiller1976c'
-SPATIAL_FREQUENCY_STIM_NAME = 'dicarlo.Marques2020_spatial_frequency'
+SPATIAL_FREQUENCY_STIM_NAME = 'Marques2020_spatial_frequency'
 
 
 def collect_data():

--- a/brainscore_vision/data/marques2020/test.py
+++ b/brainscore_vision/data/marques2020/test.py
@@ -9,13 +9,13 @@ class TestMarques2020V1Properties:
         ('Cavanaugh2002a', 190, [
             'surround_suppression_index', 'strongly_suppressed', 'grating_summation_field', 'surround_diameter',
             'surround_grating_summation_field_ratio'],
-         'dicarlo.Marques2020_size'),
+         'Marques2020_size'),
         ('DeValois1982a', 385, [
             'preferred_orientation'],
-         'dicarlo.Marques2020_orientation'),
+         'Marques2020_orientation'),
         ('DeValois1982b', 363, [
             'peak_spatial_frequency'],
-         'dicarlo.Marques2020_spatial_frequency'),
+         'Marques2020_spatial_frequency'),
         ('FreemanZiemba2013_V1_properties', 102, [
             'absolute_texture_modulation_index', 'family_variance', 'max_noise', 'max_texture', 'noise_selectivity',
             'noise_sparseness', 'sample_variance', 'texture_modulation_index', 'texture_selectivity',
@@ -25,10 +25,10 @@ class TestMarques2020V1Properties:
             'bandwidth', 'baseline', 'circular_variance', 'circular_variance_bandwidth_ratio', 'max_ac', 'max_dc',
             'min_dc', 'modulation_ratio', 'orientation_selective', 'orthogonal_preferred_ratio',
             'orthogonal_preferred_ratio_bandwidth_ratio', 'orthogonal_preferred_ratio_circular_variance_difference'],
-         'dicarlo.Marques2020_orientation'),
+         'Marques2020_orientation'),
         ('Schiller1976c', 87, [
             'spatial_frequency_selective', 'spatial_frequency_bandwidth'],
-         'dicarlo.Marques2020_spatial_frequency'),
+         'Marques2020_spatial_frequency'),
     ])
     def test_assembly(self, identifier, num_neuroids, properties, stimulus_set_identifier):
         assembly = brainscore_vision.load_dataset(identifier)


### PR DESCRIPTION
Currently, the file names for most stimulus sets still contain lab identifiers on S3. However, the stimulus set registry recently removed the lab identifiers in the Brain Score 2.0 refactor. This currently leads to an issue where none of the Marques stimulus sets  can be loaded properly during evaluation:
```
AssertionError: No registrations found for dicarlo.Marques2020_orientation
```

Ideally, the solution would be to rename the stimulus set filenames on S3 to match the current identifiers in the `stimulus_set_registry` (e.g. `dicarlo.Marques2020_receptive_field` --> `Marques2020_receptive_field`), but this requires access to S3 and an effort to ensure every single reference to those stimulus sets in the codebase is corrected. This PR provides a hacky fix to unblock certain problems in scoring website submissions.
