### PR TITLE
Fix a behavioral assertion about stimulus order 

### DIFF
--- a/brainscore_vision/model_helpers/brain_transformation/behavior.py
+++ b/brainscore_vision/model_helpers/brain_transformation/behavior.py
@@ -243,6 +243,11 @@ class ProbabilitiesMapping(BrainModel):
 
     @staticmethod
     def order_preserving_unique(array):
+        """
+        This function sorts an array and removes duplicates while preserving the order of the elements.
+        This function is used in favor of np.unique to ensure that the order of the stimulus_ids is preserved, as
+        np.unique performs sorting on the array.
+        """
         _, indices = np.unique(array, return_index=True)
         return array[np.sort(indices)]
 

--- a/brainscore_vision/model_helpers/brain_transformation/behavior.py
+++ b/brainscore_vision/model_helpers/brain_transformation/behavior.py
@@ -192,7 +192,7 @@ class ProbabilitiesMapping(BrainModel):
                                                   number_of_trials=number_of_trials,
                                                   require_variance=require_variance)
         fitting_features = fitting_features.transpose('presentation', 'neuroid')
-        assert all(fitting_features['stimulus_id'].values == fitting_stimuli['stimulus_id'].values), \
+        assert all(self.order_preserving_unique(fitting_features['stimulus_id'].values) == fitting_stimuli['stimulus_id'].values), \
             "stimulus_id ordering is incorrect"
         self.classifier.fit(fitting_features, fitting_features['image_label'])
 
@@ -240,6 +240,11 @@ class ProbabilitiesMapping(BrainModel):
                 indices.append(label2index[label])
             index2label = OrderedDict((index, label) for label, index in label2index.items())
             return indices, index2label
+
+    @staticmethod
+    def order_preserving_unique(array):
+        _, indices = np.unique(array, return_index=True)
+        return array[np.sort(indices)]
 
 
 class OddOneOut(BrainModel):


### PR DESCRIPTION
PR #917 mistakenly did not update the `behavior.py` assertion about stimulus order to check for the order correctly. This causes issues with microsaccades (PR #365) and could cause issues with misalignment of other `stimulus_id` order errors that would not get caught here.

This PR fixes that issue.