### PR TITLE
Add composite benchmark to Scialom2024, and update AccuracyDistance

### DIFF
--- a/brainscore_vision/benchmarks/scialom2024/__init__.py
+++ b/brainscore_vision/benchmarks/scialom2024/__init__.py
@@ -26,6 +26,8 @@ benchmark_registry['Scialom2024_segments-100BehavioralAccuracyDistance'] = lambd
 # composites
 benchmark_registry['Scialom2024_phosphenes-allBehavioralErrorConsistency'] = lambda: benchmark._Scialom2024BehavioralErrorConsistency('phosphenes-all')
 benchmark_registry['Scialom2024_segments-allBehavioralErrorConsistency'] = lambda: benchmark._Scialom2024BehavioralErrorConsistency('segments-all')
+benchmark_registry['Scialom2024_phosphenes-allBehavioralAccuracyDistance'] = lambda: benchmark._Scialom2024BehavioralAccuracyDistance('phosphenes-all')
+benchmark_registry['Scialom2024_segments-allBehavioralAccuracyDistance'] = lambda: benchmark._Scialom2024BehavioralAccuracyDistance('segments-all')
 
 # engineering benchmarks
 benchmark_registry['Scialom2024_rgbEngineeringAccuracy'] = lambda: benchmark._Scialom2024EngineeringAccuracy('rgb')

--- a/brainscore_vision/benchmarks/scialom2024/test.py
+++ b/brainscore_vision/benchmarks/scialom2024/test.py
@@ -79,26 +79,26 @@ class TestBehavioral:
 
     @pytest.mark.private_access
     @pytest.mark.parametrize('dataset, expected_raw_score', [
-        ('rgb', approx(0.98963, abs=0.001)),
-        ('contours', approx(0.53011, abs=0.001)),
+        ('rgb', approx(0.92616, abs=0.001)),
+        ('contours', approx(0.25445, abs=0.001)),
         ('phosphenes-12', approx(0.84177, abs=0.001)),
         ('phosphenes-16', approx(0.77513, abs=0.001)),
         ('phosphenes-21', approx(0.76437, abs=0.001)),
         ('phosphenes-27', approx(0.56895, abs=0.001)),
-        ('phosphenes-35', approx(0.45105, abs=0.001)),
+        ('phosphenes-35', approx(0.52008, abs=0.001)),
         ('phosphenes-46', approx(0.29478, abs=0.001)),
         ('phosphenes-59', approx(0.19022, abs=0.001)),
         ('phosphenes-77', approx(0.13569, abs=0.001)),
-        ('phosphenes-100', approx(0.08426, abs=0.001)),
+        ('phosphenes-100', approx(0.11234, abs=0.001)),
         ('segments-12', approx(0.72937, abs=0.001)),
         ('segments-16', approx(0.57043, abs=0.001)),
         ('segments-21', approx(0.49300, abs=0.001)),
-        ('segments-27', approx(0.37131, abs=0.001)),
-        ('segments-35', approx(0.29337, abs=0.001)),
-        ('segments-46', approx(0.23712, abs=0.001)),
-        ('segments-59', approx(0.17800, abs=0.001)),
+        ('segments-27', approx(0.30014, abs=0.001)),
+        ('segments-35', approx(0.22442, abs=0.001)),
+        ('segments-46', approx(0.14312, abs=0.001)),
+        ('segments-59', approx(0.12072, abs=0.001)),
         ('segments-77', approx(0.12996, abs=0.001)),
-        ('segments-100', approx(0.16156, abs=0.001)),  # all of the above are AccuracyDistance
+        ('segments-100', approx(0.11540, abs=0.001)),  # all of the above are AccuracyDistance
         ('phosphenes-all', approx(0.18057, abs=0.01)),  # alls are ErrorConsistency
         ('segments-all', approx(0.15181, abs=0.01)),
     ])

--- a/brainscore_vision/benchmarks/scialom2024/test.py
+++ b/brainscore_vision/benchmarks/scialom2024/test.py
@@ -32,7 +32,9 @@ from brainscore_vision.data_helpers import s3
     'Scialom2024_segments-77BehavioralAccuracyDistance',
     'Scialom2024_segments-100BehavioralAccuracyDistance',
     'Scialom2024_phosphenes-allBehavioralErrorConsistency',
-    'Scialom2024_segments-allBehavioralErrorConsistency'
+    'Scialom2024_segments-allBehavioralErrorConsistency',
+    'Scialom2024_phosphenes-allBehavioralAccuracyDistance',
+    'Scialom2024_segments-allBehavioralAccuracyDistance'
 ])
 def test_benchmark_registry(benchmark):
     assert benchmark in benchmark_registry
