### PR TITLE
Fix trigger scoring run bug

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -141,13 +141,13 @@ jobs:
 
       - name: Write PLUGIN_INFO to a json file
         run: |
-          echo "$PLUGIN_INFO" > plugin-info.json
+          echo "$PLUGIN_INFO" > plugin-info2.json
       
       - name: Upload PLUGIN_INFO as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: plugin-info
-          path: plugin-info.json
+          name: plugin-info2
+          path: plugin-info2.json
 
   run_scoring:
     name: Score plugins
@@ -163,12 +163,12 @@ jobs:
       - name: Download PLUGIN_INFO artifact
         uses: actions/download-artifact@v4
         with:
-          name: plugin-info
+          name: plugin-info2
           path: artifact-directory
     
       - name: Set PLUGIN_INFO as an environment variable
         run: |
-          PLUGIN_INFO=$(cat artifact-directory/plugin-info.json)
+          PLUGIN_INFO=$(cat artifact-directory/plugin-info2.json)
           USER_EMAIL=$(echo "$PLUGIN_INFO" | jq -r '.email')
           echo "::add-mask::$USER_EMAIL"  # readd a mask when bringing email back from artifact
           echo "PLUGIN_INFO=${PLUGIN_INFO}" >> $GITHUB_ENV

--- a/.github/workflows/user_notification_system.yml
+++ b/.github/workflows/user_notification_system.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Encrypt and set job-level output for email
         id: set_email_output
         run: |
-          ENCRYPTED_EMAIL=$(echo -n $EMAIL | openssl enc -aes-256-cbc -a -salt -pass pass:${{ secrets.EMAIL_ENCRYPTION_KEY }})
+          ENCRYPTED_EMAIL=$(echo -n $EMAIL | openssl enc -aes-256-cbc -a -A -salt -pass pass:${{ secrets.EMAIL_ENCRYPTION_KEY }})
           echo "EMAIL=$ENCRYPTED_EMAIL" >> $GITHUB_OUTPUT
           
       - name: Write email to file


### PR DESCRIPTION
This bug fix addresses 2 separate issues:

1. When long emails are encrypted, `openssl enc -aes-256-cbc -a` generates a Base64-encoded output, which includes newline characters by default to fit within a certain line width. `-A` was added to output the Base64 encoding as a single line.
2. When dealing with artifacts in v4, artifacts must have original names and can't overwrite each other.