### PR TITLE
This PR (will eventually) convert the rest of the top-25 models.

### DIFF
--- a/brainscore_vision/models/densenet_201_pytorch/__init__.py
+++ b/brainscore_vision/models/densenet_201_pytorch/__init__.py
@@ -1,0 +1,7 @@
+from brainscore_vision import model_registry
+from brainscore_vision.model_helpers.brain_transformation import ModelCommitment
+from .model import get_model, get_layers
+
+model_registry['densenet_201_pytorch'] = lambda: ModelCommitment(identifier='densenet_201_pytorch',
+                                                               activations_model=get_model(),
+                                                               layers=get_layers())

--- a/brainscore_vision/models/densenet_201_pytorch/model.py
+++ b/brainscore_vision/models/densenet_201_pytorch/model.py
@@ -1,0 +1,52 @@
+from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
+from model_helpers.activations.pytorch import load_preprocess_images
+import ssl
+import functools
+import timm
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
+'''
+This is a Pytorch implementation of densenet_201.
+
+Previously on Brain-Score, this model existed as a Tensorflow model, and was converted via:
+    https://huggingface.co/timm/densenet201.tv_in1k
+    
+Disclaimer: This (pytorch) implementation's Brain-Score scores might not align identically with Tensorflow 
+implementation. 
+
+'''
+
+
+MODEL = timm.create_model('densenet201.tv_in1k', pretrained=True)
+
+
+def get_model():
+    preprocessing = functools.partial(load_preprocess_images, image_size=224)
+    wrapper = PytorchWrapper(identifier='densenet_201_pytorch', model=MODEL,
+                             preprocessing=preprocessing,
+                             batch_size=4)  # doesn't fit into 12 GB GPU memory otherwise
+    wrapper.image_size = 224
+    return wrapper
+
+
+def get_layers():
+    layer_names = []
+
+    for name, module in MODEL.named_modules():
+        layer_names.append(name)
+
+    return layer_names[2:]
+
+
+def get_bibtex():
+    """
+    A method returning the bibtex reference of the requested model as a string.
+    """
+    return """@inproceedings{huang2017densely,
+              title={Densely Connected Convolutional Networks},
+              author={Huang, Gao and Liu, Zhuang and van der Maaten, Laurens and Weinberger, Kilian Q },
+              booktitle={Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition},
+              year={2017}
+            }
+            """

--- a/brainscore_vision/models/densenet_201_pytorch/setup.py
+++ b/brainscore_vision/models/densenet_201_pytorch/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+requirements = ["torchvision",
+                "torch",
+                "timm",
+                "functools",
+                "ssl",
+                ]
+
+setup(
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    license="MIT license",
+    zip_safe=False,
+    keywords='brain-score template',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.7',
+    ],
+    test_suite='tests',
+)

--- a/brainscore_vision/models/densenet_201_pytorch/test.py
+++ b/brainscore_vision/models/densenet_201_pytorch/test.py
@@ -1,0 +1,8 @@
+import pytest
+import brainscore_vision
+
+
+@pytest.mark.travis_slow
+def test_has_identifier():
+    model = brainscore_vision.load_model('densenet_201_pytorch')
+    assert model.identifier == 'densenet_201_pytorch'

--- a/brainscore_vision/models/inception_v3_pytorch/__init__.py
+++ b/brainscore_vision/models/inception_v3_pytorch/__init__.py
@@ -1,0 +1,7 @@
+from brainscore_vision import model_registry
+from brainscore_vision.model_helpers.brain_transformation import ModelCommitment
+from .model import get_model, get_layers
+
+model_registry['inception_v3_pytorch'] = lambda: ModelCommitment(identifier='inception_v3_pytorch',
+                                                               activations_model=get_model(),
+                                                               layers=get_layers())

