### PR TITLE
Add custom mobilenet wrapper

### DIFF
--- a/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
@@ -38,7 +38,7 @@ def get_model(name):
     :return: the model instance
     """
     assert name == 'mobilenet_v2_0_5_192'
-    model = torch.load(model_weight_path.as_posix())
+    model = torch.load(model_weight_path.as_posix(), weights_only=False)
     preprocessing = functools.partial(load_preprocess_images, image_size=192, preprocess_type='inception')
     wrapper = MobilenetPytorchWrapper(identifier=name, model=base_model, preprocessing=preprocessing)
     wrapper.image_size = 192

--- a/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
@@ -38,7 +38,7 @@ def get_model(name):
     assert name == 'mobilenet_v2_0_5_192'
     model = torch.load(model_weight_path.as_posix(), weights_only=False)
     preprocessing = functools.partial(load_preprocess_images, image_size=192, preprocess_type='inception')
-    wrapper = MobilenetPytorchWrapper(identifier=name, model=base_model, preprocessing=preprocessing)
+    wrapper = MobilenetPytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
     wrapper.image_size = 192
     return wrapper
 

--- a/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
@@ -19,9 +19,6 @@ MainModel = imp.load_source('MainModel',model_path.as_posix())
 
 # This custom wrapper handles background class removal, and is used in related mobilenets
 class MobilenetPytorchWrapper(PytorchWrapper):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     def __call__(self, *args, **kwargs):
         result = super().__call__(*args, **kwargs)  # retrieve original output
         if 'logits' in kwargs.get('layers', []):

--- a/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
@@ -15,7 +15,18 @@ model_weight_path = load_weight_file(bucket="brainscore-storage", folder_name="b
                                     version_id="null",
                                     sha1="e5aa083caa4833fccd48af0c578a45064824dd7f")
 MainModel = imp.load_source('MainModel',model_path.as_posix())
-model = torch.load(model_weight_path.as_posix())
+
+
+# This custom wrapper handles background class removal, and is used in related mobilenets
+class MobilenetPytorchWrapper(PytorchWrapper):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        result = super().__call__(*args, **kwargs)  # retrieve original output
+        result = result.isel(neuroid=slice(1, None))  # remove the background class from the neuroid dimension
+        return result
+
 
 def get_model(name):
     """
@@ -27,8 +38,9 @@ def get_model(name):
     :return: the model instance
     """
     assert name == 'mobilenet_v2_0_5_192'
+    model = torch.load(model_weight_path.as_posix())
     preprocessing = functools.partial(load_preprocess_images, image_size=192, preprocess_type='inception')
-    wrapper = PytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
+    wrapper = MobilenetPytorchWrapper(identifier=name, model=base_model, preprocessing=preprocessing)
     wrapper.image_size = 192
     return wrapper
 

--- a/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_5_192/model.py
@@ -24,7 +24,8 @@ class MobilenetPytorchWrapper(PytorchWrapper):
 
     def __call__(self, *args, **kwargs):
         result = super().__call__(*args, **kwargs)  # retrieve original output
-        result = result.isel(neuroid=slice(1, None))  # remove the background class from the neuroid dimension
+        if 'logits' in kwargs.get('layers', []):
+            result = result.isel(neuroid=slice(1, None))  # remove background class in last layer
         return result
 
 

--- a/brainscore_vision/models/mobilenet_v2_0_5_224/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_5_224/model.py
@@ -1,8 +1,8 @@
 import functools
 from brainscore_vision.model_helpers.activations.pytorch import load_preprocess_images
-from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
 from brainscore_vision.model_helpers.check_submission import check_models
 from brainscore_vision.model_helpers.s3 import load_weight_file
+from brainscore_vision.models.mobilenet_v2_0_5_192.model import MobilenetPytorchWrapper
 import torch
 import imp
 
@@ -15,7 +15,6 @@ model_weight_path = load_weight_file(bucket="brainscore-storage", folder_name="b
                                     version_id="null",
                                     sha1="649501eadcf01f871bdb2265aa7dcac80594160a")
 MainModel = imp.load_source('MainModel',model_path.as_posix())
-model = torch.load(model_weight_path.as_posix())
 
 def get_model(name):
     """
@@ -27,17 +26,9 @@ def get_model(name):
     :return: the model instance
     """
     assert name == 'mobilenet_v2_0_5_224'
-    last_layer = model
-    while last_layer._modules:
-        last_layer = last_layer._modules[next(reversed(last_layer._modules))]
-    last_layer.register_forward_hook(lambda _layer, _input, logits: logits[:, 1:])
-    
+    model = torch.load(model_weight_path.as_posix())
     preprocessing = functools.partial(load_preprocess_images, image_size=224, preprocess_type='inception')
-    wrapper = PytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
-    wrapper.image_size = 224
-    return wrapper
-    preprocessing = functools.partial(load_preprocess_images, image_size=224, preprocess_type='inception')
-    wrapper = PytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
+    wrapper = MobilenetPytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
     wrapper.image_size = 224
     return wrapper
 

--- a/brainscore_vision/models/mobilenet_v2_0_5_224/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_5_224/model.py
@@ -26,7 +26,7 @@ def get_model(name):
     :return: the model instance
     """
     assert name == 'mobilenet_v2_0_5_224'
