### PR TITLE
Fix for automerge-approved label

### DIFF
--- a/.github/workflows/check_if_pr_is_automergeable.yml
+++ b/.github/workflows/check_if_pr_is_automergeable.yml
@@ -2,7 +2,7 @@ name: Check if PR is automergeable
 
 
 # Triggered on all PRs either by
-# - completion of CI checks (status or check_run events), OR
+# - completion of CI checks (status events), OR
 # - tagging with "automerge" or "automerge-web" labels
 # This workflow checks if the PR that invoked the trigger is automergeable. 
 # A PR is automergeable iff it:
@@ -16,8 +16,6 @@ name: Check if PR is automergeable
 on:
   pull_request:
     types: [labeled]
-  check_run:
-    types: [completed]
   status:
 
 permissions: write-all

--- a/brainscore_vision/submission/actions_helpers.py
+++ b/brainscore_vision/submission/actions_helpers.py
@@ -25,7 +25,7 @@ def get_data(url: str) -> dict:
 
 def get_pr_num_from_head(pr_head) -> int:
     """
-    Given either an SHA (check_run or status event) or a branch name (pull request event),
+    Given either an SHA (status event) or a branch name (pull request event),
     returns the number of the pull request with that head SHA or branch name.
     """
     event_type = os.environ["GITHUB_EVENT_NAME"]
@@ -47,8 +47,8 @@ def _load_event_file() -> dict:
     
 def get_pr_head_from_github_event() -> str:
     """
-    Based on the event that triggered the workflow (check_run, status, or pull_request),
-    returns either an SHA (check_run or status) or branch name (pull_request)
+    Based on the event that triggered the workflow (status or pull_request),
+    returns either an SHA (status) or branch name (pull_request)
     """
     pr_head = None
     event_type = os.environ["GITHUB_EVENT_NAME"]
@@ -58,10 +58,6 @@ def get_pr_head_from_github_event() -> str:
         candidate_branches = [branch for branch in f["branches"] if branch["name"] != "master"]
         if len(candidate_branches) == 1:
             pr_head = candidate_branches[0]["commit"]["sha"]
-
-    elif event_type == "check_run":
-        f = _load_event_file()
-        pr_head = f["check_run"]["head_sha"]
 
     elif event_type == "pull_request":
         pr_head = os.environ["GITHUB_HEAD_REF"]
@@ -90,11 +86,9 @@ def are_all_tests_passing(test_results: dict) -> dict:
     else:
         return True
     
-def is_labeled_automerge(check_runs_json: dict) -> bool:
-    pull_requests = [check_run['pull_requests'] for check_run in check_runs_json['check_runs']]
-    assert all(len(pull_request) == 1 for pull_request in pull_requests), f'Expected one PR associated with this SHA but found none or more than one, cannot automerge'
-    pull_request_data = get_data(pull_requests[0][0]["url"])
-    labeled_automerge = any(label['name'] in ('automerge', 'automerge-web') for label in pull_request_data['labels'])
+def is_labeled_automerge(pr_num: int) -> bool:
+    label_data = get_data(f"{BASE_URL}/issues/{pr_num}/labels")
+    labeled_automerge = any(label['name'] in ('automerge', 'automerge-web') for label in label_data)
     return labeled_automerge
 
 
@@ -103,17 +97,17 @@ if __name__ == "__main__":
     pr_head = get_pr_head_from_github_event()
     if not pr_head:
         print("No PR head found. Exiting."); sys.exit()
+    pr_num = get_pr_num_from_head(pr_head)
     
     # GitHub Actions helpers
     if len(sys.argv) > 1:
         if sys.argv[1] == "get_pr_head":
             print(pr_head)
         elif sys.argv[1] == "get_pr_num":
-            print(get_pr_num_from_head(pr_head))
+            print(pr_num)
         sys.exit()
 
     # Check test results and ensure PR is automergeable
