### PR TITLE
Handle multiple part folder paths in S3

### DIFF
--- a/brainscore_vision/data_helpers/s3.py
+++ b/brainscore_vision/data_helpers/s3.py
@@ -46,8 +46,9 @@ def load_assembly_from_s3(identifier: str, version_id: str, sha1: str, bucket: s
     """
     # Parse bucket name and folder name
     if '/' in bucket:
-        folder_name = bucket.split('/')[1]
-        bucket = bucket.split('/')[0]
+        parts = bucket.split('/', 1)  # Split only on first '/', preserving the rest as folder path
+        bucket = parts[0]
+        folder_name = parts[1]
     else:
         folder_name = None
     file_path = get_path(identifier, 'nc', bucket, version_id, sha1, folder_name=folder_name)
@@ -68,8 +69,9 @@ def load_stimulus_set_from_s3(identifier: str, bucket: str, csv_sha1: str, zip_s
                               csv_version_id: str, zip_version_id: str, filename_prefix: str = None):
     # Parse bucket name and folder name
     if '/' in bucket:
-        folder_name = bucket.split('/')[1]
-        bucket = bucket.split('/')[0]
+        parts = bucket.split('/', 1)  # Split only on first '/', preserving the rest as folder path
+        bucket = parts[0]
+        folder_name = parts[1]
     else:
         folder_name = None
     csv_path = get_path(identifier, 'csv', bucket, csv_version_id, csv_sha1, filename_prefix=filename_prefix, folder_name=folder_name)


### PR DESCRIPTION
Previously we stored all data in the `brainscore-storage/brainscore-brainio` folder. We retrieve data by splitting this path by `/` and then treating `[0]` as bucket and `[1]` as the final folder.

With shift to a more organized S3 directory (e.g., `brainscore-storage/brainscore-vision/benchmarks/`, etc.), new data stored here would not be found because only partial path was being used.

This PR introduces a simple change to use `[0]` as bucket, and then the rest of the path after the first `/` as the folder_path.