### PR TITLE
Update `test_submission/test_actions_helpers` with more recent PR

### DIFF
--- a/tests/test_submission/test_actions_helpers.py
+++ b/tests/test_submission/test_actions_helpers.py
@@ -3,19 +3,19 @@ from subprocess import call
 
 from brainscore_vision.submission.actions_helpers import BASE_URL, get_pr_num_from_head, get_data, get_statuses_result, are_all_tests_passing, is_labeled_automerge, get_pr_head_from_github_event
 
-PR_HEAD_SHA = '209e6c81d39179fd161a1bd3a5845682170abfd2'
-PR_BRANCH_NAME = 'web_submission_11/add_plugins'
+PR_HEAD_SHA = '6ff4c26e35f67ad13bd075dbb73bd5166c854b7d'
+PR_BRANCH_NAME = 'web_submission_741/add_plugins'
 
 
 def test_get_pr_num_from_head_pull_request(monkeypatch):
     monkeypatch.setenv('GITHUB_EVENT_NAME', 'pull_request')
     pr_num = get_pr_num_from_head(PR_BRANCH_NAME)
-    assert pr_num == 442
+    assert pr_num == 1803
 
 def test_get_pr_num_from_head_non_pull_request(monkeypatch):
     monkeypatch.setenv('GITHUB_EVENT_NAME', 'status')
     pr_num = get_pr_num_from_head(PR_HEAD_SHA)
-    assert pr_num == 442
+    assert pr_num == 1803
 
 def test_get_pr_head_status_event(monkeypatch, mocker):
     monkeypatch.setenv('GITHUB_EVENT_NAME', 'status')
@@ -34,14 +34,14 @@ def test_get_pr_head_pull_request_event(monkeypatch):
     monkeypatch.setenv('GITHUB_HEAD_REF', PR_BRANCH_NAME)
     assert get_pr_head_from_github_event() == PR_BRANCH_NAME
 
-def test_get_statuses_result():
+def test_get_statuses_result_len():
     data = get_data(f"{BASE_URL}/statuses/{PR_HEAD_SHA}")
-    assert len(data) == 9
+    assert len(data) == 8
 
 def test_get_statuses_result():
     data = get_data(f"{BASE_URL}/statuses/{PR_HEAD_SHA}")
-    jenkins_plugintests_result = get_statuses_result('Brain-Score Jenkins CI - plugin tests', data)
-    assert jenkins_plugintests_result == 'failure'
+    jenkins_plugintests_result = get_statuses_result('Brain-Score Plugins Unit tests (AWS Jenkins, AWS Execution)', data)
+    assert jenkins_plugintests_result == 'success'
 
 def test_are_all_tests_passing():
     results_dict = {'jenkins_plugintests_result': 'success',
@@ -56,8 +56,8 @@ def test_one_test_failing():
     assert success == False
  
 def test_is_labeled_automerge(mocker):
-    assert is_labeled_automerge(442) == True
+    assert is_labeled_automerge(1803) == True
 
 def test_is_not_labeled_automerge(mocker):
-    assert is_labeled_automerge(433) == False
+    assert is_labeled_automerge(1801) == False
 


### PR DESCRIPTION
Previous version of `test_actions_helpers` used a `PR_HEAD_SHA` and `PR_BRANCH_NAME` that was older than how long GitHub retains status checks for (i.e., 400 days). As a result, `unittest_brainscore` was failing on `test_get_statuses_result` as the context could not be found. Replaced these two with more recent PRs (gives us 395 days before having to update again).

While debugging, also noticed there were two `test_get_statuses_result`s. Renamed the test looking at the length of the status response.

Made additional changes to `test_is_labeled_automerge` and `test_is_not_labeled_automerge` with more recent PRs although was not necessary.

Tests work locally (see image).
![image](https://github.com/user-attachments/assets/ae36b949-db02-4ae6-93cd-79359a4694c9)
