### PR TITLE
enable resultcaching for ViT models from timm

### DIFF
--- a/brainscore_vision/models/timm_models/model.py
+++ b/brainscore_vision/models/timm_models/model.py
@@ -1,4 +1,3 @@
-import os
 import functools
 import json
 from pathlib import Path
@@ -65,13 +64,7 @@ def get_model(model_id:str):
     model_name = config["model_name"]
     model_id = config["model_id"]
     timm_model_name = config["timm_model_name"]
-    is_vit = config["is_vit"]
     
-    # Temporary fix for vit models
-    # See https://github.com/brain-score/vision/pull/1232
-    if is_vit:
-        os.environ['RESULTCACHING_DISABLE'] = 'brainscore_vision.model_helpers.activations.core.ActivationsExtractorHelper._from_paths_stored'
-
     
     # Initialize model
     model = timm.create_model(timm_model_name, pretrained=True)


### PR DESCRIPTION
Previously, the timm model plugin checked if a model is a ViT and if yes, disabled caching of extracted activations. This was because of the problem described in #1232 and addressed in #2164 which merged. Therefore, I think we should be able to enable result caching now.