### PR TITLE
Marking test_look_at_neural_V1 memory intense

### DIFF
--- a/brainscore_vision/model_helpers/generic_plugin_tests.py
+++ b/brainscore_vision/model_helpers/generic_plugin_tests.py
@@ -5,6 +5,7 @@ from brainio.stimuli import StimulusSet
 # noinspection PyUnresolvedReferences
 from brainscore_core.plugin_management.generic_plugin_tests_helper import pytest_generate_tests
 from brainscore_vision import BrainModel, load_model
+import pytest
 
 
 def test_identifier(identifier: str):
@@ -40,7 +41,7 @@ def test_look_at_behavior_probabilities(identifier: str):
     assert (0 <= predictions.values).all()
     assert (predictions.values <= 1).all()
 
-
+@pytest.mark.memory_intense
 def test_look_at_neural_V1(identifier: str):
     model = load_model(identifier)
     if not ProbeModel().can_start_recording_region(model, recording_target=BrainModel.RecordingTarget.V1):


### PR DESCRIPTION
`test_look_at_neural_V1` is running out of memory in Travis, causing tests to fail (see #917) with the following error:

``` bash
FAILED brainscore_vision/model_helpers/generic_plugin_tests.py::test_look_at_neural_V1[resnext101_32x8d_wsl] -
RuntimeError: [enforce fail at alloc_cpu.cpp:75] err == 0. DefaultCPUAllocator: can't allocate memory: 
you tried to allocate 102760448 bytes. Error code 12 (Cannot allocate memory)
```

This PR marks the test `memory_intense`, meaning it will only be run in Jenkins