### PR TITLE
Update version bumping automerge method

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -126,14 +126,13 @@ jobs:
           allowed-conclusions: success,skipped
           verbose: true
 
-      - name: Merge PR
+      - name: Auto Merge PR
         if: steps.version-update.outputs.pr_number
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          pr_number="${{ steps.version-update.outputs.pr_number }}"
-          echo "Merging PR #$pr_number"
-          gh pr merge $pr_number --auto --squash
+        uses: plm9606/automerge_actions@1.2.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: "squash"
+          auto-delete: "true"
 
   create-release:
     needs: version-bump


### PR DESCRIPTION
The previous method (`gh pr merge $pr_number --auto --squash`) worked in some cases, but not others. Changing to use plm9606/automerge_actions@1.2.2.