--- a/brainscore_vision/models/inception_v3_pytorch/model.py
+++ b/brainscore_vision/models/inception_v3_pytorch/model.py
@@ -1,0 +1,63 @@
+from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
+from model_helpers.activations.pytorch import load_preprocess_images
+import ssl
+import functools
+import timm
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
+'''
+This is a Pytorch implementation of inception_v3.
+
+Previously on Brain-Score, this model existed as a Tensorflow model, and was converted via:
+    https://huggingface.co/docs/timm/en/models/inception-v3
+    
+Disclaimer: This (pytorch) implementation's Brain-Score scores might not align identically with Tensorflow 
+implementation. 
+
+'''
+
+
+MODEL = timm.create_model('inception_v3', pretrained=True)
+
+
+def get_model():
+    preprocessing = functools.partial(load_preprocess_images, image_size=299)
+    wrapper = PytorchWrapper(identifier='inception_v3_pytorch', model=MODEL,
+                             preprocessing=preprocessing,
+                             batch_size=4)  # doesn't fit into 12 GB GPU memory otherwise
+    wrapper.image_size = 299
+    return wrapper
+
+
+def get_layers():
+    layer_names = []
+
+    for name, module in MODEL.named_modules():
+        layer_names.append(name)
+
+    return layer_names[2:]
+
+
+def get_bibtex():
+    """
+    A method returning the bibtex reference of the requested model as a string.
+    """
+    return """@article{DBLP:journals/corr/SzegedyVISW15,
+              author    = {Christian Szegedy and
+                           Vincent Vanhoucke and
+                           Sergey Ioffe and
+                           Jonathon Shlens and
+                           Zbigniew Wojna},
+              title     = {Rethinking the Inception Architecture for Computer Vision},
+              journal   = {CoRR},
+              volume    = {abs/1512.00567},
+              year      = {2015},
+              url       = {http://arxiv.org/abs/1512.00567},
+              archivePrefix = {arXiv},
+              eprint    = {1512.00567},
+              timestamp = {Mon, 13 Aug 2018 16:49:07 +0200},
+              biburl    = {https://dblp.org/rec/journals/corr/SzegedyVISW15.bib},
+              bibsource = {dblp computer science bibliography, https://dblp.org}
+            }
+            """

--- a/brainscore_vision/models/inception_v3_pytorch/setup.py
+++ b/brainscore_vision/models/inception_v3_pytorch/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+requirements = ["torchvision",
+                "torch",
+                "timm",
+                "functools",
+                "ssl",
+                ]
+
+setup(
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    license="MIT license",
+    zip_safe=False,
+    keywords='brain-score template',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.7',
+    ],
+    test_suite='tests',
+)

--- a/brainscore_vision/models/inception_v3_pytorch/test.py
+++ b/brainscore_vision/models/inception_v3_pytorch/test.py
@@ -1,0 +1,8 @@
+import pytest
+import brainscore_vision
+
+
+@pytest.mark.travis_slow
+def test_has_identifier():
+    model = brainscore_vision.load_model('inception_v3_pytorch')
+    assert model.identifier == 'inception_v3_pytorch'

--- a/brainscore_vision/models/inception_v4_pytorch/__init__.py
+++ b/brainscore_vision/models/inception_v4_pytorch/__init__.py
@@ -1,0 +1,7 @@
+from brainscore_vision import model_registry
+from brainscore_vision.model_helpers.brain_transformation import ModelCommitment
+from .model import get_model, get_layers
+
+model_registry['inception_v4_pytorch'] = lambda: ModelCommitment(identifier='inception_v4_pytorch',
+                                                               activations_model=get_model(),
+                                                               layers=get_layers())

--- a/brainscore_vision/models/inception_v4_pytorch/model.py
+++ b/brainscore_vision/models/inception_v4_pytorch/model.py
@@ -43,11 +43,11 @@ def get_bibtex():
     """
     A method returning the bibtex reference of the requested model as a string.
     """
-    return """@misc{zoph2018learning,
-              title={Learning Transferable Architectures for Scalable Image Recognition},
-              author={Barret Zoph and Vijay Vasudevan and Jonathon Shlens and Quoc V. Le},
-              year={2018},
-              eprint={1707.07012},
+    return """@misc{szegedy2016inceptionv4,
+              title={Inception-v4, Inception-ResNet and the Impact of Residual Connections on Learning}, 
+              author={Christian Szegedy and Sergey Ioffe and Vincent Vanhoucke and Alex Alemi},
+              year={2016},
+              eprint={1602.07261},
               archivePrefix={arXiv},
               primaryClass={cs.CV}
         }

