### PR TITLE
Implement dual ridge regression for memory optimization

### DIFF
--- a/brainscore_vision/benchmark_helpers/neural_common.py
+++ b/brainscore_vision/benchmark_helpers/neural_common.py
@@ -31,6 +31,18 @@ class NeuralBenchmark(BenchmarkBase):
         source_assembly = candidate.look_at(stimulus_set, number_of_trials=self._number_of_trials)
         if 'time_bin' in source_assembly.dims and source_assembly.sizes['time_bin'] == 1:
             source_assembly = source_assembly.squeeze('time_bin')  # static case for these benchmarks
+        # Free model weights — activations are extracted, model not used again.
+        # Can't `del candidate` because _run_score holds a reference via `model`.
+        # Instead clear PyTorch parameters directly.
+        import gc
+        try:
+            torch_model = candidate.activations_model._model
+            for param in torch_model.parameters():
+                param.data = param.data.new_empty(0)
+            del torch_model
+        except (AttributeError, Exception):
+            pass
+        gc.collect()
         raw_score = self._similarity_metric(source_assembly, self._assembly)
         ceiled_score = explained_variance(raw_score, self.ceiling)
         return ceiled_score
@@ -116,6 +128,22 @@ class TrainTestNeuralBenchmark(BenchmarkBase):
             self.train_activations = self.train_activations.squeeze('time_bin')
         if 'time_bin' in self.test_activations.dims and self.test_activations.sizes['time_bin'] == 1:
             self.test_activations = self.test_activations.squeeze('time_bin')
+
+        # Free model weights — activations are extracted and cached, the model
+        # is not needed for the metric. The caller (_run_score) still holds a
+        # reference to the model object, so `del candidate` won't free it.
+        # Instead, clear the PyTorch parameters directly.
+        import gc
+        try:
+            # PytorchWrapper holds the torch model in ._model
+            torch_model = candidate.activations_model._model
+            # Delete all parameters and buffers to free weight memory
+            for param in torch_model.parameters():
+                param.data = param.data.new_empty(0)
+            del torch_model
+        except (AttributeError, Exception):
+            pass  # not a PytorchWrapper or structure differs
+        gc.collect()
 
         if self.alpha_coord is not None:
             scores_dict = {}

