### PR TITLE
Remove brainscore vision from env lock to make env updates easier

### DIFF
--- a/environment_lock.yml
+++ b/environment_lock.yml
@@ -36,7 +36,6 @@ dependencies:
       - botocore==1.35.3
       - brainscore-brainio==1.0.0
       - brainscore-core==2.1
-      - brainscore-vision==2.1
       - certifi==2024.7.4
       - cffi==1.17.0
       - cftime==1.6.4


### PR DESCRIPTION
Brainscore vision should be removed from the env lock until a pipeline is set up to automate the version bumping/pypi package building. For now, the latest master branch will be used in the container instead.