--- a/brainscore_vision/models/inception_v4_pytorch/model.py
+++ b/brainscore_vision/models/inception_v4_pytorch/model.py
@@ -7,10 +7,10 @@ import timm
 ssl._create_default_https_context = ssl._create_unverified_context
 
 '''
-This is a Pytorch implementation of nasnet_large.
+This is a Pytorch implementation of inception_v4.
 
 Previously on Brain-Score, this model existed as a Tensorflow model, and was converted via:
-    https://huggingface.co/docs/timm/en/models/nasnet
+    https://huggingface.co/docs/timm/en/models/inception-v4
     
 Disclaimer: This (pytorch) implementation's Brain-Score scores might not align identically with Tensorflow 
 implementation. 
@@ -18,15 +18,15 @@ implementation.
 '''
 
 
-MODEL = timm.create_model('nasnetalarge', pretrained=True)
+MODEL = timm.create_model('inception_v4', pretrained=True)
 
 
 def get_model():
-    preprocessing = functools.partial(load_preprocess_images, image_size=331)
-    wrapper = PytorchWrapper(identifier='nasnet_large_pytorch', model=MODEL,
+    preprocessing = functools.partial(load_preprocess_images, image_size=299)
+    wrapper = PytorchWrapper(identifier='inception_v4_pytorch', model=MODEL,
                              preprocessing=preprocessing,
                              batch_size=4)  # doesn't fit into 12 GB GPU memory otherwise
-    wrapper.image_size = 331
+    wrapper.image_size = 299
     return wrapper
 
 

--- a/brainscore_vision/models/inception_v4_pytorch/setup.py
+++ b/brainscore_vision/models/inception_v4_pytorch/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+requirements = ["torchvision",
+                "torch",
+                "timm",
+                "functools",
+                "ssl",
+                ]
+
+setup(
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    license="MIT license",
+    zip_safe=False,
+    keywords='brain-score template',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.7',
+    ],
+    test_suite='tests',
+)

--- a/brainscore_vision/models/inception_v4_pytorch/test.py
+++ b/brainscore_vision/models/inception_v4_pytorch/test.py
@@ -1,0 +1,8 @@
+import pytest
+import brainscore_vision
+
+
+@pytest.mark.travis_slow
+def test_has_identifier():
+    model = brainscore_vision.load_model('inception_v4_pytorch')
+    assert model.identifier == 'inception_v4_pytorch'

--- a/brainscore_vision/models/nasnet_large_pytorch/__init__.py
+++ b/brainscore_vision/models/nasnet_large_pytorch/__init__.py
@@ -1,0 +1,7 @@
+from brainscore_vision import model_registry
+from brainscore_vision.model_helpers.brain_transformation import ModelCommitment
+from .model import get_model, get_layers
+
+model_registry['nasnet_large_pytorch'] = lambda: ModelCommitment(identifier='nasnet_large_pytorch',
+                                                               activations_model=get_model(),
+                                                               layers=get_layers())

--- a/brainscore_vision/models/nasnet_large_pytorch/model.py
+++ b/brainscore_vision/models/nasnet_large_pytorch/model.py
@@ -1,0 +1,54 @@
+from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
+from model_helpers.activations.pytorch import load_preprocess_images
+import ssl
+import functools
+import timm
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
+'''
+This is a Pytorch implementation of nasnet_large.
+
+Previously on Brain-Score, this model existed as a Tensorflow model, and was converted via:
+    https://huggingface.co/docs/timm/en/models/nasnet
+    
+Disclaimer: This (pytorch) implementation's Brain-Score scores might not align identically with Tensorflow 
+implementation. 
+
+'''
+
+
+MODEL = timm.create_model('nasnetalarge', pretrained=True)
+
+
+def get_model():
+    preprocessing = functools.partial(load_preprocess_images, image_size=224)
+    wrapper = PytorchWrapper(identifier='nasnet_large_pytorch', model=MODEL,
+                             preprocessing=preprocessing,
+                             batch_size=4)  # doesn't fit into 12 GB GPU memory otherwise
+    wrapper.image_size = 224
+    return wrapper
+
+
+def get_layers():
+    layer_names = []
+
+    for name, module in MODEL.named_modules():
+        layer_names.append(name)
+
+    return layer_names[2:]
+
+
+def get_bibtex():
+    """
+    A method returning the bibtex reference of the requested model as a string.
+    """
+    return """@misc{zoph2018learning,
+              title={Learning Transferable Architectures for Scalable Image Recognition},
+              author={Barret Zoph and Vijay Vasudevan and Jonathon Shlens and Quoc V. Le},
+              year={2018},
+              eprint={1707.07012},
+              archivePrefix={arXiv},
+              primaryClass={cs.CV}
+        }
+            """

