### PR TITLE
add conditionals to automerge action

### DIFF
--- a/.github/workflows/automerge_plugin-only_prs.yml
+++ b/.github/workflows/automerge_plugin-only_prs.yml
@@ -44,6 +44,7 @@ jobs:
         uses: hmarr/auto-approve-action@v3.1.0
 
       - name: Auto Merge (GitHub submissions)
+        if: contains(github.event.pull_request.labels.*.name, 'automerge')
         uses: plm9606/automerge_actions@1.2.3
         with:
           github-token: ${{ secrets.WORKFLOW_TOKEN }}
@@ -52,6 +53,7 @@ jobs:
           auto-delete: "true"
 
       - name: Auto Merge (brain-score.org submissions)
+        if: contains(github.event.pull_request.labels.*.name, 'automerge-web')
         uses: plm9606/automerge_actions@1.2.3
         with:
           github-token: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
A web submission got caught up in the automerge action for git submissions [here](https://github.com/brain-score/vision/actions/runs/8455401605/job/23162806696). Conditionals have been added to block this from occurring in the future.