### PR TITLE
Decrease fps of causal inferencer testing

### DIFF
--- a/tests/test_model_helpers/temporal/activations/test_inferencer.py
+++ b/tests/test_model_helpers/temporal/activations/test_inferencer.py
@@ -129,7 +129,7 @@ def test_compute_temporal_context():
 
 @pytest.mark.memory_intense
 @pytest.mark.parametrize("preprocess", ["normal", "downsample"])
-@pytest.mark.parametrize("fps", [1, 40])
+@pytest.mark.parametrize("fps", [1, 10])
 def test_causal_inferencer(preprocess, fps):
     if preprocess == "normal":
         preprocess = dummy_preprocess


### PR DESCRIPTION
Causal inferencer tests currently take about 7 minutes each when at 40 fps. Decreasing to 10 in order to decrease testing time of general brainscore unit testing.