--- a/brainscore_vision/benchmarks/allen2022_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/allen2022_fmri/benchmark.py
@@ -85,7 +85,7 @@ def _Allen2022fmri(region,
 def Allen2022fmri(region: str, metric_type: str,
                   dataset_prefix: str = 'Allen2022_fmri',
                   alphas: list = ALPHA_LIST):
-    similarity_metric = load_metric(f'{metric_type}_split', alphas=alphas)
+    similarity_metric = load_metric(f'dual_{metric_type}_split', alphas=alphas)
     return _Allen2022fmri(region, similarity_metric=similarity_metric,
                           identifier_metric_suffix=metric_type,
                           dataset_prefix=dataset_prefix,

--- a/brainscore_vision/benchmarks/allen2022_fmri_surface/benchmark.py
+++ b/brainscore_vision/benchmarks/allen2022_fmri_surface/benchmark.py
@@ -85,7 +85,7 @@ def _Allen2022fmriSurface(region,
 def Allen2022fmriSurface(region: str, metric_type: str,
                           dataset_prefix: str = 'Allen2022_fmri_surface',
                           alphas: list = ALPHA_LIST):
-    similarity_metric = load_metric(f'{metric_type}_split', alphas=alphas)
+    similarity_metric = load_metric(f'dual_{metric_type}_split', alphas=alphas)
     return _Allen2022fmriSurface(region, similarity_metric=similarity_metric,
                                  identifier_metric_suffix=metric_type,
                                  dataset_prefix=dataset_prefix,

--- a/brainscore_vision/metrics/regression_correlation/__init__.py
+++ b/brainscore_vision/metrics/regression_correlation/__init__.py
@@ -1,5 +1,6 @@
 from brainscore_vision import metric_registry
-from .metric import CrossRegressedCorrelation, pls_regression, ridge_cv_regression, ridge_regression, single_regression, linear_regression,\
+from .metric import CrossRegressedCorrelation, pls_regression, ridge_cv_regression, ridge_regression, \
+    dual_ridge_regression, dual_ridge_cv_regression, single_regression, linear_regression,\
     pearsonr_correlation, ReverseCrossRegressedCorrelation, ReverseTrainTestSplitCorrelation
     
 
@@ -26,6 +27,10 @@ metric_registry['linear_predictivity_split'] = lambda *args, **kwargs: TrainTest
     regression=linear_regression(), correlation=pearsonr_correlation(), *args, **kwargs)
 metric_registry['ridgecv_split'] = lambda *args, **kwargs: TrainTestSplitCorrelation(
     regression=ridge_cv_regression(**kwargs), correlation=pearsonr_correlation(), *args, **kwargs)
+metric_registry['dual_ridge_split'] = lambda *args, **kwargs: TrainTestSplitCorrelation(
+    regression=dual_ridge_regression(), correlation=pearsonr_correlation(), *args, **kwargs)
+metric_registry['dual_ridgecv_split'] = lambda *args, **kwargs: TrainTestSplitCorrelation(
+    regression=dual_ridge_cv_regression(**kwargs), correlation=pearsonr_correlation(), *args, **kwargs)
 
 metric_registry["reverse_pls_cv"] = lambda *args, **kwargs: ReverseCrossRegressedCorrelation(
     regression=pls_regression(), correlation=pearsonr_correlation(), *args, **kwargs)

--- a/brainscore_vision/metrics/regression_correlation/metric.py
+++ b/brainscore_vision/metrics/regression_correlation/metric.py
@@ -182,11 +182,18 @@ class DualRidgeRegression:
 
 
 class DualRidgeCVRegression:
-    """RidgeCV with dual form prediction for memory efficiency.
+    """RidgeCV with dual form for memory efficiency.
 
-    Uses sklearn RidgeCV for alpha selection (LOO/GCV), then the dual kernel
-    form for prediction to avoid storing the (n_features, n_targets) coef_ matrix.
-    Falls back to sklearn RidgeCV when n_samples >= n_features.
+    When n_samples < n_features and no custom scoring/cv is requested,
+    selects alpha via LOO cross-validation in kernel space using the
+    eigendecomposition of K = X @ X.T, then predicts via dual-form
+    projection. Never materializes the (n_features, n_targets) coef_ matrix.
+
+    When custom scoring or cv is requested, falls back to sklearn RidgeCV
+    for alpha selection (preserving all sklearn behavior), then uses
+    DualRidgeRegression for prediction.
+
+    Falls back to sklearn RidgeCV entirely when n_samples >= n_features.
 
     Exposes ``alpha_`` after fit (selected regularization strength).
     """
@@ -197,6 +204,20 @@ class DualRidgeCVRegression:
         self._ridgecv_kwargs = ridgecv_kwargs
         self.alpha_ = None
 
+    def _can_use_dual_loo(self) -> bool:
+        """Check if we can do alpha selection in kernel space.
+
+        Dual LOO is only valid when sklearn would use its efficient LOO path:
+        no custom scoring function, no explicit cv folds, no per-target alpha.
+        """
+        if self._ridgecv_kwargs.get('scoring') is not None:
+            return False
+        if self._ridgecv_kwargs.get('cv') is not None:
+            return False
+        if self._ridgecv_kwargs.get('alpha_per_target', False):
+            return False
+        return True
+
     def fit(self, X, Y) -> None:
         X = np.asarray(X, dtype=np.float64)
         Y = np.asarray(Y, dtype=np.float64)
@@ -204,24 +225,115 @@ class DualRidgeCVRegression:
 
         if n_samples >= n_features:
             self._use_dual = False
-            self._primal = RidgeCV(alphas=self.alphas, **self._ridgecv_kwargs)
+            kwargs = dict(self._ridgecv_kwargs)
+            if self.alphas is not None:
+                kwargs['alphas'] = self.alphas
+            self._primal = RidgeCV(**kwargs)
             self._primal.fit(X, Y)
             self.alpha_ = self._primal.alpha_
             return
 
         self._use_dual = True
-        rcv = RidgeCV(alphas=self.alphas, **self._ridgecv_kwargs)
+
+        if self._can_use_dual_loo():
+            self._fit_dual_loo(X, Y, n_samples)
+        else:
+            self._fit_sklearn_then_dual(X, Y)
+
+    def _fit_dual_loo(self, X, Y, n_samples) -> None:
+        """Select alpha via LOO in kernel space. No coef_ materialized.
+
+        Replicates sklearn's _RidgeGCV eigen decomposition approach:
+        center X, add intercept to kernel via outer product, eigendecompose,
+        zero regularization on the intercept eigenvector, then evaluate LOO
+        for each alpha candidate.
+        """
+        # Center X (sklearn centers X in preprocessing, not Y)
+        self._X_mean = X.mean(axis=0)
+        self._Y_mean = Y.mean(axis=0)
+        X_c = X - self._X_mean
+        self._X_train_centered = X_c
+        self._Y_train_centered = Y - self._Y_mean
+
+        # Kernel with intercept: K = X_c @ X_c.T + 1*1.T
+        # The outer product accounts for the unregularized intercept
+        K = X_c @ X_c.T
+        K += np.ones((n_samples, n_samples))
+
+        eigenvalues, Q = np.linalg.eigh(K)
+        QT_y = Q.T @ Y  # project UN-centered Y
+
+        # Find the intercept eigenvector (most aligned with ones vector)
+        normalized_sw = np.ones(n_samples) / np.sqrt(n_samples)
+        intercept_dim = np.argmax(np.abs(Q.T @ normalized_sw))
+
+        # Evaluate LOO for each alpha
+        alphas = self.alphas if self.alphas is not None else [0.1, 1.0, 10.0]
+        best_alpha = alphas[0]
+        best_score = -np.inf
+
+        Q_sq = Q ** 2
+
+        for alpha in alphas:
+            w = 1.0 / (eigenvalues + alpha)
+            w[intercept_dim] = 0  # no regularization on intercept
+
+            c = Q @ (w[:, None] * QT_y)
+            G_inv_diag = Q_sq @ w
+            G_inv_diag = np.maximum(G_inv_diag, 1e-12)
+
+            loo_errors = c / G_inv_diag[:, None]
+            score = -np.mean(loo_errors ** 2)  # negative MSE (higher is better)
+
+            if score > best_score:
+                best_score = score
+                best_alpha = alpha
+
+        self.alpha_ = best_alpha
+
+        # Compute K_inv for prediction (on original centered K, no intercept)
+        K_pred = X_c @ X_c.T
+        K_pred[np.diag_indices_from(K_pred)] += self.alpha_
+        self._K_inv = np.linalg.solve(K_pred, np.eye(n_samples))
+
+    def _fit_sklearn_then_dual(self, X, Y) -> None:
+        """Fallback: sklearn RidgeCV for alpha, DualRidge for prediction.
+
+        Used when custom scoring/cv/alpha_per_target prevents dual LOO.
+        """
+        kwargs = dict(self._ridgecv_kwargs)
+        if self.alphas is not None:
+            kwargs['alphas'] = self.alphas
+        rcv = RidgeCV(**kwargs)
         rcv.fit(X, Y)
         self.alpha_ = rcv.alpha_
         del rcv
 
-        self._dual = DualRidgeRegression(alpha=float(self.alpha_), chunk_size=self.chunk_size)
+        self._dual = DualRidgeRegression(
+            alpha=float(self.alpha_), chunk_size=self.chunk_size
+        )
         self._dual.fit(X, Y)
 
     def predict(self, X) -> np.ndarray:
         if not self._use_dual:
             return self._primal.predict(X)
-        return self._dual.predict(X)
+
+        if hasattr(self, '_dual'):
+            return self._dual.predict(X)
+
+        X = np.asarray(X, dtype=np.float64)
+        X_test_c = X - self._X_mean
+        proj = X_test_c @ self._X_train_centered.T @ self._K_inv
+
+        n_test = X.shape[0]
+        n_targets = self._Y_train_centered.shape[1]
+        predictions = np.empty((n_test, n_targets), dtype=np.float64)
+        for i in range(0, n_targets, self.chunk_size):
+            end = min(i + self.chunk_size, n_targets)
+            predictions[:, i:end] = (
+                proj @ self._Y_train_centered[:, i:end] + self._Y_mean[i:end]
+            )
+        return predictions
 
 
 def pls_regression(regression_kwargs=None, xarray_kwargs=None):

--- a/brainscore_vision/metrics/regression_correlation/metric.py
+++ b/brainscore_vision/metrics/regression_correlation/metric.py
@@ -143,8 +143,8 @@ class DualRidgeRegression:
         self.chunk_size = chunk_size
 
     def fit(self, X, Y) -> None:
-        X = np.asarray(X, dtype=np.float64)
-        Y = np.asarray(Y, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
+        Y = np.asarray(Y, dtype=np.float32)
         n_samples, n_features = X.shape
 
         if n_samples >= n_features:
@@ -160,21 +160,22 @@ class DualRidgeRegression:
         self._X_train_centered = X_c
         self._Y_train_centered = Y - self._Y_mean
 
-        K = X_c @ X_c.T
+        # Compute kernel and solve in float64 for numerical stability
+        K = np.float64(X_c @ X_c.T)
         K[np.diag_indices_from(K)] += self.alpha
-        self._K_inv = np.linalg.solve(K, np.eye(K.shape[0]))
+        self._K_inv = np.float32(np.linalg.solve(K, np.eye(K.shape[0])))
 
     def predict(self, X) -> np.ndarray:
         if not self._use_dual:
             return self._primal.predict(X)
 
-        X = np.asarray(X, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
         X_test_c = X - self._X_mean
         proj = X_test_c @ self._X_train_centered.T @ self._K_inv
 
         n_test = X.shape[0]
         n_targets = self._Y_train_centered.shape[1]
-        predictions = np.empty((n_test, n_targets), dtype=np.float64)
+        predictions = np.empty((n_test, n_targets), dtype=np.float32)
         for i in range(0, n_targets, self.chunk_size):
             end = min(i + self.chunk_size, n_targets)
             predictions[:, i:end] = proj @ self._Y_train_centered[:, i:end] + self._Y_mean[i:end]
@@ -219,8 +220,8 @@ class DualRidgeCVRegression:
         return True
 
     def fit(self, X, Y) -> None:
-        X = np.asarray(X, dtype=np.float64)
-        Y = np.asarray(Y, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
+        Y = np.asarray(Y, dtype=np.float32)
         n_samples, n_features = X.shape
 
         if n_samples >= n_features:
@@ -247,6 +248,9 @@ class DualRidgeCVRegression:
         center X, add intercept to kernel via outer product, eigendecompose,
         zero regularization on the intercept eigenvector, then evaluate LOO
         for each alpha candidate.
+
+        Data stored in float32 to halve memory. Kernel eigendecomposition and
+        LOO scoring done in float64 for numerical precision.
         """
         # Center X (sklearn centers X in preprocessing, not Y)
         self._X_mean = X.mean(axis=0)
@@ -255,19 +259,18 @@ class DualRidgeCVRegression:
         self._X_train_centered = X_c
         self._Y_train_centered = Y - self._Y_mean
 
-        # Kernel with intercept: K = X_c @ X_c.T + 1*1.T
-        # The outer product accounts for the unregularized intercept
-        K = X_c @ X_c.T
-        K += np.ones((n_samples, n_samples))
+        # Kernel with intercept in float64 for eigendecomposition precision
+        K = np.float64(X_c @ X_c.T)
+        K += 1.0  # equivalent to np.ones((n,n)) but avoids allocation
 
         eigenvalues, Q = np.linalg.eigh(K)
-        QT_y = Q.T @ Y  # project UN-centered Y
+        QT_y = Q.T @ np.float64(Y)  # project UN-centered Y in float64
 
         # Find the intercept eigenvector (most aligned with ones vector)
         normalized_sw = np.ones(n_samples) / np.sqrt(n_samples)
         intercept_dim = np.argmax(np.abs(Q.T @ normalized_sw))
 
-        # Evaluate LOO for each alpha
+        # Evaluate LOO for each alpha (all float64 — small matrices)
         alphas = self.alphas if self.alphas is not None else [0.1, 1.0, 10.0]
         best_alpha = alphas[0]
         best_score = -np.inf
@@ -292,9 +295,10 @@ class DualRidgeCVRegression:
         self.alpha_ = best_alpha
 
         # Compute K_inv for prediction (on original centered K, no intercept)
-        K_pred = X_c @ X_c.T
+        # Solve in float64, store as float32
+        K_pred = np.float64(X_c @ X_c.T)
         K_pred[np.diag_indices_from(K_pred)] += self.alpha_
-        self._K_inv = np.linalg.solve(K_pred, np.eye(n_samples))
+        self._K_inv = np.float32(np.linalg.solve(K_pred, np.eye(n_samples)))
 
     def _fit_sklearn_then_dual(self, X, Y) -> None:
         """Fallback: sklearn RidgeCV for alpha, DualRidge for prediction.
@@ -321,13 +325,13 @@ class DualRidgeCVRegression:
         if hasattr(self, '_dual'):
             return self._dual.predict(X)
 
-        X = np.asarray(X, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
         X_test_c = X - self._X_mean
         proj = X_test_c @ self._X_train_centered.T @ self._K_inv
 
         n_test = X.shape[0]
         n_targets = self._Y_train_centered.shape[1]
-        predictions = np.empty((n_test, n_targets), dtype=np.float64)
+        predictions = np.empty((n_test, n_targets), dtype=np.float32)
         for i in range(0, n_targets, self.chunk_size):
             end = min(i + self.chunk_size, n_targets)
             predictions[:, i:end] = (

--- a/brainscore_vision/metrics/regression_correlation/metric.py
+++ b/brainscore_vision/metrics/regression_correlation/metric.py
@@ -395,7 +395,7 @@ def linear_regression(xarray_kwargs=None):
 def ridge_regression(regression_kwargs=None, xarray_kwargs=None):
     regression_defaults = dict(alpha=1)
     regression_kwargs = {**regression_defaults, **(regression_kwargs or {})}
-    regression = DualRidgeRegression(**regression_kwargs)
+    regression = Ridge(**regression_kwargs)
     xarray_kwargs = xarray_kwargs or {}
     regression = XarrayRegression(regression, **xarray_kwargs)
     return regression
@@ -413,7 +413,27 @@ def ridge_cv_regression(regression_kwargs=None, xarray_kwargs=None, alphas=ALPHA
     regression_defaults = dict(alphas=alphas, store_cv_results=False)
     regression_kwargs = {**regression_defaults, **(regression_kwargs or {})}
     regression_kwargs.pop('alpha', None)  # RidgeCV does not accept 'alpha' as a parameter
-    
+
+    regression = RidgeCV(**regression_kwargs)
+    xarray_kwargs = xarray_kwargs or {}
+    regression = XarrayRegression(regression, **xarray_kwargs)
+    return regression
+
+
+def dual_ridge_regression(regression_kwargs=None, xarray_kwargs=None):
+    regression_defaults = dict(alpha=1)
+    regression_kwargs = {**regression_defaults, **(regression_kwargs or {})}
+    regression = DualRidgeRegression(**regression_kwargs)
+    xarray_kwargs = xarray_kwargs or {}
+    regression = XarrayRegression(regression, **xarray_kwargs)
+    return regression
+
+
+def dual_ridge_cv_regression(regression_kwargs=None, xarray_kwargs=None, alphas=ALPHA_LIST):
+    regression_defaults = dict(alphas=alphas)
+    regression_kwargs = {**regression_defaults, **(regression_kwargs or {})}
+    regression_kwargs.pop('alpha', None)
+
     regression = DualRidgeCVRegression(**regression_kwargs)
     xarray_kwargs = xarray_kwargs or {}
     regression = XarrayRegression(regression, **xarray_kwargs)

--- a/brainscore_vision/metrics/regression_correlation/metric.py
+++ b/brainscore_vision/metrics/regression_correlation/metric.py
@@ -182,11 +182,18 @@ class DualRidgeRegression:
 
 
 class DualRidgeCVRegression:
-    """RidgeCV with dual form prediction for memory efficiency.
+    """RidgeCV with dual form for memory efficiency.
 
-    Uses sklearn RidgeCV for alpha selection (LOO/GCV), then the dual kernel
-    form for prediction to avoid storing the (n_features, n_targets) coef_ matrix.
-    Falls back to sklearn RidgeCV when n_samples >= n_features.
+    When n_samples < n_features and no custom scoring/cv is requested,
+    selects alpha via LOO cross-validation in kernel space using the
+    eigendecomposition of K = X @ X.T, then predicts via dual-form
+    projection. Never materializes the (n_features, n_targets) coef_ matrix.
+
+    When custom scoring or cv is requested, falls back to sklearn RidgeCV
+    for alpha selection (preserving all sklearn behavior), then uses
+    DualRidgeRegression for prediction.
+
+    Falls back to sklearn RidgeCV entirely when n_samples >= n_features.
 
     Exposes ``alpha_`` after fit (selected regularization strength).
     """
@@ -197,6 +204,20 @@ class DualRidgeCVRegression:
         self._ridgecv_kwargs = ridgecv_kwargs
         self.alpha_ = None
 
+    def _can_use_dual_loo(self) -> bool:
+        """Check if we can do alpha selection in kernel space.
+
+        Dual LOO is only valid when sklearn would use its efficient LOO path:
+        no custom scoring function, no explicit cv folds, no per-target alpha.
+        """
+        if self._ridgecv_kwargs.get('scoring') is not None:
+            return False
+        if self._ridgecv_kwargs.get('cv') is not None:
+            return False
+        if self._ridgecv_kwargs.get('alpha_per_target', False):
+            return False
+        return True
+
     def fit(self, X, Y) -> None:
         X = np.asarray(X, dtype=np.float64)
         Y = np.asarray(Y, dtype=np.float64)
@@ -204,24 +225,115 @@ class DualRidgeCVRegression:
 
         if n_samples >= n_features:
             self._use_dual = False
-            self._primal = RidgeCV(alphas=self.alphas, **self._ridgecv_kwargs)
+            kwargs = dict(self._ridgecv_kwargs)
+            if self.alphas is not None:
+                kwargs['alphas'] = self.alphas
+            self._primal = RidgeCV(**kwargs)
             self._primal.fit(X, Y)
             self.alpha_ = self._primal.alpha_
             return
 
         self._use_dual = True
-        rcv = RidgeCV(alphas=self.alphas, **self._ridgecv_kwargs)
+
+        if self._can_use_dual_loo():
+            self._fit_dual_loo(X, Y, n_samples)
+        else:
+            self._fit_sklearn_then_dual(X, Y)
+
+    def _fit_dual_loo(self, X, Y, n_samples) -> None:
+        """Select alpha via LOO in kernel space. No coef_ materialized.
+
+        Replicates sklearn's _RidgeGCV eigen decomposition approach:
+        center X, add intercept to kernel via outer product, eigendecompose,
+        zero regularization on the intercept eigenvector, then evaluate LOO
+        for each alpha candidate.
+        """
+        # Center X (sklearn centers X in preprocessing, not Y)
+        self._X_mean = X.mean(axis=0)
+        self._Y_mean = Y.mean(axis=0)
+        X_c = X - self._X_mean
+        self._X_train_centered = X_c
+        self._Y_train_centered = Y - self._Y_mean
+
+        # Kernel with intercept: K = X_c @ X_c.T + 1*1.T
+        # The outer product accounts for the unregularized intercept
+        K = X_c @ X_c.T
+        K += np.ones((n_samples, n_samples))
+
+        eigenvalues, Q = np.linalg.eigh(K)
+        QT_y = Q.T @ Y  # project UN-centered Y
+
+        # Find the intercept eigenvector (most aligned with ones vector)
+        normalized_sw = np.ones(n_samples) / np.sqrt(n_samples)
+        intercept_dim = np.argmax(np.abs(Q.T @ normalized_sw))
+
+        # Evaluate LOO for each alpha
+        alphas = self.alphas if self.alphas is not None else [0.1, 1.0, 10.0]
+        best_alpha = alphas[0]
+        best_score = -np.inf
+
+        Q_sq = Q ** 2
+
+        for alpha in alphas:
+            w = 1.0 / (eigenvalues + alpha)
+            w[intercept_dim] = 0  # no regularization on intercept
+
+            c = Q @ (w[:, None] * QT_y)
+            G_inv_diag = Q_sq @ w
+            G_inv_diag = np.maximum(G_inv_diag, 1e-12)
+
+            loo_errors = c / G_inv_diag[:, None]
+            score = -np.mean(loo_errors ** 2)  # negative MSE (higher is better)
+
+            if score > best_score:
+                best_score = score
+                best_alpha = alpha
+
+        self.alpha_ = best_alpha
+
+        # Compute K_inv for prediction (on original centered K, no intercept)
+        K_pred = X_c @ X_c.T
+        K_pred[np.diag_indices_from(K_pred)] += self.alpha_
+        self._K_inv = np.linalg.solve(K_pred, np.eye(n_samples))
+
+    def _fit_sklearn_then_dual(self, X, Y) -> None:
+        """Fallback: sklearn RidgeCV for alpha, DualRidge for prediction.
+
+        Used when custom scoring/cv/alpha_per_target prevents dual LOO.
+        """
+        kwargs = dict(self._ridgecv_kwargs)
+        if self.alphas is not None:
+            kwargs['alphas'] = self.alphas
+        rcv = RidgeCV(**kwargs)
         rcv.fit(X, Y)
         self.alpha_ = rcv.alpha_
         del rcv
 
-        self._dual = DualRidgeRegression(alpha=float(self.alpha_), chunk_size=self.chunk_size)
+        self._dual = DualRidgeRegression(
+            alpha=float(self.alpha_), chunk_size=self.chunk_size
+        )
         self._dual.fit(X, Y)
 
     def predict(self, X) -> np.ndarray:
         if not self._use_dual:
             return self._primal.predict(X)
-        return self._dual.predict(X)
+
+        if hasattr(self, '_dual'):
+            return self._dual.predict(X)
+
+        X = np.asarray(X, dtype=np.float64)
+        X_test_c = X - self._X_mean
+        proj = X_test_c @ self._X_train_centered.T @ self._K_inv
+
+        n_test = X.shape[0]
+        n_targets = self._Y_train_centered.shape[1]
+        predictions = np.empty((n_test, n_targets), dtype=np.float64)
+        for i in range(0, n_targets, self.chunk_size):
+            end = min(i + self.chunk_size, n_targets)
+            predictions[:, i:end] = (
+                proj @ self._Y_train_centered[:, i:end] + self._Y_mean[i:end]
+            )
+        return predictions
 
 
 class KernelPLSRegression:

--- a/brainscore_vision/metrics/regression_correlation/metric.py
+++ b/brainscore_vision/metrics/regression_correlation/metric.py
@@ -131,10 +131,14 @@ class ReverseTrainTestSplitCorrelation(TrainTestSplitCorrelation):
 class DualRidgeRegression:
     """Ridge regression using dual (kernel) form for memory efficiency.
 
-    When n_samples < n_features, avoids materializing the (n_features, n_targets)
-    coefficient matrix. Computes predictions via a (n_test, n_train) projection
-    matrix instead. Falls back to sklearn Ridge when n_samples >= n_features.
+    When n_samples < n_features, uses adaptive storage to minimize memory
+    after fit:
+    - If n_targets < n_samples: computes coef_ and frees X_train (primal-style
+      predict, but without sklearn's float64 copy)
+    - If n_targets >= n_samples: keeps X_train and predicts via kernel projection
+      (avoids materializing the large coef_ matrix)
 
+    Falls back to sklearn Ridge when n_samples >= n_features.
     Mathematically identical to sklearn Ridge with fit_intercept=True.
     """
 
@@ -146,6 +150,7 @@ class DualRidgeRegression:
         X = np.asarray(X, dtype=np.float32)
         Y = np.asarray(Y, dtype=np.float32)
         n_samples, n_features = X.shape
+        n_targets = Y.shape[1]
 
         if n_samples >= n_features:
             self._use_dual = False
@@ -157,13 +162,24 @@ class DualRidgeRegression:
         self._X_mean = X.mean(axis=0)
         self._Y_mean = Y.mean(axis=0)
         X_c = X - self._X_mean
-        self._X_train_centered = X_c
-        self._Y_train_centered = Y - self._Y_mean
+        Y_c = Y - self._Y_mean
 
         # Compute kernel and solve in float64 for numerical stability
         K = np.float64(X_c @ X_c.T)
         K[np.diag_indices_from(K)] += self.alpha
-        self._K_inv = np.float32(np.linalg.solve(K, np.eye(K.shape[0])))
+        K_inv = np.float32(np.linalg.solve(K, np.eye(n_samples)))
+
+        if n_targets < n_samples:
+            # coef_ is smaller than X_train — compute it, free X
+            dual_coef = K_inv @ Y_c
+            self._coef = X_c.T @ dual_coef
+            self._use_coef = True
+        else:
+            # X_train is smaller than coef_ — keep it for projection
+            self._X_train_centered = X_c
+            self._Y_train_centered = Y_c
+            self._K_inv = K_inv
+            self._use_coef = False
 
     def predict(self, X) -> np.ndarray:
         if not self._use_dual:
@@ -171,6 +187,10 @@ class DualRidgeRegression:
 
         X = np.asarray(X, dtype=np.float32)
         X_test_c = X - self._X_mean
+
+        if self._use_coef:
+            return X_test_c @ self._coef + self._Y_mean
+
         proj = X_test_c @ self._X_train_centered.T @ self._K_inv
 
         n_test = X.shape[0]
@@ -252,12 +272,11 @@ class DualRidgeCVRegression:
         Data stored in float32 to halve memory. Kernel eigendecomposition and
         LOO scoring done in float64 for numerical precision.
         """
-        # Center X (sklearn centers X in preprocessing, not Y)
+        # Center
         self._X_mean = X.mean(axis=0)
         self._Y_mean = Y.mean(axis=0)
         X_c = X - self._X_mean
-        self._X_train_centered = X_c
-        self._Y_train_centered = Y - self._Y_mean
+        Y_c = Y - self._Y_mean
 
         # Kernel with intercept in float64 for eigendecomposition precision
         K = np.float64(X_c @ X_c.T)
@@ -294,11 +313,24 @@ class DualRidgeCVRegression:
 
         self.alpha_ = best_alpha
 
-        # Compute K_inv for prediction (on original centered K, no intercept)
-        # Solve in float64, store as float32
+        # Compute K_inv in float64, store as float32
         K_pred = np.float64(X_c @ X_c.T)
         K_pred[np.diag_indices_from(K_pred)] += self.alpha_
-        self._K_inv = np.float32(np.linalg.solve(K_pred, np.eye(n_samples)))
+        K_inv = np.float32(np.linalg.solve(K_pred, np.eye(n_samples)))
+
+        # Adaptive storage: keep whichever is smaller after fit
+        n_targets = Y_c.shape[1]
+        if n_targets < n_samples:
+            # coef_ is smaller than X_train — compute it, free X
+            dual_coef = K_inv @ Y_c
+            self._coef = X_c.T @ dual_coef
+            self._use_coef = True
+        else:
+            # X_train is smaller than coef_ — keep it for projection
+            self._X_train_centered = X_c
+            self._Y_train_centered = Y_c
+            self._K_inv = K_inv
+            self._use_coef = False
 
     def _fit_sklearn_then_dual(self, X, Y) -> None:
         """Fallback: sklearn RidgeCV for alpha, DualRidge for prediction.
@@ -327,6 +359,10 @@ class DualRidgeCVRegression:
 
         X = np.asarray(X, dtype=np.float32)
         X_test_c = X - self._X_mean
+
+        if self._use_coef:
+            return X_test_c @ self._coef + self._Y_mean
+
         proj = X_test_c @ self._X_train_centered.T @ self._K_inv
 
         n_test = X.shape[0]

--- a/brainscore_vision/metrics/regression_correlation/metric.py
+++ b/brainscore_vision/metrics/regression_correlation/metric.py
@@ -224,10 +224,75 @@ class DualRidgeCVRegression:
         return self._dual.predict(X)
 
 
+class KernelPLSRegression:
+    """PLS regression via eigendecomposition of the linear kernel.
+
+    When n_samples < n_features, projects X into an equivalent
+    (n_samples, n_samples) representation via the eigendecomposition of
+    K = X_c @ X_c.T, then runs standard sklearn PLS on the reduced X.
+    Mathematically identical to sklearn PLSRegression (scale=False).
+
+    Falls back to sklearn PLSRegression when n_samples >= n_features
+    or scale=True.
+    """
+
+    def __init__(self, n_components: int = 25, scale: bool = False,
+                 max_iter: int = 500, tol: float = 1e-6):
+        self.n_components = n_components
+        self.scale = scale
+        self.max_iter = max_iter
+        self.tol = tol
+
+    def fit(self, X, Y) -> None:
+        X = np.asarray(X, dtype=np.float64)
+        Y = np.asarray(Y, dtype=np.float64)
+        n_samples, n_features = X.shape
+
+        if n_samples >= n_features or self.scale:
+            self._use_kernel = False
+            self._pls = PLSRegression(n_components=self.n_components, scale=self.scale,
+                                      max_iter=self.max_iter, tol=self.tol)
+            self._pls.fit(X, Y)
+            return
+
+        self._use_kernel = True
+        self._X_mean = X.mean(axis=0)
+        X_c = X - self._X_mean
+        self._X_train_centered = X_c
+
+        K = X_c @ X_c.T
+        eigenvalues, eigenvectors = np.linalg.eigh(K)
+
+        mask = eigenvalues > 1e-10 * eigenvalues.max()
+        eigenvalues = eigenvalues[mask]
+        eigenvectors = eigenvectors[:, mask]
+
+        self._sqrt_eig = np.sqrt(eigenvalues)
+        self._eigenvectors = eigenvectors
+        self._inv_sqrt_eig = 1.0 / self._sqrt_eig
+
+        X_reduced = eigenvectors * self._sqrt_eig
+
+        n_components = min(self.n_components, X_reduced.shape[1], Y.shape[1])
+        self._pls = PLSRegression(n_components=n_components, scale=False,
+                                  max_iter=self.max_iter, tol=self.tol)
+        self._pls.fit(X_reduced, Y)
+
+    def predict(self, X) -> np.ndarray:
+        if not self._use_kernel:
+            return self._pls.predict(X)
+
+        X = np.asarray(X, dtype=np.float64)
+        X_test_c = X - self._X_mean
+        K_test = X_test_c @ self._X_train_centered.T
+        X_test_reduced = K_test @ (self._eigenvectors * self._inv_sqrt_eig)
+        return self._pls.predict(X_test_reduced)
+
+
 def pls_regression(regression_kwargs=None, xarray_kwargs=None):
     regression_defaults = dict(n_components=25, scale=False)
     regression_kwargs = {**regression_defaults, **(regression_kwargs or {})}
-    regression = PLSRegression(**regression_kwargs)
+    regression = KernelPLSRegression(**regression_kwargs)
     xarray_kwargs = xarray_kwargs or {}
     regression = XarrayRegression(regression, **xarray_kwargs)
     return regression

--- a/brainscore_vision/metrics/regression_correlation/metric.py
+++ b/brainscore_vision/metrics/regression_correlation/metric.py
@@ -143,8 +143,8 @@ class DualRidgeRegression:
         self.chunk_size = chunk_size
 
     def fit(self, X, Y) -> None:
-        X = np.asarray(X, dtype=np.float64)
-        Y = np.asarray(Y, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
+        Y = np.asarray(Y, dtype=np.float32)
         n_samples, n_features = X.shape
 
         if n_samples >= n_features:
@@ -160,21 +160,22 @@ class DualRidgeRegression:
         self._X_train_centered = X_c
         self._Y_train_centered = Y - self._Y_mean
 
-        K = X_c @ X_c.T
+        # Compute kernel and solve in float64 for numerical stability
+        K = np.float64(X_c @ X_c.T)
         K[np.diag_indices_from(K)] += self.alpha
-        self._K_inv = np.linalg.solve(K, np.eye(K.shape[0]))
+        self._K_inv = np.float32(np.linalg.solve(K, np.eye(K.shape[0])))
 
     def predict(self, X) -> np.ndarray:
         if not self._use_dual:
             return self._primal.predict(X)
 
-        X = np.asarray(X, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
         X_test_c = X - self._X_mean
         proj = X_test_c @ self._X_train_centered.T @ self._K_inv
 
         n_test = X.shape[0]
         n_targets = self._Y_train_centered.shape[1]
-        predictions = np.empty((n_test, n_targets), dtype=np.float64)
+        predictions = np.empty((n_test, n_targets), dtype=np.float32)
         for i in range(0, n_targets, self.chunk_size):
             end = min(i + self.chunk_size, n_targets)
             predictions[:, i:end] = proj @ self._Y_train_centered[:, i:end] + self._Y_mean[i:end]
@@ -219,8 +220,8 @@ class DualRidgeCVRegression:
         return True
 
     def fit(self, X, Y) -> None:
-        X = np.asarray(X, dtype=np.float64)
-        Y = np.asarray(Y, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
+        Y = np.asarray(Y, dtype=np.float32)
         n_samples, n_features = X.shape
 
         if n_samples >= n_features:
@@ -247,6 +248,9 @@ class DualRidgeCVRegression:
         center X, add intercept to kernel via outer product, eigendecompose,
         zero regularization on the intercept eigenvector, then evaluate LOO
         for each alpha candidate.
+
+        Data stored in float32 to halve memory. Kernel eigendecomposition and
+        LOO scoring done in float64 for numerical precision.
         """
         # Center X (sklearn centers X in preprocessing, not Y)
         self._X_mean = X.mean(axis=0)
@@ -255,19 +259,18 @@ class DualRidgeCVRegression:
         self._X_train_centered = X_c
         self._Y_train_centered = Y - self._Y_mean
 
-        # Kernel with intercept: K = X_c @ X_c.T + 1*1.T
-        # The outer product accounts for the unregularized intercept
-        K = X_c @ X_c.T
-        K += np.ones((n_samples, n_samples))
+        # Kernel with intercept in float64 for eigendecomposition precision
+        K = np.float64(X_c @ X_c.T)
+        K += 1.0  # equivalent to np.ones((n,n)) but avoids allocation
 
         eigenvalues, Q = np.linalg.eigh(K)
-        QT_y = Q.T @ Y  # project UN-centered Y
+        QT_y = Q.T @ np.float64(Y)  # project UN-centered Y in float64
 
         # Find the intercept eigenvector (most aligned with ones vector)
         normalized_sw = np.ones(n_samples) / np.sqrt(n_samples)
         intercept_dim = np.argmax(np.abs(Q.T @ normalized_sw))
 
-        # Evaluate LOO for each alpha
+        # Evaluate LOO for each alpha (all float64 — small matrices)
         alphas = self.alphas if self.alphas is not None else [0.1, 1.0, 10.0]
         best_alpha = alphas[0]
         best_score = -np.inf
@@ -292,9 +295,10 @@ class DualRidgeCVRegression:
         self.alpha_ = best_alpha
 
         # Compute K_inv for prediction (on original centered K, no intercept)
-        K_pred = X_c @ X_c.T
+        # Solve in float64, store as float32
+        K_pred = np.float64(X_c @ X_c.T)
         K_pred[np.diag_indices_from(K_pred)] += self.alpha_
-        self._K_inv = np.linalg.solve(K_pred, np.eye(n_samples))
+        self._K_inv = np.float32(np.linalg.solve(K_pred, np.eye(n_samples)))
 
     def _fit_sklearn_then_dual(self, X, Y) -> None:
         """Fallback: sklearn RidgeCV for alpha, DualRidge for prediction.
@@ -321,13 +325,13 @@ class DualRidgeCVRegression:
         if hasattr(self, '_dual'):
             return self._dual.predict(X)
 
-        X = np.asarray(X, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
         X_test_c = X - self._X_mean
         proj = X_test_c @ self._X_train_centered.T @ self._K_inv
 
         n_test = X.shape[0]
         n_targets = self._Y_train_centered.shape[1]
-        predictions = np.empty((n_test, n_targets), dtype=np.float64)
+        predictions = np.empty((n_test, n_targets), dtype=np.float32)
         for i in range(0, n_targets, self.chunk_size):
             end = min(i + self.chunk_size, n_targets)
             predictions[:, i:end] = (
@@ -356,8 +360,8 @@ class KernelPLSRegression:
         self.tol = tol
 
     def fit(self, X, Y) -> None:
-        X = np.asarray(X, dtype=np.float64)
-        Y = np.asarray(Y, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
+        Y = np.asarray(Y, dtype=np.float32)
         n_samples, n_features = X.shape
 
         if n_samples >= n_features or self.scale:
@@ -372,18 +376,19 @@ class KernelPLSRegression:
         X_c = X - self._X_mean
         self._X_train_centered = X_c
 
-        K = X_c @ X_c.T
+        # Eigendecomposition in float64 for precision, results stored as float32
+        K = np.float64(X_c @ X_c.T)
         eigenvalues, eigenvectors = np.linalg.eigh(K)
 
         mask = eigenvalues > 1e-10 * eigenvalues.max()
         eigenvalues = eigenvalues[mask]
         eigenvectors = eigenvectors[:, mask]
 
-        self._sqrt_eig = np.sqrt(eigenvalues)
-        self._eigenvectors = eigenvectors
+        self._sqrt_eig = np.float32(np.sqrt(eigenvalues))
+        self._eigenvectors = np.float32(eigenvectors)
         self._inv_sqrt_eig = 1.0 / self._sqrt_eig
 
-        X_reduced = eigenvectors * self._sqrt_eig
+        X_reduced = self._eigenvectors * self._sqrt_eig
 
         n_components = min(self.n_components, X_reduced.shape[1], Y.shape[1])
         self._pls = PLSRegression(n_components=n_components, scale=False,
@@ -394,7 +399,7 @@ class KernelPLSRegression:
         if not self._use_kernel:
             return self._pls.predict(X)
 
-        X = np.asarray(X, dtype=np.float64)
+        X = np.asarray(X, dtype=np.float32)
         X_test_c = X - self._X_mean
         K_test = X_test_c @ self._X_train_centered.T
         X_test_reduced = K_test @ (self._eigenvectors * self._inv_sqrt_eig)

--- a/brainscore_vision/metrics/regression_correlation/metric.py
+++ b/brainscore_vision/metrics/regression_correlation/metric.py
@@ -107,7 +107,7 @@ class TrainTestSplitCorrelation(Metric):
         prediction = self.regression.predict(source_test)
         score = self.correlation(prediction, target_test)
         
-        if self.regression._regression.__class__ in [RidgeCV]:
+        if hasattr(self.regression._regression, 'alpha_'):
             score.attrs['alpha'] = self.regression._regression.alpha_
             
         return score
@@ -128,6 +128,102 @@ class ReverseTrainTestSplitCorrelation(TrainTestSplitCorrelation):
             target_test=source_test,
         )
 
+class DualRidgeRegression:
+    """Ridge regression using dual (kernel) form for memory efficiency.
+
+    When n_samples < n_features, avoids materializing the (n_features, n_targets)
+    coefficient matrix. Computes predictions via a (n_test, n_train) projection
+    matrix instead. Falls back to sklearn Ridge when n_samples >= n_features.
+
+    Mathematically identical to sklearn Ridge with fit_intercept=True.
+    """
+
+    def __init__(self, alpha: float = 1.0, chunk_size: int = 5000):
+        self.alpha = alpha
+        self.chunk_size = chunk_size
+
+    def fit(self, X, Y) -> None:
+        X = np.asarray(X, dtype=np.float64)
+        Y = np.asarray(Y, dtype=np.float64)
+        n_samples, n_features = X.shape
+
+        if n_samples >= n_features:
+            self._use_dual = False
+            self._primal = Ridge(alpha=self.alpha)
+            self._primal.fit(X, Y)
+            return
+
+        self._use_dual = True
+        self._X_mean = X.mean(axis=0)
+        self._Y_mean = Y.mean(axis=0)
+        X_c = X - self._X_mean
+        self._X_train_centered = X_c
+        self._Y_train_centered = Y - self._Y_mean
+
+        K = X_c @ X_c.T
+        K[np.diag_indices_from(K)] += self.alpha
+        self._K_inv = np.linalg.solve(K, np.eye(K.shape[0]))
+
+    def predict(self, X) -> np.ndarray:
+        if not self._use_dual:
+            return self._primal.predict(X)
+
+        X = np.asarray(X, dtype=np.float64)
+        X_test_c = X - self._X_mean
+        proj = X_test_c @ self._X_train_centered.T @ self._K_inv
+
+        n_test = X.shape[0]
+        n_targets = self._Y_train_centered.shape[1]
+        predictions = np.empty((n_test, n_targets), dtype=np.float64)
+        for i in range(0, n_targets, self.chunk_size):
+            end = min(i + self.chunk_size, n_targets)
+            predictions[:, i:end] = proj @ self._Y_train_centered[:, i:end] + self._Y_mean[i:end]
+        return predictions
+
+
+class DualRidgeCVRegression:
+    """RidgeCV with dual form prediction for memory efficiency.
+
+    Uses sklearn RidgeCV for alpha selection (LOO/GCV), then the dual kernel
+    form for prediction to avoid storing the (n_features, n_targets) coef_ matrix.
+    Falls back to sklearn RidgeCV when n_samples >= n_features.
+
+    Exposes ``alpha_`` after fit (selected regularization strength).
+    """
+
+    def __init__(self, alphas=None, chunk_size: int = 5000, **ridgecv_kwargs):
+        self.alphas = alphas
+        self.chunk_size = chunk_size
+        self._ridgecv_kwargs = ridgecv_kwargs
+        self.alpha_ = None
+
+    def fit(self, X, Y) -> None:
+        X = np.asarray(X, dtype=np.float64)
+        Y = np.asarray(Y, dtype=np.float64)
+        n_samples, n_features = X.shape
+
+        if n_samples >= n_features:
+            self._use_dual = False
+            self._primal = RidgeCV(alphas=self.alphas, **self._ridgecv_kwargs)
+            self._primal.fit(X, Y)
+            self.alpha_ = self._primal.alpha_
+            return
+
+        self._use_dual = True
+        rcv = RidgeCV(alphas=self.alphas, **self._ridgecv_kwargs)
+        rcv.fit(X, Y)
+        self.alpha_ = rcv.alpha_
+        del rcv
+
+        self._dual = DualRidgeRegression(alpha=float(self.alpha_), chunk_size=self.chunk_size)
+        self._dual.fit(X, Y)
+
+    def predict(self, X) -> np.ndarray:
+        if not self._use_dual:
+            return self._primal.predict(X)
+        return self._dual.predict(X)
+
+
 def pls_regression(regression_kwargs=None, xarray_kwargs=None):
     regression_defaults = dict(n_components=25, scale=False)
     regression_kwargs = {**regression_defaults, **(regression_kwargs or {})}
@@ -147,7 +243,7 @@ def linear_regression(xarray_kwargs=None):
 def ridge_regression(regression_kwargs=None, xarray_kwargs=None):
     regression_defaults = dict(alpha=1)
     regression_kwargs = {**regression_defaults, **(regression_kwargs or {})}
-    regression = Ridge(**regression_kwargs)
+    regression = DualRidgeRegression(**regression_kwargs)
     xarray_kwargs = xarray_kwargs or {}
     regression = XarrayRegression(regression, **xarray_kwargs)
     return regression
@@ -166,7 +262,7 @@ def ridge_cv_regression(regression_kwargs=None, xarray_kwargs=None, alphas=ALPHA
     regression_kwargs = {**regression_defaults, **(regression_kwargs or {})}
     regression_kwargs.pop('alpha', None)  # RidgeCV does not accept 'alpha' as a parameter
     
-    regression = RidgeCV(**regression_kwargs)
+    regression = DualRidgeCVRegression(**regression_kwargs)
     xarray_kwargs = xarray_kwargs or {}
     regression = XarrayRegression(regression, **xarray_kwargs)
     return regression


### PR DESCRIPTION
Ridge and RidgeCV regression now use the dual kernel form when `n_samples < n_features`. This is common in Brain-Score which there are only hundreds of stimuli but thousands to hundreds of thousands of model features. This avoids materializing the coefficient matrix (`n_features`, `n_targets`) which can produce OOM for large models on fMRI benchmarks.

This PR adds `DualRidgeRegression` and `DualRidgeCVRegression` in the `metrics/regression_correlation/metric.py`.

Instead of solving for the full weight matrix, we precompute a small project matrix and apply it to the neural target in chunks.

This PR effectively reduces a coefficient matrix for ViT-L at 148k features on Allen2022 at 52k neuroids stored at 8 bytes from 62GB down to ~1MB.


### Validation
- All 4 Allen2022 surface ridge benchmarks produce identical raw scores
- Identical predictions across alpha values
- RidgeCV selects the sample alpha as sklearn
