### PR TITLE
Added cross_validation_kwargs parameter to the InternalConsistency class

### DIFF
--- a/brainscore_vision/metrics/internal_consistency/ceiling.py
+++ b/brainscore_vision/metrics/internal_consistency/ceiling.py
@@ -76,7 +76,8 @@ class InternalConsistency(Ceiling):
     def __init__(self,
                  consistency_metric: Metric = None,
                  aggregate=None,
-                 split_coord=_SplitHalvesConsistency.Defaults.split_coord):
+                 split_coord=_SplitHalvesConsistency.Defaults.split_coord,
+                 cross_validation_kwargs: dict = None):
         """
         Creates a class to estimate the ceiling for a given assembly, based on split-half consistencies.
 
@@ -91,7 +92,8 @@ class InternalConsistency(Ceiling):
             aggregate = consistency_metric.aggregate
         self._consistency = _SplitHalvesConsistency(consistency_metric=consistency_metric,
                                                     aggregate=aggregate,
-                                                    split_coord=split_coord)
+                                                    split_coord=split_coord,
+                                                    cross_validation_kwargs=cross_validation_kwargs)
 
     def __call__(self, assembly: DataAssembly) -> Score:
         return self._consistency(assembly)
@@ -125,3 +127,4 @@ class TemporalCeiling:
             ceilings.append(ceiling)
         ceiling = Score.merge(*ceilings)
         return ceiling
+


### PR DESCRIPTION
Added a `cross_validation_kwargs` parameter to the `__init__()` of `InternalConsistency`, which is later passed to `_SplitHalvesConsistency` which was already expecting `cross_validation_kwargs` in it's init.

In my case this was useful because I have a low-repitition setup, where some of the stimuli have been repeated less times than a default number of cross-val splits for internal consistency.

Although internal consistency estimates with less than 5 repititions yield questionable results, this change makes the interface more complete.