### PR TITLE
Remove layer map discovery log warning

### DIFF
--- a/brainscore_vision/model_helpers/brain_transformation/__init__.py
+++ b/brainscore_vision/model_helpers/brain_transformation/__init__.py
@@ -79,10 +79,9 @@ class ModelCommitment(BrainModel):
                     self._logger.info(f"Successfully loaded region_layer_map for {identifier}")
                     return json.load(region_layer_map_file)
             else:
-                self._logger.info(f"No region_layer_map file found for {identifier}, proceeding with default layer mapping")
+                self._logger.info(f"No region_layer_map file found for {identifier}. Will proceed with default layer mapping")
                 return None
         except Exception as e:
-            self._logger.error(f"Error importing model to search for region_layer_map: {e}")
             return None
 
     def visual_degrees(self) -> int:


### PR DESCRIPTION
Previously, we had some logging for when layer mapping could not be loaded. This logging made it seem like there was an actual error rather than a warning/info. See example here: https://github.com/brain-score/vision/issues/533#issuecomment-2457429854

Decided to remove the logging entirely to be consistent with previous version of ModelCommitment. I.e., if no region layer map was provided, it would just silently continue the way it was before.

Additionally, local development (without placing the model in `/models/`) also works but the Error makes it seem like it did not. See below:

![image](https://github.com/user-attachments/assets/fe9789fb-3449-4461-853f-37ce430fdd67)