-    model = torch.load(model_weight_path.as_posix())
+    model = torch.load(model_weight_path.as_posix(), weights_only=False)
     preprocessing = functools.partial(load_preprocess_images, image_size=224, preprocess_type='inception')
     wrapper = MobilenetPytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
     wrapper.image_size = 224

--- a/brainscore_vision/models/mobilenet_v2_0_75_160/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_75_160/model.py
@@ -27,7 +27,7 @@ def get_model(name):
     :return: the model instance
     """
     assert name == 'mobilenet_v2_0_75_160'
-    model = torch.load(model_weight_path.as_posix(), , weights_only=False)
+    model = torch.load(model_weight_path.as_posix(), weights_only=False)
     preprocessing = functools.partial(load_preprocess_images, image_size=160, preprocess_type='inception')
     wrapper = MobilenetPytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
     wrapper.image_size = 160

--- a/brainscore_vision/models/mobilenet_v2_0_75_160/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_75_160/model.py
@@ -27,7 +27,7 @@ def get_model(name):
     :return: the model instance
     """
     assert name == 'mobilenet_v2_0_75_160'
-    model = torch.load(model_weight_path.as_posix())
+    model = torch.load(model_weight_path.as_posix(), , weights_only=False)
     preprocessing = functools.partial(load_preprocess_images, image_size=160, preprocess_type='inception')
     wrapper = MobilenetPytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
     wrapper.image_size = 160

--- a/brainscore_vision/models/mobilenet_v2_0_75_160/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_75_160/model.py
@@ -1,8 +1,8 @@
 import functools
 from brainscore_vision.model_helpers.activations.pytorch import load_preprocess_images
-from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
 from brainscore_vision.model_helpers.check_submission import check_models
 from brainscore_vision.model_helpers.s3 import load_weight_file
+from brainscore_vision.models.mobilenet_v2_0_5_192.model import MobilenetPytorchWrapper
 import torch
 import imp
 
@@ -15,7 +15,6 @@ model_weight_path = load_weight_file(bucket="brainscore-storage", folder_name="b
                                     version_id="null",
                                     sha1="9fc6f5e9864d524760c6e1dc8aa5702415457df4")
 MainModel = imp.load_source('MainModel',model_path.as_posix())
-model = torch.load(model_weight_path.as_posix())
 
 
 def get_model(name):
@@ -28,8 +27,9 @@ def get_model(name):
     :return: the model instance
     """
     assert name == 'mobilenet_v2_0_75_160'
+    model = torch.load(model_weight_path.as_posix())
     preprocessing = functools.partial(load_preprocess_images, image_size=160, preprocess_type='inception')
-    wrapper = PytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
+    wrapper = MobilenetPytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
     wrapper.image_size = 160
     return wrapper
 

--- a/brainscore_vision/models/mobilenet_v2_0_75_192/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_75_192/model.py
@@ -28,7 +28,7 @@ def get_model(name):
     """
     assert name == 'mobilenet_v2_0_75_192'
     preprocessing = functools.partial(load_preprocess_images, image_size=192, preprocess_type='inception')
-    model = torch.load(model_weight_path.as_posix())
+    model = torch.load(model_weight_path.as_posix(), weights_only=False)
     wrapper = MobilenetPytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
     wrapper.image_size = 192
     return wrapper

--- a/brainscore_vision/models/mobilenet_v2_0_75_192/model.py
+++ b/brainscore_vision/models/mobilenet_v2_0_75_192/model.py
@@ -1,8 +1,8 @@
 import functools
 from brainscore_vision.model_helpers.activations.pytorch import load_preprocess_images
-from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
 from brainscore_vision.model_helpers.check_submission import check_models
 from brainscore_vision.model_helpers.s3 import load_weight_file
+from brainscore_vision.models.mobilenet_v2_0_5_192.model import MobilenetPytorchWrapper
 import torch
 import imp
 
@@ -15,7 +15,7 @@ model_weight_path = load_weight_file(bucket="brainscore-storage", folder_name="b
                                     version_id="null",
                                     sha1="af063236e83cb92fd78ed3eb7d9d2d4a65d794ab")
 MainModel = imp.load_source('MainModel', model_path.as_posix())
-model = torch.load(model_weight_path.as_posix())
+
 
 def get_model(name):
     """
@@ -28,7 +28,8 @@ def get_model(name):
     """
     assert name == 'mobilenet_v2_0_75_192'
     preprocessing = functools.partial(load_preprocess_images, image_size=192, preprocess_type='inception')
-    wrapper = PytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
+    model = torch.load(model_weight_path.as_posix())
+    wrapper = MobilenetPytorchWrapper(identifier=name, model=model, preprocessing=preprocessing)
     wrapper.image_size = 192
     return wrapper
 


### PR DESCRIPTION
Currently, behavioral benchmarks are not working on these mobilenets due to an assertion error related to number of logits results. This wrapper slices the background class out which is not typical in pytorch models. 