### PR TITLE
Point pyproject dependencies to pypi instead of git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@ requires-python = ">=3.11"
 
 dependencies = [
     "numpy<2",
-    "brainscore_core @ git+https://github.com/brain-score/core@main",
-    "result_caching @ git+https://github.com/brain-score/result_caching@master",
+    "brainscore_core",
+    "result_caching",
     "importlib-metadata<5", # workaround to https://github.com/brain-score/brainio/issues/28
     "scikit-learn", # for metric_helpers/transformations.py cross-validation
     "scipy", # for benchmark_helpers/properties_common.py


### PR DESCRIPTION
brainscore_core and result_caching have both been packaged to pypi. In order for brainscore_vision to be packaged, these dependencies must point to pypi instead of git repos.