### PR TITLE
set visual degrees for BMD2024 benchmark

### DIFF
--- a/brainscore_vision/benchmarks/bmd2024/benchmark.py
+++ b/brainscore_vision/benchmarks/bmd2024/benchmark.py
@@ -14,6 +14,7 @@ BIBTEX = ""  # to appear in a future article
 class _BMD_2024_BehavioralAccuracyDistance(BenchmarkBase):
     # behavioral benchmark
     def __init__(self, dataset):
+        self._visual_degrees = 8
         self._metric = load_metric('accuracy_distance')
         self._assembly = LazyLoad(lambda: load_assembly(dataset))
         super(_BMD_2024_BehavioralAccuracyDistance, self).__init__(


### PR DESCRIPTION
8 degrees "is also what we calibrated stimulus presentation for participants to be in the actual experiments" (from Marin Dujmovic)