### PR TITLE
Read the docs fix

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,3 +8,6 @@ build:
 python:
    install:
       - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/source/conf.py


### PR DESCRIPTION
See blog post here:
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
