### PR TITLE
Remove travis build status from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](http://www.brain-score-jenkins.com:8080/job/vision_daily_test/badge/icon)](http://www.brain-score-jenkins.com:8080/job/vision_daily_test/)
 [![Documentation Status](https://readthedocs.org/projects/brain-score/badge/?version=latest)](https://brain-score.readthedocs.io/en/latest/?badge=latest)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Build Status](https://app.travis-ci.com/brain-score/vision.svg?token=vqt7d2yhhpLGwHsiTZvT&branch=master)](https://app.travis-ci.com/brain-score/vision)
 [![Documentation Status](https://readthedocs.org/projects/brain-score/badge/?version=latest)](https://brain-score.readthedocs.io/en/latest/?badge=latest)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) 
 


### PR DESCRIPTION
Removed broken build status from the README. @KartikP perhaps we update with a build status for a jenkins cron job or something similar?