### PR TITLE
Coggan benchmark identifiers fix

### DIFF
--- a/brainscore_vision/benchmarks/coggan2024_behavior/__init__.py
+++ b/brainscore_vision/benchmarks/coggan2024_behavior/__init__.py
@@ -4,5 +4,5 @@ from brainscore_vision import benchmark_registry
 from .benchmark import (
     Coggan2024_behavior_ConditionWiseAccuracySimilarity)
 
-benchmark_registry['Coggan2024_behavior-ConditionWiseAccuracySimilarity'] = (
+benchmark_registry['tong.Coggan2024_behavior-ConditionWiseAccuracySimilarity'] = (
     Coggan2024_behavior_ConditionWiseAccuracySimilarity)

--- a/brainscore_vision/benchmarks/coggan2024_behavior/__init__.py
+++ b/brainscore_vision/benchmarks/coggan2024_behavior/__init__.py
@@ -6,3 +6,4 @@ from .benchmark import (
 
 benchmark_registry['tong.Coggan2024_behavior-ConditionWiseAccuracySimilarity'] = (
     Coggan2024_behavior_ConditionWiseAccuracySimilarity)
+

--- a/brainscore_vision/benchmarks/coggan2024_behavior/test.py
+++ b/brainscore_vision/benchmarks/coggan2024_behavior/test.py
@@ -7,13 +7,13 @@ from brainscore_vision import load_model
 
 
 def test_benchmark_registry():
-    assert ('Coggan2024_behavior-ConditionWiseAccuracySimilarity' in
+    assert ('tong.Coggan2024_behavior-ConditionWiseAccuracySimilarity' in
             benchmark_registry)
 
 @pytest.mark.private_access
 def test_benchmarks():
     benchmark = load_benchmark(
-        'Coggan2024_behavior-ConditionWiseAccuracySimilarity')
+        'tong.Coggan2024_behavior-ConditionWiseAccuracySimilarity')
     model = load_model('alexnet')
     result = benchmark(model)
     assert result.values == approx(0.1318, abs=.001)

--- a/brainscore_vision/benchmarks/coggan2024_fMRI/__init__.py
+++ b/brainscore_vision/benchmarks/coggan2024_fMRI/__init__.py
@@ -8,8 +8,8 @@ from .benchmark import (
     Coggan2024_IT,
 )
 
-benchmark_registry['Coggan2024_fMRI.V1-rdm'] = Coggan2024_V1
-benchmark_registry['Coggan2024_fMRI.V2-rdm'] = Coggan2024_V2
-benchmark_registry['Coggan2024_fMRI.V4-rdm'] = Coggan2024_V4
-benchmark_registry['Coggan2024_fMRI.IT-rdm'] = Coggan2024_IT
+benchmark_registry['tong.Coggan2024_fMRI.V1-rdm'] = Coggan2024_V1
+benchmark_registry['tong.Coggan2024_fMRI.V2-rdm'] = Coggan2024_V2
+benchmark_registry['tong.Coggan2024_fMRI.V4-rdm'] = Coggan2024_V4
+benchmark_registry['tong.Coggan2024_fMRI.IT-rdm'] = Coggan2024_IT
 

--- a/brainscore_vision/benchmarks/coggan2024_fMRI/test.py
+++ b/brainscore_vision/benchmarks/coggan2024_fMRI/test.py
@@ -8,7 +8,7 @@ from brainscore_vision import load_model
 
 @pytest.mark.parametrize('region', ['V1', 'V2', 'V4', 'IT'])
 def test_benchmark_registry(region):
-    assert f'Coggan2024_fMRI.{region}-rdm' in benchmark_registry
+    assert f'tong.Coggan2024_fMRI.{region}-rdm' in benchmark_registry
 
 
 @pytest.mark.parametrize('region', ['V1', 'V2', 'V4', 'IT'])
@@ -19,7 +19,7 @@ def test_benchmarks(region):
         V4=0.3008136,
         IT=0.4486508)[region]
     model = load_model('alexnet')
-    benchmark = load_benchmark(f'Coggan2024_fMRI.{region}-rdm')
+    benchmark = load_benchmark(f'tong.Coggan2024_fMRI.{region}-rdm')
     score = benchmark(model)
     assert score.values == approx(expected_score, abs=.005)
 


### PR DESCRIPTION
Currently, assertion errors are occurring for the Coggan benchmark because the registry doesn't include `tong.` before the identifier. Here is an example of the error:
`AssertionError: No registrations found for tong.Coggan2024_behavior-ConditionWiseAccuracySimilarity`