### PR TITLE
Replace status event trigger with check_run

### DIFF
--- a/.github/workflows/map_new_plugins.yml
+++ b/.github/workflows/map_new_plugins.yml
@@ -4,7 +4,11 @@ name: Perform layer mapping
 # THIS WORKFLOW ONLY WORKS WHEN NEW_MODEL CHANGES ARE MADE. BENCHMARKS ARE NOT SUPPORTED
 
 on:
-  status:
+  check_run:
+    types: [completed]
+    check_name:
+      - "Brain-Score Non-Plugin Unit tests (AWS Jenkins, AWS Execution)"
+      - "Brain-Score Plugins Unit tests (AWS Jenkins, AWS Execution)"
   pull_request:
     types: [labeled, synchronize]
 


### PR DESCRIPTION
Previously the status event trigger was too permissive and causing long delays in mapping and then auto merging. Now, mapping should be retriggered on unit test completion properly.