@@ -41,32 +43,34 @@ def test_benchmark_registry(benchmark):
 class TestBehavioral:
     @pytest.mark.private_access
     @pytest.mark.parametrize('dataset, expected_ceiling', [
-        ('rgb', approx(0.98513, abs=0.001)),
-        ('contours', approx(0.97848, abs=0.001)),
-        ('phosphenes-12', approx(0.95416, abs=0.001)),
-        ('phosphenes-16', approx(0.92583, abs=0.001)),
-        ('phosphenes-21', approx(0.92166, abs=0.001)),
-        ('phosphenes-27', approx(0.86888, abs=0.001)),
-        ('phosphenes-35', approx(0.87277, abs=0.001)),
-        ('phosphenes-46', approx(0.87125, abs=0.001)),
-        ('phosphenes-59', approx(0.87625, abs=0.001)),
-        ('phosphenes-77', approx(0.89277, abs=0.001)),
-        ('phosphenes-100', approx(0.89930, abs=0.001)),
-        ('segments-12', approx(0.89847, abs=0.001)),
-        ('segments-16', approx(0.89055, abs=0.001)),
-        ('segments-21', approx(0.88083, abs=0.001)),
-        ('segments-27', approx(0.87083, abs=0.001)),
-        ('segments-35', approx(0.86333, abs=0.001)),
-        ('segments-46', approx(0.90250, abs=0.001)),
-        ('segments-59', approx(0.87847, abs=0.001)),
-        ('segments-77', approx(0.89013, abs=0.001)),
-        ('segments-100', approx(0.93236, abs=0.001)),  # all of the above are AccuracyDistance
-        ('phosphenes-all', approx(0.45755, abs=0.01)),  # alls are ErrorConsistency
-        ('segments-all', approx(0.42529, abs=0.01)),
+        ('rgb', approx(0.98484, abs=0.001)),
+        ('contours', approx(0.97794, abs=0.001)),
+        ('phosphenes-12', approx(0.94213, abs=0.001)),
+        ('phosphenes-16', approx(0.90114, abs=0.001)),
+        ('phosphenes-21', approx(0.89134, abs=0.001)),
+        ('phosphenes-27', approx(0.77732, abs=0.001)),
+        ('phosphenes-35', approx(0.78466, abs=0.001)),
+        ('phosphenes-46', approx(0.78246, abs=0.001)),
+        ('phosphenes-59', approx(0.79745, abs=0.001)),
+        ('phosphenes-77', approx(0.83475, abs=0.001)),
+        ('phosphenes-100', approx(0.86073, abs=0.001)),
+        ('segments-12', approx(0.86167, abs=0.001)),
+        ('segments-16', approx(0.8202, abs=0.001)),
+        ('segments-21', approx(0.8079, abs=0.001)),
+        ('segments-27', approx(0.78282, abs=0.001)),
+        ('segments-35', approx(0.77724, abs=0.001)),
+        ('segments-46', approx(0.85391, abs=0.001)),
+        ('segments-59', approx(0.83410, abs=0.001)),
+        ('segments-77', approx(0.86227, abs=0.001)),
+        ('segments-100', approx(0.92517, abs=0.001)),  # all of the above are AccuracyDistance
+        ('phosphenes-allBehavioralErrorConsistency', approx(0.45755, abs=0.01)),
+        ('segments-allBehavioralErrorConsistency', approx(0.42529, abs=0.01)),
+        ('phosphenes-allBehavioralAccuracyDistance', approx(0.89533, abs=0.01)),
+        ('segments-allBehavioralAccuracyDistance', approx(0.89052, abs=0.01)),
     ])
     def test_dataset_ceiling(self, dataset, expected_ceiling):
         if 'all' in dataset:
-            benchmark = f"Scialom2024_{dataset}BehavioralErrorConsistency"
+            benchmark = f"Scialom2024_{dataset}"
         else:
             benchmark = f"Scialom2024_{dataset}BehavioralAccuracyDistance"
         benchmark = load_benchmark(benchmark)
