### PR TITLE
Update sleep time of status checks

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -127,7 +127,7 @@ jobs:
           # Initial delay to allow statuses to start being reported
           echo "Sleeping for initial delay to allow statuses to be reported..."
           sleep 60
-          ELAPSED=$((ELAPSED + 10))
+          ELAPSED=$((ELAPSED + 60))
       
           while true; do
             echo "Polling statuses for commit $COMMIT_SHA"

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -126,7 +126,7 @@ jobs:
       
           # Initial delay to allow statuses to start being reported
           echo "Sleeping for initial delay to allow statuses to be reported..."
-          sleep 10
+          sleep 60
           ELAPSED=$((ELAPSED + 10))
       
           while true; do


### PR DESCRIPTION
Sleep time must be increased so that status checks can begin during version bumping.