### PR TITLE
test_db.py bug fix

### DIFF
--- a/tests/test_submission/test_db.py
+++ b/tests/test_submission/test_db.py
@@ -51,4 +51,4 @@ def test_db(database):
 
     assert len(user_entries) == 2
     assert len(model_entries) == 3
-    assert len(benchmark_type_entries) == 6
+    assert len(benchmark_type_entries) == 7


### PR DESCRIPTION
Adjusts the amount of benchmarks found in the test to the actual number (7 instead of 6).