### PR TITLE
Fix pip install git

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To contribute, please [send in a pull request](https://github.com/brain-score/vi
 
 You will need Python = 3.11 and pip >= 18.1.
 
-`pip install git+https://github.com/brain-score/vision`
+`pip install git+https://github.com/brain-score/vision.git`
 
 Test if the installation is successful by scoring a model on a public benchmark:
 


### PR DESCRIPTION
The previous `pip install` would produce an error locally:

pip install pip install git+https://github.com/brain-score/vision
Collecting git+https://github.com/brain-score/vision
  Cloning https://github.com/brain-score/vision to /private/var/folders/h6/g53mxg516n538136hh74630r0000gn/T/pip-req-build-nomx4qn8
  Running command git clone --filter=blob:none --quiet https://github.com/brain-score/vision /private/var/folders/h6/g53mxg516n538136hh74630r0000gn/T/pip-req-build-nomx4qn8
  Resolved https://github.com/brain-score/vision to commit 4e57d9066a601cbf8e7f5d4620c30d309f7dd3b4
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: pip in /opt/anaconda3/envs/test3.11/lib/python3.11/site-packages (24.2)
ERROR: Could not find a version that satisfies the requirement install (from versions: none)
ERROR: No matching distribution found for install


Adding `.git` in the web url fixed this.