### PR TITLE
add require_variance to model_interface look_at signature

### DIFF
--- a/brainscore_vision/model_helpers/activations/core.py
+++ b/brainscore_vision/model_helpers/activations/core.py
@@ -74,7 +74,8 @@ class ActivationsExtractorHelper:
         for hook in self._stimulus_set_hooks.copy().values():  # copy to avoid stale handles
             stimulus_set = hook(stimulus_set)
         stimuli_paths = [str(stimulus_set.get_stimulus(stimulus_id)) for stimulus_id in stimulus_set['stimulus_id']]
-        activations = self.from_paths(stimuli_paths=stimuli_paths, layers=layers, stimuli_identifier=stimuli_identifier)
+        activations = self.from_paths(stimuli_paths=stimuli_paths, layers=layers, stimuli_identifier=stimuli_identifier,
+                                      require_variance=require_variance)
         activations = attach_stimulus_set_meta(activations,
                                                stimulus_set,
                                                number_of_trials=self._microsaccade_helper.number_of_trials,

--- a/brainscore_vision/model_helpers/activations/core.py
+++ b/brainscore_vision/model_helpers/activations/core.py
@@ -45,7 +45,8 @@ class ActivationsExtractorHelper:
         :param number_of_trials: An integer that determines how many repetitions of the same model performs.
         :param require_variance: A bool that asks models to output different responses to the same stimuli (i.e.,
             allows stochastic responses to identical stimuli, even in otherwise deterministic base models). 
-            We here implement this using microsaccades. For more, see ...
+            We here implement this using microsaccades. For more, see
+            :cls:`~brainscore_vision.model_helpers.activations.core.MicrosaccadeHelper`.
 
         """
         if require_variance:

--- a/brainscore_vision/model_helpers/brain_transformation/__init__.py
+++ b/brainscore_vision/model_helpers/brain_transformation/__init__.py
@@ -62,11 +62,13 @@ class ModelCommitment(BrainModel):
         else:
             self.do_behavior = False
 
-    def look_at(self, stimuli, number_of_trials=1):
+    def look_at(self, stimuli, number_of_trials=1, require_variance: bool = False):
         if self.do_behavior:
-            return self.behavior_model.look_at(stimuli, number_of_trials=number_of_trials)
+            return self.behavior_model.look_at(stimuli, number_of_trials=number_of_trials,
+                                               require_variance=require_variance)
         else:
-            return self.layer_model.look_at(stimuli, number_of_trials=number_of_trials)
+            return self.layer_model.look_at(stimuli, number_of_trials=number_of_trials,
+                                            require_variance=require_variance)
 
     def start_recording(self, recording_target, time_bins):
         return self.layer_model.start_recording(recording_target, time_bins)

--- a/brainscore_vision/model_helpers/brain_transformation/behavior.py
+++ b/brainscore_vision/model_helpers/brain_transformation/behavior.py
@@ -43,9 +43,9 @@ class LabelBehavior(BrainModel):
         self.current_task = task
         self.choice_labels = choice_labels
 
-    def look_at(self, stimuli, number_of_trials=1):
+    def look_at(self, stimuli, number_of_trials=1, require_variance: bool = False):
         assert self.current_task == BrainModel.Task.label
-        logits = self.activations_model(stimuli, layers=['logits'])
+        logits = self.activations_model(stimuli, layers=['logits'], require_variance=require_variance)
         choices = self.logits_to_choice(logits)
         return choices
 
@@ -176,10 +176,10 @@ class ProbabilitiesMapping(BrainModel):
             "stimulus_id ordering is incorrect"
         self.classifier.fit(fitting_features, fitting_stimuli['image_label'])
 
-    def look_at(self, stimuli, number_of_trials=1):
+    def look_at(self, stimuli, number_of_trials=1, require_variance: bool = False):
         if self.current_task is BrainModel.Task.passive:
             return
-        features = self.activations_model(stimuli, layers=self.readout)
+        features = self.activations_model(stimuli, layers=self.readout, require_variance=require_variance)
         features = features.transpose('presentation', 'neuroid')
         prediction = self.classifier.predict_proba(features)
         return prediction
@@ -242,13 +242,13 @@ class OddOneOut(BrainModel):
         assert task == BrainModel.Task.odd_one_out
         self.current_task = task
 
-    def look_at(self, triplets, number_of_trials=1):
+    def look_at(self, triplets, number_of_trials=1, require_variance: bool = False):
         # Compute unique features and image_pathst
         stimuli = triplets.drop_duplicates(subset=['stimulus_id'])
         stimuli = stimuli.sort_values(by='stimulus_id')
 
         # Get features
-        features = self.activations_model(stimuli, layers=self.readout)
+        features = self.activations_model(stimuli, layers=self.readout, require_variance=require_variance)
         features = features.transpose('presentation', 'neuroid')
 
         # Compute similarity matrix

--- a/brainscore_vision/model_helpers/brain_transformation/temporal.py
+++ b/brainscore_vision/model_helpers/brain_transformation/temporal.py
@@ -28,8 +28,9 @@ class TemporalIgnore(BrainModel):
     def visual_degrees(self) -> int:
         return self._layer_model.visual_degrees()
 
-    def look_at(self, stimuli, number_of_trials=1):
-        responses = self._layer_model.look_at(stimuli, number_of_trials=number_of_trials)
+    def look_at(self, stimuli, number_of_trials=1, require_variance: bool = False):
+        responses = self._layer_model.look_at(stimuli, number_of_trials=number_of_trials,
+                                              require_variance=require_variance)
         time_responses = []
         self._logger.debug(f'Repeating single assembly across time bins {self._time_bins}')
         for time_bin in self._time_bins:

--- a/brainscore_vision/model_interface.py
+++ b/brainscore_vision/model_interface.py
@@ -196,8 +196,8 @@ class BrainModel:
         """
         raise NotImplementedError()
 
-    def look_at(self, stimuli: Union[StimulusSet, List[str]], number_of_trials=1) \
-            -> Union[BehavioralAssembly, NeuroidAssembly]:
+    def look_at(self, stimuli: Union[StimulusSet, List[str]], number_of_trials: int = 1,
+                require_variance: bool = False) -> Union[BehavioralAssembly, NeuroidAssembly]:
         """
         Digest a set of stimuli and return requested outputs. Which outputs to return is instructed by the
         :meth:`~brainscore_vision.model_interface.BrainMode.start_task` and
@@ -207,6 +207,9 @@ class BrainModel:
             or a list of image file paths
         :param number_of_trials: The number of repeated trials of the stimuli that the model should average over.
             E.g. 10 or 35. Non-stochastic models can likely ignore this parameter.
+        :param require_variance: Allows all models access to different activations to the same stimuli, currently
+            implemented using microsaccades. For more information, see the class
+            :cls:`~brainscore_vision.model_helpers.activations.core.MicrosaccadeHelper`.
         :return: task behaviors or recordings as instructed
         """
         raise NotImplementedError()

--- a/brainscore_vision/model_interface.py
+++ b/brainscore_vision/model_interface.py
@@ -207,9 +207,7 @@ class BrainModel:
             or a list of image file paths
         :param number_of_trials: The number of repeated trials of the stimuli that the model should average over.
             E.g. 10 or 35. Non-stochastic models can likely ignore this parameter.
-        :param require_variance: Allows all models access to different activations to the same stimuli, currently
-            implemented using microsaccades. For more information, see the class
-            :cls:`~brainscore_vision.model_helpers.activations.core.MicrosaccadeHelper`.
+        :param require_variance: Whether to require models to return different activations for the same stimuli or not. This is typically true in biological measurements due to e.g. micro-saccades and noise. Ideally this would always be the same in the models, but for compute reasons this flag allows specifying the need more directly.
         :return: task behaviors or recordings as instructed
         """
         raise NotImplementedError()


### PR DESCRIPTION
This PR resolves issue #651.

In addition, this PR adds traversal paths for `require_variance` for non-neural task models (Behavior, ProbabilitiesMapping, Temporal).