### PR TITLE
remove unnecessary requirements in hmax

### DIFF
--- a/brainscore_vision/models/hmax/requirements.txt
+++ b/brainscore_vision/models/hmax/requirements.txt
@@ -1,6 +1,1 @@
-torchvision
-torch
-numpy
-scipy
-logging
 pillow


### PR DESCRIPTION
Errors are arising due to unnecessary requirements within hmax.