-    check_runs_json = get_data(f"{BASE_URL}/commits/{pr_head}/check-runs")
     statuses_json = get_data(f"{BASE_URL}/statuses/{pr_head}")
 
     results_dict = {'travis_pr_result': get_statuses_result('continuous-integration/travis', statuses_json),
@@ -123,7 +117,7 @@ if __name__ == "__main__":
     tests_pass = are_all_tests_passing(results_dict)
 
     if tests_pass:
-        if is_labeled_automerge(check_runs_json):
+        if is_labeled_automerge(pr_num):
             print(True)
         else:
             print("All tests pass but not labeled for automerge. Exiting.")

--- a/brainscore_vision/submission/actions_helpers.py
+++ b/brainscore_vision/submission/actions_helpers.py
@@ -78,12 +78,6 @@ def _return_last_result(results: list) -> Union[str, None]:
         last_result = None
     return last_result
 
-def get_check_runs_result(run_name: str, check_runs_json: dict) -> str:
-    check_runs = [{'end_time': run['completed_at'], 'result': run['conclusion']} 
-                  for run in check_runs_json['check_runs'] if run['name'] == run_name]
-    last_run_result = _return_last_result(check_runs)
-    return last_run_result
-
 def get_statuses_result(context: str, statuses_json: dict) -> str:
     statuses = [{'end_time': status['updated_at'], 'result': status['state']} 
                 for status in statuses_json if status['context'] == context]

--- a/brainscore_vision/submission/actions_helpers.py
+++ b/brainscore_vision/submission/actions_helpers.py
@@ -122,8 +122,7 @@ if __name__ == "__main__":
     check_runs_json = get_data(f"{BASE_URL}/commits/{pr_head}/check-runs")
     statuses_json = get_data(f"{BASE_URL}/statuses/{pr_head}")
 
-    results_dict = {'travis_branch_result': get_check_runs_result('Travis CI - Branch', check_runs_json),
-                    'travis_pr_result': get_statuses_result('continuous-integration/travis', statuses_json),
+    results_dict = {'travis_pr_result': get_statuses_result('continuous-integration/travis', statuses_json),
                     'jenkins_plugintests_result': get_statuses_result('Brain-Score Jenkins CI - plugin tests', statuses_json),
                     'jenkins_unittests_result': get_statuses_result('Brain-Score Jenkins CI', statuses_json)}
 

--- a/tests/test_submission/test_actions_helpers.py
+++ b/tests/test_submission/test_actions_helpers.py
@@ -1,7 +1,7 @@
 import pytest
 from subprocess import call
 
-from brainscore_vision.submission.actions_helpers import BASE_URL, get_pr_num_from_head, get_data, get_check_runs_result, get_statuses_result, are_all_tests_passing, is_labeled_automerge, get_pr_head_from_github_event
+from brainscore_vision.submission.actions_helpers import BASE_URL, get_pr_num_from_head, get_data, get_statuses_result, are_all_tests_passing, is_labeled_automerge, get_pr_head_from_github_event
 
 PR_HEAD_SHA = '209e6c81d39179fd161a1bd3a5845682170abfd2'
 PR_BRANCH_NAME = 'web_submission_11/add_plugins'
@@ -47,11 +47,6 @@ def test_get_check_runs_data():
 def test_get_statuses_result():
     data = get_data(f"{BASE_URL}/statuses/{PR_HEAD_SHA}")
     assert len(data) == 9
-
-def test_get_check_runs_result():
-    data = get_data(f"{BASE_URL}/commits/{PR_HEAD_SHA}/check-runs")
-    travis_branch_result = get_check_runs_result('Travis CI - Branch', data)
-    assert travis_branch_result == 'success'
 
 def test_get_statuses_result():
     data = get_data(f"{BASE_URL}/statuses/{PR_HEAD_SHA}")

--- a/tests/test_submission/test_actions_helpers.py
+++ b/tests/test_submission/test_actions_helpers.py
@@ -29,20 +29,10 @@ def test_get_pr_head_status_event_master_only(monkeypatch, mocker):
     mocker.patch('brainscore_vision.submission.actions_helpers._load_event_file', return_value=mock_status_json)
     assert not get_pr_head_from_github_event()
 
-def test_get_pr_head_check_run_event(monkeypatch, mocker):
-    monkeypatch.setenv('GITHUB_EVENT_NAME', 'check_run')
-    mock_check_run_json = {'check_run': {'head_sha': PR_HEAD_SHA}}
-    mocker.patch('brainscore_vision.submission.actions_helpers._load_event_file', return_value=mock_check_run_json)
-    assert get_pr_head_from_github_event() == PR_HEAD_SHA
-
 def test_get_pr_head_pull_request_event(monkeypatch):
     monkeypatch.setenv('GITHUB_EVENT_NAME', 'pull_request')
     monkeypatch.setenv('GITHUB_HEAD_REF', PR_BRANCH_NAME)
     assert get_pr_head_from_github_event() == PR_BRANCH_NAME
-
-def test_get_check_runs_data():
-    data = get_data(f"{BASE_URL}/commits/{PR_HEAD_SHA}/check-runs")
-    assert data['total_count'] == 6
 
 def test_get_statuses_result():
     data = get_data(f"{BASE_URL}/statuses/{PR_HEAD_SHA}")
@@ -70,20 +60,8 @@ def test_one_test_failing():
     assert success == False
  
 def test_is_labeled_automerge(mocker):
-    dummy_check_runs_json = {"check_runs": [{"pull_requests": [{"url": "https://api.github.com/repos/brain-score/vision/pulls/453"}]}]}
-    dummy_pull_request_data  = {"labels": [{"name": "automerge-web"}]}
-    mocker.patch('brainscore_vision.submission.actions_helpers.get_data', return_value=dummy_pull_request_data) 
-    assert is_labeled_automerge(dummy_check_runs_json) == True
+    assert is_labeled_automerge(442) == True
 
 def test_is_not_labeled_automerge(mocker):
-    dummy_check_runs_json = {"check_runs": [{"pull_requests": [{"url": "https://api.github.com/repos/brain-score/vision/pulls/453"}]}]}
-    dummy_pull_request_data  = {'labels': []}
-    mocker.patch('brainscore_vision.submission.actions_helpers.get_data', return_value=dummy_pull_request_data) 
-    assert is_labeled_automerge(dummy_check_runs_json) == False
+    assert is_labeled_automerge(433) == False
 
-def test_sha_associated_with_more_than_one_pr():
-    dummy_check_runs_json = {"check_runs": [{"pull_requests": [{"url": "https://api.github.com/repos/brain-score/vision/pulls/453"}, {"url": "https://api.github.com/repos/brain-score/vision/pulls/452"}]}]}
-    with pytest.raises(AssertionError):
-        is_labeled_automerge(dummy_check_runs_json)
-
-        


### PR DESCRIPTION
Currently, automerge-approved labels are not being applied to automerge-web PRs because they `results_dict` (in [actions_helpers.py](https://github.com/brain-score/vision/blob/master/brainscore_vision/submission/actions_helpers.py)) still requires a 'success' for 'travis_branch_result'. 

This PR just removes the `travis_branch_result` from the `results_dict` which should allow for the label to be applied.

@kvfairchild will more changes need to addressed? Anything in the testing pipeline?