### PR TITLE
Put V1 test before behavior test

### DIFF
--- a/brainscore_vision/model_helpers/generic_plugin_tests.py
+++ b/brainscore_vision/model_helpers/generic_plugin_tests.py
@@ -23,24 +23,6 @@ def test_start_task_or_recording(identifier: str):
     can_do = ProbeModel()
     assert can_do.can_start_task(model) or can_do.can_start_recording(model)
 
-
-def test_look_at_behavior_probabilities(identifier: str):
-    model = load_model(identifier)
-    stimuli = fitting_stimuli = _make_stimulus_set()
-    if not ProbeModel().can_start_task_specific(model,
-                                                task=BrainModel.Task.probabilities, fitting_stimuli=fitting_stimuli):
-        # model cannot do this task, ignore. We're testing for behavior or neural in `test_supports_behavior_or_neural`
-        return
-
-    model.start_task(BrainModel.Task.probabilities, fitting_stimuli=stimuli)
-    predictions = model.look_at(stimuli=stimuli, number_of_trials=1)
-    assert set(predictions.dims) == {'presentation', 'choice'}
-    assert set(predictions['stimulus_id'].values) == {'stimid1', 'stimid2', 'stimid3'}
-    assert all(predictions['object_name'] == 'rgb')
-    assert set(predictions['choice'].values) == set(fitting_stimuli['image_label'].values)
-    assert (0 <= predictions.values).all()
-    assert (predictions.values <= 1).all()
-
 @pytest.mark.memory_intense
 def test_look_at_neural_V1(identifier: str):
     model = load_model(identifier)
@@ -61,6 +43,24 @@ def test_look_at_neural_V1(identifier: str):
     assert 'neuroid' in predictions.dims
     if len(predictions.dims) == 3:
         assert 'time_bin' in predictions.dims
+
+def test_look_at_behavior_probabilities(identifier: str):
+    model = load_model(identifier)
+    stimuli = fitting_stimuli = _make_stimulus_set()
+    if not ProbeModel().can_start_task_specific(model,
+                                                task=BrainModel.Task.probabilities, fitting_stimuli=fitting_stimuli):
+        # model cannot do this task, ignore. We're testing for behavior or neural in `test_supports_behavior_or_neural`
+        return
+
+    model.start_task(BrainModel.Task.probabilities, fitting_stimuli=stimuli)
+    predictions = model.look_at(stimuli=stimuli, number_of_trials=1)
+    assert set(predictions.dims) == {'presentation', 'choice'}
+    assert set(predictions['stimulus_id'].values) == {'stimid1', 'stimid2', 'stimid3'}
+    assert all(predictions['object_name'] == 'rgb')
+    assert set(predictions['choice'].values) == set(fitting_stimuli['image_label'].values)
+    assert (0 <= predictions.values).all()
+    assert (predictions.values <= 1).all()
+
 
 
 def _make_stimulus_set() -> StimulusSet:

--- a/brainscore_vision/model_helpers/generic_plugin_tests.py
+++ b/brainscore_vision/model_helpers/generic_plugin_tests.py
@@ -23,6 +23,7 @@ def test_start_task_or_recording(identifier: str):
     can_do = ProbeModel()
     assert can_do.can_start_task(model) or can_do.can_start_recording(model)
 
+
 @pytest.mark.memory_intense
 def test_look_at_neural_V1(identifier: str):
     model = load_model(identifier)


### PR DESCRIPTION
Tests for Vision Transformer models fail when the line in [result-caching ](https://github.com/brain-score/result_caching/blob/05120fa98a95ed537227bd54be4c04bf6d9af098/result_caching/__init__.py#L336) tries to merge behavioral test results and V1 neural results. The reason is the `neuroid` dimensions do not match: the behavioral array has `channel_x` and `channel_y` dimensions whereas V1 outputs only have `embedding` [see here](https://github.com/brain-score/vision/blob/07c835cf87fd1e312fb07407b66611c157962064/brainscore_vision/model_helpers/activations/core.py#L279). This causes tests in [generic_plugin_tests.py](https://github.com/brain-score/vision/blob/master/brainscore_vision/model_helpers/generic_plugin_tests.py) to fail and the issue disappears when result caching is disabled. Locally, reordering these tests (putting V1 before behavior) resolves the issue.