@@ -75,26 +79,26 @@ class TestBehavioral:
 
     @pytest.mark.private_access
     @pytest.mark.parametrize('dataset, expected_raw_score', [
-        ('rgb', approx(0.92666, abs=0.001)),
-        ('contours', approx(0.26708, abs=0.001)),
-        ('phosphenes-12', approx(0.87666, abs=0.001)),
-        ('phosphenes-16', approx(0.83666, abs=0.001)),
-        ('phosphenes-21', approx(0.83166, abs=0.001)),
-        ('phosphenes-27', approx(0.73666, abs=0.001)),
-        ('phosphenes-35', approx(0.72416, abs=0.001)),
-        ('phosphenes-46', approx(0.59500, abs=0.001)),
-        ('phosphenes-59', approx(0.50666, abs=0.001)),
-        ('phosphenes-77', approx(0.42083, abs=0.001)),
-        ('phosphenes-100', approx(0.33166, abs=0.001)),
-        ('segments-12', approx(0.81500, abs=0.001)),
-        ('segments-16', approx(0.73750, abs=0.001)),
-        ('segments-21', approx(0.69666, abs=0.001)),
-        ('segments-27', approx(0.59500, abs=0.001)),
-        ('segments-35', approx(0.52666, abs=0.001)),
-        ('segments-46', approx(0.42166, abs=0.001)),
-        ('segments-59', approx(0.34583, abs=0.001)),
-        ('segments-77', approx(0.28916, abs=0.001)),
-        ('segments-100', approx(0.19750, abs=0.001)),  # all of the above are AccuracyDistance
+        ('rgb', approx(0.98963, abs=0.001)),
+        ('contours', approx(0.53011, abs=0.001)),
+        ('phosphenes-12', approx(0.84177, abs=0.001)),
+        ('phosphenes-16', approx(0.77513, abs=0.001)),
+        ('phosphenes-21', approx(0.76437, abs=0.001)),
+        ('phosphenes-27', approx(0.56895, abs=0.001)),
+        ('phosphenes-35', approx(0.45105, abs=0.001)),
+        ('phosphenes-46', approx(0.29478, abs=0.001)),
+        ('phosphenes-59', approx(0.19022, abs=0.001)),
+        ('phosphenes-77', approx(0.13569, abs=0.001)),
+        ('phosphenes-100', approx(0.08426, abs=0.001)),
+        ('segments-12', approx(0.72937, abs=0.001)),
+        ('segments-16', approx(0.57043, abs=0.001)),
+        ('segments-21', approx(0.49300, abs=0.001)),
+        ('segments-27', approx(0.37131, abs=0.001)),
+        ('segments-35', approx(0.29337, abs=0.001)),
+        ('segments-46', approx(0.23712, abs=0.001)),
+        ('segments-59', approx(0.17800, abs=0.001)),
+        ('segments-77', approx(0.12996, abs=0.001)),
+        ('segments-100', approx(0.16156, abs=0.001)),  # all of the above are AccuracyDistance
         ('phosphenes-all', approx(0.18057, abs=0.01)),  # alls are ErrorConsistency
         ('segments-all', approx(0.15181, abs=0.01)),
     ])

--- a/brainscore_vision/metrics/accuracy_distance/metric.py
+++ b/brainscore_vision/metrics/accuracy_distance/metric.py
@@ -9,6 +9,10 @@ from brainscore_vision.metric_helpers.transformations import apply_aggregate
 
 
 class AccuracyDistance(Metric):
+    """
+    Computes the accuracy distance using the relative distance between the source and target accuracies, adjusted
+    for the maximum possible difference between the two accuracies.
+    """
     def __call__(self, source: BehavioralAssembly, target: BehavioralAssembly) -> Score:
         """Target should be the entire BehavioralAssembly, containing truth values."""
 

--- a/brainscore_vision/metrics/accuracy_distance/metric.py
+++ b/brainscore_vision/metrics/accuracy_distance/metric.py
@@ -52,8 +52,6 @@ class AccuracyDistance(Metric):
         # 0.2 and 0.6 respectively, then the relative floor-adjusted distance is 0.33... since the score is
         # 33% of the way from the source to the target
         relative_distance = 1 - np.abs(source_mean - target_mean) / maximum_distance
-        if relative_distance > 1:
-            print(relative_distance)
 
         return Score(relative_distance)
 

--- a/brainscore_vision/metrics/accuracy_distance/metric.py
+++ b/brainscore_vision/metrics/accuracy_distance/metric.py
@@ -48,9 +48,8 @@ class AccuracyDistance(Metric):
         target_mean = sum(target_correct) / len(target_correct)
 
         maximum_distance = np.max([1 - target_mean, target_mean])
-        # get the proportion of the distance between the source and target accuracies. e.g., if raw means are
-        # 0.2 and 0.6 respectively, then the relative floor-adjusted distance is 0.33... since the score is
-        # 33% of the way from the source to the target
+        # get the proportion of the distance between the source and target accuracies, adjusted for the maximum possible
+        # difference between the two accuracies
         relative_distance = 1 - np.abs(source_mean - target_mean) / maximum_distance
 
         return Score(relative_distance)