--- a/brainscore_vision/models/nasnet_large_pytorch/setup.py
+++ b/brainscore_vision/models/nasnet_large_pytorch/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+requirements = ["torchvision",
+                "torch",
+                "timm",
+                "functools",
+                "ssl",
+                ]
+
+setup(
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    license="MIT license",
+    zip_safe=False,
+    keywords='brain-score template',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.7',
+    ],
+    test_suite='tests',
+)

--- a/brainscore_vision/models/nasnet_large_pytorch/test.py
+++ b/brainscore_vision/models/nasnet_large_pytorch/test.py
@@ -1,0 +1,8 @@
+import pytest
+import brainscore_vision
+
+
+@pytest.mark.travis_slow
+def test_has_identifier():
+    model = brainscore_vision.load_model('nasnet_large_pytorch')
+    assert model.identifier == 'nasnet_large_pytorch'

--- a/brainscore_vision/models/resnext101_32x16d_wsl/__init__.py
+++ b/brainscore_vision/models/resnext101_32x16d_wsl/__init__.py
@@ -1,0 +1,7 @@
+from brainscore_vision import model_registry
+from brainscore_vision.model_helpers.brain_transformation import ModelCommitment
+from .model import get_model, get_layers
+
+model_registry['resnext101_32x16d_wsl'] = lambda: ModelCommitment(identifier='resnext101_32x16d_wsl',
+                                                               activations_model=get_model(),
+                                                               layers=get_layers('resnext101_32x16d_wsl'))

--- a/brainscore_vision/models/resnext101_32x16d_wsl/model.py
+++ b/brainscore_vision/models/resnext101_32x16d_wsl/model.py
@@ -1,0 +1,27 @@
+import functools
+from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
+from brainscore_vision.model_helpers.activations.pytorch import load_preprocess_images
+import torch.hub
+import ssl
+
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
+
+def get_model():
+    model_identifier = "resnext101_32x16d_wsl"
+    model = torch.hub.load('facebookresearch/WSL-Images', model_identifier)
+    preprocessing = functools.partial(load_preprocess_images, image_size=224)
+    batch_size = {8: 32, 16: 16, 32: 8, 48: 4}
+    wrapper = PytorchWrapper(identifier=model_identifier, model=model, preprocessing=preprocessing,
+                             batch_size=batch_size[16])
+    wrapper.image_size = 224
+    return wrapper
+
+
+def get_layers(name):
+    return (['conv1'] +
+            # note that while relu is used multiple times, by default the last one will overwrite all previous ones
+            [f"layer{block + 1}.{unit}.relu"
+             for block, block_units in enumerate([3, 4, 23, 3]) for unit in range(block_units)] +
+            ['avgpool'])

--- a/brainscore_vision/models/resnext101_32x16d_wsl/setup.py
+++ b/brainscore_vision/models/resnext101_32x16d_wsl/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+requirements = ["torchvision",
+                "torch",
+                'ssl',
+                "functools",
+                "torch"
+                ]
+
+setup(
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    license="MIT license",
+    zip_safe=False,
+    keywords='brain-score template',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.7',
+    ],
+    test_suite='tests',
+)

