### PR TITLE
fix superfluous apostrophe in benchmark identifier

### DIFF
--- a/brainscore_vision/benchmarks/maniquet2024/benchmark.py
+++ b/brainscore_vision/benchmarks/maniquet2024/benchmark.py
@@ -63,7 +63,7 @@ class _Maniquet2024ConfusionSimilarity(BenchmarkBase):
 
         # Call the parent class constructor to complete initialization
         super(_Maniquet2024ConfusionSimilarity, self).__init__(
-            identifier="Maniquet2024-confusion_similarity'",
+            identifier="Maniquet2024-confusion_similarity",
             version=1,
             ceiling_func=lambda: Score(0.53526),  # use pre-computed from `self._metric._ceiling(self._human_assembly)`
             parent="Maniquet2024",

--- a/brainscore_vision/benchmarks/maniquet2024/test.py
+++ b/brainscore_vision/benchmarks/maniquet2024/test.py
@@ -9,9 +9,12 @@ Created on Mon Jun 24 17:22:59 2024
 import pytest
 from brainscore_vision import load_benchmark
 
-@pytest.mark.parametrize('benchmark', [
+
+@pytest.mark.parametrize("identifier", [
     'Maniquet2024-confusion_similarity',
     'Maniquet2024-tasks_consistency',
 ])
-def test_benchmark_registry(benchmark):
-    assert load_benchmark(benchmark) is not None
+def test_benchmark_registry(identifier):
+    benchmark = load_benchmark(identifier)
+    assert benchmark is not None
+    assert benchmark.identifier == identifier

--- a/brainscore_vision/benchmarks/maniquet2024/test.py
+++ b/brainscore_vision/benchmarks/maniquet2024/test.py
@@ -8,7 +8,7 @@ Created on Mon Jun 24 17:22:59 2024
 
 import pytest
 from brainscore_vision import load_benchmark
-
+@pytest.mark.private_access
 
 @pytest.mark.parametrize("identifier", [
     'Maniquet2024-confusion_similarity',


### PR DESCRIPTION
this has to be fixed together with the database