### PR TITLE
Prevent deletions from triggering scoring

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -50,10 +50,11 @@ jobs:
           python -m pip install ".[test]"
 
       - name: Save changed files to env var
+        # Only allow Added, Copied, Modified, Renamed, Changed (T) to trigger scoring
         run: |
           git fetch origin refs/pull/${{ github.event.number }}/head
           MERGE_COMMIT=$(git log --format='%H %P' --all | grep "$(git rev-parse FETCH_HEAD)\$" | cut -f1 -d' ')
-          echo "CHANGED_FILES=$(git diff --name-only origin/master~1 $MERGE_COMMIT | tr '\n' ' ')"  >> $GITHUB_ENV
+          echo "CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/master~1 $MERGE_COMMIT | tr '\n' ' ')"  >> $GITHUB_ENV
 
       - name: Get plugin info
         id: getpluginfo


### PR DESCRIPTION
Previously a simple `git diff` was used to identify changed files. Models that are removed, as a result, would be identified as a `CHANGED_FILES`. These would ultimately result in failed builds because the model no longer exists in the updated main branch post-merge.

Added flags to only allow Added (A), Copied (C), Modified (M), Renamed (R) and Changed (T) to trigger scoring. Deletion (D) has not been added. Same change applied in unit test plugins.