### PR TITLE
Clean up stale web submissions

### DIFF
--- a/.github/workflows/cleanup_web_submissions.yml
+++ b/.github/workflows/cleanup_web_submissions.yml
@@ -1,0 +1,89 @@
+name: Close stale web submissions
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  fetch_prs:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_list: ${{ steps.get_prs.outputs.prs }}
+    steps:
+      - name: Get relevant PRs
+        id: get_prs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+            const filtered = prs.filter(pr => pr.title.startsWith('brain-score.org submission'));
+            return JSON.stringify(filtered.map(pr => ({ number: pr.number, sha: pr.head.sha, updated_at: pr.updated_at })));
+          result-encoding: string
+
+  process_prs:
+    needs: fetch_prs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process and close stale PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MAX_DAYS_PASSED_CHECKS = 28;
+            const MAX_DAYS_FAILED_CHECKS = 14;
+
+            const prs = JSON.parse(process.env.PR_LIST);
+            const now = new Date();
+            
+            // Iterate over all PRs
+            for (const pr of prs) {
+              const { data: combinedStatus } = await github.rest.repos.getCombinedStatusForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.sha
+              });
+              const statusState = combinedStatus.state;
+              const updatedAt = new Date(pr.updated_at);
+              const ageInDays = (now - updatedAt) / (1000 * 60 * 60 * 24);
+
+              // If PR has passed status checks, allow for more time
+              if (statusState === 'success' && ageInDays > MAX_DAYS_PASSED_CHECKS) {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  state: 'closed'
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `Closing this PR as it has been inactive for more than ${MAX_DAYS_PASSED_CHECKS} days since last update.`
+                });
+              // If PR has failed stastus checks, close more quickly  
+              } else if (statusState === 'failure' && ageInDays > MAX_DAYS_FAILED_CHECKS) {
+                await github.rest.pulls.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  state: 'closed'
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  body: `Closing this PR as it has been inactive for more than ${MAX_DAYS_FAILED_CHECKS} days since last update.`
+                });
+              }
+            }
+        env:
+          PR_LIST: ${{ needs.fetch_prs.outputs.pr_list }}


### PR DESCRIPTION
Currently, the pull request tab is littered with stale web submissions. As a result, important, longer-running PRs are getting buried.

This is a quick PR to close stale web submission pull requests.

## Steps:
1. Triggered every day at midnight (UTC) or manually.
2. Get a list of all open PRs that start with `brain-score.org submission`
3. Iterate over all PRs
4. Check how long it has been since last update, and status checks
5. If status checks have failed, close after 14 days since last update
6. If status checks have passed, close after 28 days since last update
7. When closing, leave a comment indicating reason