--- a/brainscore_vision/models/resnext101_32x16d_wsl/test.py
+++ b/brainscore_vision/models/resnext101_32x16d_wsl/test.py
@@ -1,0 +1,8 @@
+import pytest
+import brainscore_vision
+
+
+@pytest.mark.travis_slow
+def test_has_identifier():
+    model = brainscore_vision.load_model('resnext101_32x16d_wsl')
+    assert model.identifier == 'resnext101_32x16d_wsl'

--- a/brainscore_vision/models/resnext101_32x48d_wsl/__init__.py
+++ b/brainscore_vision/models/resnext101_32x48d_wsl/__init__.py
@@ -1,0 +1,7 @@
+from brainscore_vision import model_registry
+from brainscore_vision.model_helpers.brain_transformation import ModelCommitment
+from .model import get_model, get_layers
+
+model_registry['resnext101_32x48d_wsl'] = lambda: ModelCommitment(identifier='resnext101_32x48d_wsl',
+                                                               activations_model=get_model(),
+                                                               layers=get_layers('resnext101_32x48d_wsl'))

--- a/brainscore_vision/models/resnext101_32x48d_wsl/model.py
+++ b/brainscore_vision/models/resnext101_32x48d_wsl/model.py
@@ -1,0 +1,27 @@
+import functools
+from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
+from brainscore_vision.model_helpers.activations.pytorch import load_preprocess_images
+import torch.hub
+import ssl
+
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
+
+def get_model():
+    model_identifier = "resnext101_32x48d_wsl"
+    model = torch.hub.load('facebookresearch/WSL-Images', model_identifier)
+    preprocessing = functools.partial(load_preprocess_images, image_size=224)
+    batch_size = {8: 32, 16: 16, 32: 8, 48: 4}
+    wrapper = PytorchWrapper(identifier=model_identifier, model=model, preprocessing=preprocessing,
+                             batch_size=batch_size[48])
+    wrapper.image_size = 224
+    return wrapper
+
+
+def get_layers(name):
+    return (['conv1'] +
+            # note that while relu is used multiple times, by default the last one will overwrite all previous ones
+            [f"layer{block + 1}.{unit}.relu"
+             for block, block_units in enumerate([3, 4, 23, 3]) for unit in range(block_units)] +
+            ['avgpool'])

--- a/brainscore_vision/models/resnext101_32x48d_wsl/setup.py
+++ b/brainscore_vision/models/resnext101_32x48d_wsl/setup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from setuptools import setup, find_packages
+
+requirements = ["torchvision",
+                "torch",
+                'ssl',
+                "functools",
+                "torch"
+                ]
+
+setup(
+    packages=find_packages(exclude=['tests']),
+    include_package_data=True,
+    install_requires=requirements,
+    license="MIT license",
+    zip_safe=False,
+    keywords='brain-score template',
+    classifiers=[
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.7',
+    ],
+    test_suite='tests',
+)

--- a/brainscore_vision/models/resnext101_32x48d_wsl/test.py
+++ b/brainscore_vision/models/resnext101_32x48d_wsl/test.py
@@ -1,0 +1,8 @@
+import pytest
+import brainscore_vision
+
+
+@pytest.mark.travis_slow
+def test_has_identifier():
+    model = brainscore_vision.load_model('resnext101_32x48d_wsl')
+    assert model.identifier == 'resnext101_32x48d_wsl'


### PR DESCRIPTION
Models Converted:

1. `resnext101_32x16d_wsl` (rank 11)
2. `resnext101_32x48d_wsl` (rank 7)
3. `nasnet_large` (rank 14)
4. `inception_v4` (rank 20)
5. `inception_v3` (rank 24
6. `densenet-201` (rank 22)

To Do Still:

- [ ] `resnet50_finetune_cutmix_e3_robust_linf8255_e0_247x234 `(rank 12)
- [ ] `effnetb1_cutmix_augmix_sam_e1_5avg_424x377` (rank 13)
- [ ] `antialias-resnet152` (rank 16)
- [ ] `resnet50-VITO-8deg-cc` (rank 18)
- [ ] `resnet-50_v2` (rank 19)
- [ ] `antialiased-rnext101_32x8d` (rank 21)
- [ ] `cv_18_dagger_408_pretrained` (rank 24)
- [ ] `AdvProp_efficientnet-b6` (rank 25)