--- a/brainscore_vision/metrics/accuracy_distance/metric.py
+++ b/brainscore_vision/metrics/accuracy_distance/metric.py
@@ -43,9 +43,12 @@ class AccuracyDistance(Metric):
         source_mean = sum(source_correct) / len(source_correct)
         target_mean = sum(target_correct) / len(target_correct)
 
-        source_to_target_distance = np.abs(source_mean - target_mean)
-        accuracy_distance_score = 1 - source_to_target_distance
-        return Score(accuracy_distance_score)
+        floor_score = np.max([1 - target_mean, target_mean])
+        # get the proportion of the distance between the source and target accuracies. e.g., if raw means are
+        # 0.2 and 0.6 respectively, then the relative floor-adjusted distance is 0.33... since the score is
+        # 33% of the way from the source to the target
+        relative_distance = source_mean / floor_score
+        return Score(relative_distance)
 
     def ceiling(self, assembly):
         subjects = self.extract_subjects(assembly)

--- a/brainscore_vision/metrics/accuracy_distance/metric.py
+++ b/brainscore_vision/metrics/accuracy_distance/metric.py
@@ -47,11 +47,11 @@ class AccuracyDistance(Metric):
         source_mean = sum(source_correct) / len(source_correct)
         target_mean = sum(target_correct) / len(target_correct)
 
-        floor_score = np.max([1 - target_mean, target_mean])
+        maximum_distance = np.max([1 - target_mean, target_mean])
         # get the proportion of the distance between the source and target accuracies. e.g., if raw means are
         # 0.2 and 0.6 respectively, then the relative floor-adjusted distance is 0.33... since the score is
         # 33% of the way from the source to the target
-        relative_distance = source_mean / floor_score
+        relative_distance = source_mean / maximum_distance
         return Score(relative_distance)
 
     def ceiling(self, assembly):

--- a/brainscore_vision/metrics/accuracy_distance/metric.py
+++ b/brainscore_vision/metrics/accuracy_distance/metric.py
@@ -51,7 +51,10 @@ class AccuracyDistance(Metric):
         # get the proportion of the distance between the source and target accuracies. e.g., if raw means are
         # 0.2 and 0.6 respectively, then the relative floor-adjusted distance is 0.33... since the score is
         # 33% of the way from the source to the target
-        relative_distance = source_mean / maximum_distance
+        relative_distance = 1 - np.abs(source_mean - target_mean) / maximum_distance
+        if relative_distance > 1:
+            print(relative_distance)
+
         return Score(relative_distance)
 
     def ceiling(self, assembly):
@@ -65,6 +68,8 @@ class AccuracyDistance(Metric):
             pairwise_score['subject_left'] = 'subject', [subject1]
             pairwise_score['subject_right'] = 'subject', [subject2]
             subject_scores.append(Score(pairwise_score))
+            if pairwise_score > 1.:
+                print(pairwise_score)
 
         subject_scores = Score.merge(*subject_scores)
         subject_scores = apply_aggregate(aggregate_fnc=self.aggregate, values=subject_scores)

--- a/brainscore_vision/metrics/accuracy_distance/metric.py
+++ b/brainscore_vision/metrics/accuracy_distance/metric.py
@@ -68,8 +68,6 @@ class AccuracyDistance(Metric):
             pairwise_score['subject_left'] = 'subject', [subject1]
             pairwise_score['subject_right'] = 'subject', [subject2]
             subject_scores.append(Score(pairwise_score))
-            if pairwise_score > 1.:
-                print(pairwise_score)
 
         subject_scores = Score.merge(*subject_scores)
         subject_scores = apply_aggregate(aggregate_fnc=self.aggregate, values=subject_scores)

--- a/brainscore_vision/metrics/accuracy_distance/test.py
+++ b/brainscore_vision/metrics/accuracy_distance/test.py
@@ -9,7 +9,7 @@ def test_score():
     assembly = _make_data()
     metric = load_metric('accuracy_distance')
     score = metric(assembly.sel(subject='A'), assembly)
-    assert score == approx(0.77777778)
+    assert score == approx(0.74074074)
 
 
 def test_has_error():


### PR DESCRIPTION
This PR updates the AccuracyDistance to be relative to a floor (maximum possible distance), recomputes the expected Scialom2024 scores, and adds the composite BehavioralAccuracyDistance Benchmark.