### PR TITLE
Update brainio paths for benchmark test.py files

### DIFF
--- a/brainscore_vision/benchmarks/baker2022/test.py
+++ b/brainscore_vision/benchmarks/baker2022/test.py
@@ -5,7 +5,7 @@ from brainscore_core.supported_data_standards.brainio.assemblies import Behavior
 from brainscore_vision import benchmark_registry, load_benchmark
 from brainscore_vision.benchmarks.baker2022 import DATASETS
 from brainscore_vision.benchmark_helpers import PrecomputedFeatures
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 
 
 @pytest.mark.private_access

--- a/brainscore_vision/benchmarks/freemanziemba2013/test.py
+++ b/brainscore_vision/benchmarks/freemanziemba2013/test.py
@@ -7,7 +7,7 @@ from brainscore_vision import benchmark_registry, load_benchmark
 from brainscore_vision.benchmark_helpers import PrecomputedFeatures
 from brainscore_vision.benchmark_helpers.test_helper import StandardizedTests, PrecomputedTests, NumberOfTrialsTests, \
     VisualDegreesTests
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 
 standardized_tests = StandardizedTests()
 precomputed_test = PrecomputedTests()

--- a/brainscore_vision/benchmarks/geirhos2021/test.py
+++ b/brainscore_vision/benchmarks/geirhos2021/test.py
@@ -8,7 +8,7 @@ from brainscore_core.supported_data_standards.brainio.assemblies import Behavior
 from brainscore_vision import benchmark_registry, load_benchmark
 from brainscore_vision.benchmark_helpers import PrecomputedFeatures
 from brainscore_vision.benchmarks.geirhos2021.benchmark import DATASETS, cast_coordinate_type
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 
 
 @pytest.mark.parametrize('benchmark', [

--- a/brainscore_vision/benchmarks/hermann2020/test.py
+++ b/brainscore_vision/benchmarks/hermann2020/test.py
@@ -6,7 +6,7 @@ from pytest import approx
 from brainscore_core.supported_data_standards.brainio.assemblies import BehavioralAssembly
 from brainscore_vision import load_benchmark
 from brainscore_vision.benchmark_helpers import PrecomputedFeatures
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 
 
 class TestEngineering:

--- a/brainscore_vision/benchmarks/kar2019/test.py
+++ b/brainscore_vision/benchmarks/kar2019/test.py
@@ -10,7 +10,7 @@ from brainscore_vision import load_benchmark
 from brainscore_vision.benchmark_helpers import PrecomputedFeatures
 from brainscore_vision.benchmark_helpers.test_helper import VisualDegreesTests, NumberOfTrialsTests
 from brainscore_vision.benchmarks.kar2019 import DicarloKar2019OST
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 
 visual_degrees = VisualDegreesTests()
 number_trials = NumberOfTrialsTests()

--- a/brainscore_vision/benchmarks/majajhong2015/test.py
+++ b/brainscore_vision/benchmarks/majajhong2015/test.py
@@ -8,7 +8,7 @@ from brainscore_vision.benchmark_helpers import PrecomputedFeatures
 from brainscore_vision.benchmark_helpers.test_helper import StandardizedTests, PrecomputedTests, NumberOfTrialsTests, \
     VisualDegreesTests
 from brainscore_vision.benchmarks.majajhong2015.benchmark import MajajHongV4PublicBenchmark, MajajHongITPublicBenchmark
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 
 standardized_tests = StandardizedTests()
 precomputed_test = PrecomputedTests()

--- a/brainscore_vision/benchmarks/rajalingham2018/test.py
+++ b/brainscore_vision/benchmarks/rajalingham2018/test.py
@@ -12,7 +12,7 @@ from brainscore_vision.benchmark_helpers import PrecomputedFeatures
 from brainscore_vision.benchmark_helpers.test_helper import VisualDegreesTests, NumberOfTrialsTests
 from brainscore_vision.benchmarks.rajalingham2018 import DicarloRajalingham2018I2n
 from brainscore_vision.benchmarks.rajalingham2018.benchmarks.benchmark import _DicarloRajalingham2018
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 from brainscore_vision.model_helpers.brain_transformation import ProbabilitiesMapping
 from brainscore_vision.model_interface import BrainModel
 

--- a/brainscore_vision/benchmarks/rajalingham2020/test.py
+++ b/brainscore_vision/benchmarks/rajalingham2020/test.py
@@ -4,7 +4,7 @@ import pytest
 from pytest import approx
 
 from brainscore_vision.benchmark_helpers.test_helper import StandardizedTests, PrecomputedTests
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 
 standardized_tests = StandardizedTests()
 precomputed_test = PrecomputedTests()

--- a/brainscore_vision/benchmarks/scialom2024/test.py
+++ b/brainscore_vision/benchmarks/scialom2024/test.py
@@ -7,7 +7,7 @@ from pytest import approx
 from brainscore_core.supported_data_standards.brainio.assemblies import BehavioralAssembly
 from brainscore_vision import benchmark_registry, load_benchmark
 from brainscore_vision.benchmark_helpers import PrecomputedFeatures
-from brainscore_vision.data_helpers import s3
+from brainscore_core.supported_data_standards.brainio import s3
 
 
 @pytest.mark.parametrize('benchmark', [


### PR DESCRIPTION
Updates the path in 9 plugins (benchmark `test.py` files) to use new `brainio` import from core. 