### PR TITLE
Update score_new_plugins.yml to use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -91,7 +91,7 @@ jobs:
           echo "$PLUGIN_INFO" > plugin-info.json
       
       - name: Upload PLUGIN_INFO as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: plugin-info
           path: plugin-info.json
@@ -114,7 +114,7 @@ jobs:
     needs: extract_email
     steps:
       - name: Download PLUGIN_INFO artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: plugin-info
           path: artifact-directory
@@ -144,7 +144,7 @@ jobs:
           echo "$PLUGIN_INFO" > plugin-info.json
       
       - name: Upload PLUGIN_INFO as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: plugin-info
           path: plugin-info.json
@@ -161,7 +161,7 @@ jobs:
     steps:
     
       - name: Download PLUGIN_INFO artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: plugin-info
           path: artifact-directory


### PR DESCRIPTION
Current workflow uses v2. This has been causing an automatic failure in scoring jobs.

v3 is being deprecated in 2 months.

Based on `Breaking Changes` as seen on the actions readme, this should work with a simple replacement of the version number.