### PR TITLE
Trigger `score_new_plugins` action on `pull_request_target`

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -7,7 +7,7 @@ name: Trigger scoring run
 
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - master
     types:


### PR DESCRIPTION
To avoid AWS credential errors (for instance, [here](https://github.com/brain-score/vision/actions/runs/8245300679/job/22549031027)) on scoring runs originating from merged forks, updates the `score_new_plugins` workflow trigger from `pull_request` to `pull_request_target`, which runs in the context of the target branch and should therefore have secrets access.