### PR TITLE
update version of auto merge action

### DIFF
--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -44,7 +44,7 @@ jobs:
         uses: hmarr/auto-approve-action@v3.1.0
 
       - name: Auto Merge (GitHub submissions)
-        uses: plm9606/automerge_actions@1.2.2
+        uses: plm9606/automerge_actions@1.2.3
         with:
           github-token: ${{ secrets.WORKFLOW_TOKEN }}
           label-name: "automerge"
@@ -52,7 +52,7 @@ jobs:
           auto-delete: "true"
 
       - name: Auto Merge (brain-score.org submissions)
-        uses: plm9606/automerge_actions@1.2.2
+        uses: plm9606/automerge_actions@1.2.3
         with:
           github-token: ${{ secrets.WORKFLOW_TOKEN }}
           label-name: "automerge-web"


### PR DESCRIPTION
Previously, the `.github/workflows/automerge_plugin-only_prs.yml` workflow utilized [plm9606/automerge_actions@1.2.2](https://github.com/plm9606/automerge_actions) which had noted issues with its delete functionality.

The version has now been updated to 1.2.3 which supports deleting after automerge.