### PR TITLE
Fix: clamp benchmark scores to [0,1] in Coggan2024 IT-RDM & Geirhos2024 (closes #1898)

### DIFF
--- a/brainscore_vision/benchmarks/coggan2024_fMRI/benchmark.py
+++ b/brainscore_vision/benchmarks/coggan2024_fMRI/benchmark.py
@@ -8,6 +8,7 @@ from brainscore_vision.benchmark_helpers.screen import place_on_screen
 from brainscore_core.metrics import Score
 from brainscore_vision.metric_helpers import Defaults as XarrayDefaults
 from brainscore_vision.model_interface import BrainModel
+from brainscore_vision.benchmark_helpers import bound_score
 
 
 # the BIBTEX will be used to link to the publication from the benchmark for further details
@@ -60,7 +61,7 @@ class Coggan2024_fMRI_Benchmark(BenchmarkBase):
 
         # obtain the ceiled score
         ceiled_score = ceiler(raw_score, ceiling)
-
+        bound_score(ceiled_score)
         return ceiled_score
 
 

--- a/brainscore_vision/benchmarks/geirhos2021/benchmark.py
+++ b/brainscore_vision/benchmarks/geirhos2021/benchmark.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from brainio.assemblies import walk_coords
 from brainscore_vision import load_dataset, load_metric
 from brainscore_vision.benchmark_helpers.screen import place_on_screen
@@ -7,6 +6,7 @@ from brainscore_vision.benchmarks import BenchmarkBase
 from brainscore_vision.metrics import Score
 from brainscore_vision.model_interface import BrainModel
 from brainscore_vision.utils import LazyLoad
+from brainscore_vision.benchmark_helpers import bound_score
 
 BIBTEX = """@article{geirhos2021partial,
               title={Partial success in closing the gap between human and machine vision},
@@ -76,6 +76,7 @@ class _Geirhos2021ErrorConsistency(BenchmarkBase):
         raw_score = self._metric(labels, self._assembly)
         ceiling = self.ceiling
         score = raw_score / ceiling
+        bound_score(score)
         score.attrs['raw'] = raw_score
         score.attrs['ceiling'] = ceiling
         return score


### PR DESCRIPTION
Score values were coming out greater than 1 on certain models.