### PR TITLE
laion_fmri: rename benchmark identifiers to Zerbe2026_fmri

### DIFF
--- a/brainscore_vision/benchmarks/laion_fmri/METHODS.md
+++ b/brainscore_vision/benchmarks/laion_fmri/METHODS.md
@@ -84,15 +84,15 @@ Persubject ridgecv variants use ~4× the memory of shared-pool variants — each
 
 20 headline cells:
 
-- `LAION_fMRI_persubject.{V1,V2,V4,IT}-{tau,ood}-ridgecv` (8) — most discriminative
-- `LAION_fMRI.{V1,V2,V4,IT}-{tau,ood}-ridgecv` (8) — cross-subject comparable to Allen2022 / Hebart2023
-- `LAION_fMRI.{V1,V2,V4,IT}-rdm-pearson` (4) — RSA on shared pool
+- `Zerbe2026_fmri_persubject.{V1,V2,V4,IT}-{tau,ood}-ridgecv` (8) — most discriminative
+- `Zerbe2026_fmri.{V1,V2,V4,IT}-{tau,ood}-ridgecv` (8) — cross-subject comparable to Allen2022 / Hebart2023
+- `Zerbe2026_fmri.{V1,V2,V4,IT}-rdm-pearson` (4) — RSA on shared pool
 
 Non-headline (factory-only): fixed-alpha ridge (`metric_type='ridge'`), `cluster_k5` CV, per-OOD-category sub-splits, `IT_full` ablation.
 
 ## Data distribution
 
-- **Neural assemblies** (`LAION_fMRI_full_sub-XX`): CC0 1.0, served from Brain-Score S3.
+- **Neural assemblies** (`Zerbe2026_fmri_full_sub-XX`): CC0 1.0, served from Brain-Score S3.
 - **Stimulus images**: gated by the LAION-fMRI DUA (prohibits redistribution, commercial use, training general-purpose AI). Brain-Score does not mirror them; users obtain them via `laion-fmri request-access` + `laion-fmri download-stimuli`. The local stimulus loader extracts JPEGs and bundles them into Brain-Score format.
 
 All tests gated with `@pytest.mark.private_access`.

--- a/brainscore_vision/benchmarks/laion_fmri/README.md
+++ b/brainscore_vision/benchmarks/laion_fmri/README.md
@@ -8,7 +8,7 @@ For dataset, ROIs, splits, ceilings, and scoring see [METHODS.md](METHODS.md). F
 
 ```python
 from brainscore_vision import _run_score
-score = _run_score("alexnet", "LAION_fMRI_persubject.IT-tau-ridgecv")
+score = _run_score("alexnet", "Zerbe2026_fmri_persubject.IT-tau-ridgecv")
 print(float(score.values))   # ceiled per-voxel correlation, averaged across 5 subjects
 ```
 
@@ -39,9 +39,9 @@ Identifier pattern: `{family}.{region}-{split}-{metric}`.
 
 | Family | Regions | Splits | Metric | Count |
 |---|---|---|---|---|
-| `LAION_fMRI` (shared 1,492-stim pool) | V1, V2, V4, IT | tau, ood | ridgecv | 8 |
-| `LAION_fMRI_persubject` (5,833 stim/subj) | V1, V2, V4, IT | tau, ood | ridgecv | 8 |
-| `LAION_fMRI` (shared) | V1, V2, V4, IT | — | rdm-pearson | 4 |
+| `Zerbe2026_fmri` (shared 1,492-stim pool) | V1, V2, V4, IT | tau, ood | ridgecv | 8 |
+| `Zerbe2026_fmri_persubject` (5,833 stim/subj) | V1, V2, V4, IT | tau, ood | ridgecv | 8 |
+| `Zerbe2026_fmri` (shared) | V1, V2, V4, IT | — | rdm-pearson | 4 |
 
 `ridgecv` is kernel/dual ridge with per-fit CV alpha selection over a 21-value log-spaced sweep (1e-10 to 1e10). The dual form keeps the `(n_features, n_targets)` coefficient matrix from being materialized — important for wide-feature models on the persubject pool.
 

--- a/brainscore_vision/benchmarks/laion_fmri/__init__.py
+++ b/brainscore_vision/benchmarks/laion_fmri/__init__.py
@@ -6,13 +6,13 @@ Headline ridge encoding variants — predict per-voxel responses from model feat
 using kernel/dual ridge with per-fit CV alpha selection over a 21-value log-spaced
 sweep (1e-10 to 1e10).
   - Per-subject pool (5,833 stim/subject, drives the leaderboard rank):
-      LAION_fMRI_persubject.{V1,V2,V4,IT}-{tau,ood}-ridgecv  (8 variants)
+      Zerbe2026_fmri_persubject.{V1,V2,V4,IT}-{tau,ood}-ridgecv  (8 variants)
   - Shared pool (1,492 stim, cross-subject comparison):
-      LAION_fMRI.{V1,V2,V4,IT}-{tau,ood}-ridgecv             (8 variants)
+      Zerbe2026_fmri.{V1,V2,V4,IT}-{tau,ood}-ridgecv             (8 variants)
 
 Headline RSA variants — representational alignment via RDM Spearman:
   - Shared pool only (Nili ceiling requires shared stim across subjects):
-      LAION_fMRI.{V1,V2,V4,IT}-rdm-pearson                   (4 variants)
+      Zerbe2026_fmri.{V1,V2,V4,IT}-rdm-pearson                   (4 variants)
 
 Total registered: 20.
 
@@ -39,30 +39,30 @@ from .benchmark import LAIONfMRI, LAIONfMRIRSA
 # Each subject's 5,833-image pool (1,121 shared + 4,712 subject-unique).
 # Exposes generalization to subject-specific stimulus distributions —
 # where weak models collapse and only strong models hold their score.
-benchmark_registry['LAION_fMRI_persubject.V1-tau-ridgecv'] = lambda: LAIONfMRI('V1', 'tau', dataset_prefix='LAION_fMRI_persubject')
-benchmark_registry['LAION_fMRI_persubject.V1-ood-ridgecv'] = lambda: LAIONfMRI('V1', 'ood', dataset_prefix='LAION_fMRI_persubject')
-benchmark_registry['LAION_fMRI_persubject.V2-tau-ridgecv'] = lambda: LAIONfMRI('V2', 'tau', dataset_prefix='LAION_fMRI_persubject')
-benchmark_registry['LAION_fMRI_persubject.V2-ood-ridgecv'] = lambda: LAIONfMRI('V2', 'ood', dataset_prefix='LAION_fMRI_persubject')
-benchmark_registry['LAION_fMRI_persubject.V4-tau-ridgecv'] = lambda: LAIONfMRI('V4', 'tau', dataset_prefix='LAION_fMRI_persubject')
-benchmark_registry['LAION_fMRI_persubject.V4-ood-ridgecv'] = lambda: LAIONfMRI('V4', 'ood', dataset_prefix='LAION_fMRI_persubject')
-benchmark_registry['LAION_fMRI_persubject.IT-tau-ridgecv'] = lambda: LAIONfMRI('IT', 'tau', dataset_prefix='LAION_fMRI_persubject')
-benchmark_registry['LAION_fMRI_persubject.IT-ood-ridgecv'] = lambda: LAIONfMRI('IT', 'ood', dataset_prefix='LAION_fMRI_persubject')
+benchmark_registry['Zerbe2026_fmri_persubject.V1-tau-ridgecv'] = lambda: LAIONfMRI('V1', 'tau', dataset_prefix='Zerbe2026_fmri_persubject')
+benchmark_registry['Zerbe2026_fmri_persubject.V1-ood-ridgecv'] = lambda: LAIONfMRI('V1', 'ood', dataset_prefix='Zerbe2026_fmri_persubject')
+benchmark_registry['Zerbe2026_fmri_persubject.V2-tau-ridgecv'] = lambda: LAIONfMRI('V2', 'tau', dataset_prefix='Zerbe2026_fmri_persubject')
+benchmark_registry['Zerbe2026_fmri_persubject.V2-ood-ridgecv'] = lambda: LAIONfMRI('V2', 'ood', dataset_prefix='Zerbe2026_fmri_persubject')
+benchmark_registry['Zerbe2026_fmri_persubject.V4-tau-ridgecv'] = lambda: LAIONfMRI('V4', 'tau', dataset_prefix='Zerbe2026_fmri_persubject')
+benchmark_registry['Zerbe2026_fmri_persubject.V4-ood-ridgecv'] = lambda: LAIONfMRI('V4', 'ood', dataset_prefix='Zerbe2026_fmri_persubject')
+benchmark_registry['Zerbe2026_fmri_persubject.IT-tau-ridgecv'] = lambda: LAIONfMRI('IT', 'tau', dataset_prefix='Zerbe2026_fmri_persubject')
+benchmark_registry['Zerbe2026_fmri_persubject.IT-ood-ridgecv'] = lambda: LAIONfMRI('IT', 'ood', dataset_prefix='Zerbe2026_fmri_persubject')
 
 # ── Shared pool ridgecv variants (cross-subject comparison) ───────────────
 # Same 1,492 images across every subject — comparable to Allen2022 / Hebart2023.
-benchmark_registry['LAION_fMRI.V1-tau-ridgecv'] = lambda: LAIONfMRI('V1', 'tau')
-benchmark_registry['LAION_fMRI.V1-ood-ridgecv'] = lambda: LAIONfMRI('V1', 'ood')
-benchmark_registry['LAION_fMRI.V2-tau-ridgecv'] = lambda: LAIONfMRI('V2', 'tau')
-benchmark_registry['LAION_fMRI.V2-ood-ridgecv'] = lambda: LAIONfMRI('V2', 'ood')
-benchmark_registry['LAION_fMRI.V4-tau-ridgecv'] = lambda: LAIONfMRI('V4', 'tau')
-benchmark_registry['LAION_fMRI.V4-ood-ridgecv'] = lambda: LAIONfMRI('V4', 'ood')
-benchmark_registry['LAION_fMRI.IT-tau-ridgecv'] = lambda: LAIONfMRI('IT', 'tau')
-benchmark_registry['LAION_fMRI.IT-ood-ridgecv'] = lambda: LAIONfMRI('IT', 'ood')
+benchmark_registry['Zerbe2026_fmri.V1-tau-ridgecv'] = lambda: LAIONfMRI('V1', 'tau')
+benchmark_registry['Zerbe2026_fmri.V1-ood-ridgecv'] = lambda: LAIONfMRI('V1', 'ood')
+benchmark_registry['Zerbe2026_fmri.V2-tau-ridgecv'] = lambda: LAIONfMRI('V2', 'tau')
+benchmark_registry['Zerbe2026_fmri.V2-ood-ridgecv'] = lambda: LAIONfMRI('V2', 'ood')
+benchmark_registry['Zerbe2026_fmri.V4-tau-ridgecv'] = lambda: LAIONfMRI('V4', 'tau')
+benchmark_registry['Zerbe2026_fmri.V4-ood-ridgecv'] = lambda: LAIONfMRI('V4', 'ood')
+benchmark_registry['Zerbe2026_fmri.IT-tau-ridgecv'] = lambda: LAIONfMRI('IT', 'tau')
+benchmark_registry['Zerbe2026_fmri.IT-ood-ridgecv'] = lambda: LAIONfMRI('IT', 'ood')
 
 # ── Shared pool RSA variants (representational alignment) ─────────────────
 # Per-subject RDM × model-RDM Spearman r, averaged across 5 subjects.
 # Only registered for the shared pool — Nili ceiling needs shared stimuli.
-benchmark_registry['LAION_fMRI.V1-rdm-pearson'] = lambda: LAIONfMRIRSA('V1')
-benchmark_registry['LAION_fMRI.V2-rdm-pearson'] = lambda: LAIONfMRIRSA('V2')
-benchmark_registry['LAION_fMRI.V4-rdm-pearson'] = lambda: LAIONfMRIRSA('V4')
-benchmark_registry['LAION_fMRI.IT-rdm-pearson'] = lambda: LAIONfMRIRSA('IT')
+benchmark_registry['Zerbe2026_fmri.V1-rdm-pearson'] = lambda: LAIONfMRIRSA('V1')
+benchmark_registry['Zerbe2026_fmri.V2-rdm-pearson'] = lambda: LAIONfMRIRSA('V2')
+benchmark_registry['Zerbe2026_fmri.V4-rdm-pearson'] = lambda: LAIONfMRIRSA('V4')
+benchmark_registry['Zerbe2026_fmri.IT-rdm-pearson'] = lambda: LAIONfMRIRSA('IT')

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -6,7 +6,7 @@ sub-variants) on the Allen2022-style **shared pool** (1,492 stimuli seen by ever
 subject). Mirrors `Hebart2023_fmri` and `Allen2022_fmri` in benchmark structure.
 
 Data design: ONE assembly per subject is registered in the data registry (e.g.
-`LAION_fMRI_full_sub-01`); the benchmark loader iterates subjects, applies split +
+`Zerbe2026_fmri_full_sub-01`); the benchmark loader iterates subjects, applies split +
 region + NC filters per subject, then concatenates the small filtered slices on the
 presentation dim only. Avoids materializing a 5+ GB NaN-padded cross-subject matrix
 in RAM (which OOMed during development).
@@ -209,8 +209,8 @@ def _load_one_subject(
         }
     )
     # Pool depends on dataset_prefix:
-    #   "LAION_fMRI"           → "shared" pool (1,492 stimuli)
-    #   "LAION_fMRI_persubject" → that subject's pool (5,833 stimuli)
+    #   "Zerbe2026_fmri"           → "shared" pool (1,492 stimuli)
+    #   "Zerbe2026_fmri_persubject" → that subject's pool (5,833 stimuli)
     pool = sub_id if "persubject" in dataset_prefix else "shared"
     train_mask, test_mask = _split_mask_for_subject(trials, split, pool=pool)
     mask = train_mask if side == "train" else test_mask
@@ -226,7 +226,7 @@ def load_assembly(
     split: str,
     side: str,
     average_repetitions: bool,
-    dataset_prefix: str = "LAION_fMRI",
+    dataset_prefix: str = "Zerbe2026_fmri",
     subjects: tuple[str, ...] = DEFAULT_SUBJECTS,
     noise_ceiling_threshold: float = NOISE_CEILING_THRESHOLD,
     noise_ceiling_coord: str = "nc_12rep",
@@ -340,7 +340,7 @@ def _LAIONfMRI(
     split: str,
     similarity_metric,
     identifier_metric_suffix: str,
-    dataset_prefix: str = "LAION_fMRI",
+    dataset_prefix: str = "Zerbe2026_fmri",
     subjects: tuple[str, ...] = DEFAULT_SUBJECTS,
     alpha_coord: str | None = None,
     per_voxel_ceilings: bool = False,
@@ -405,7 +405,7 @@ def LAIONfMRI(
     region: str,
     split: str,
     metric_type: str = "ridgecv",
-    dataset_prefix: str = "LAION_fMRI",
+    dataset_prefix: str = "Zerbe2026_fmri",
     alphas: Sequence[float] = LAION_ALPHA_LIST,
     subjects: tuple[str, ...] = DEFAULT_SUBJECTS,
     noise_ceiling_threshold: float = NOISE_CEILING_THRESHOLD,
@@ -479,7 +479,7 @@ class _SingleSubjectErrorShim:
 def LAIONfMRIClusterCV(
     region: str,
     metric_type: str = "ridgecv",
-    dataset_prefix: str = "LAION_fMRI",
+    dataset_prefix: str = "Zerbe2026_fmri",
     alphas: Sequence[float] = LAION_ALPHA_LIST,
     n_folds: int = 5,
     subjects: tuple[str, ...] = DEFAULT_SUBJECTS,
@@ -539,7 +539,7 @@ def LAIONfMRIClusterCV(
 def load_full_assembly_one_subject(
     sub_id: str,
     region: str,
-    dataset_prefix: str = "LAION_fMRI",
+    dataset_prefix: str = "Zerbe2026_fmri",
     noise_ceiling_threshold: float = NOISE_CEILING_THRESHOLD,
     noise_ceiling_coord: str = "nc_12rep",
 ) -> xr.DataArray:
@@ -719,14 +719,14 @@ class _MultiSubjectRSABenchmark:
 
 def LAIONfMRIRSA(
     region: str,
-    dataset_prefix: str = "LAION_fMRI",
+    dataset_prefix: str = "Zerbe2026_fmri",
     subjects: tuple[str, ...] = DEFAULT_SUBJECTS,
     noise_ceiling_threshold: float = NOISE_CEILING_THRESHOLD,
     noise_ceiling_coord: str = "nc_12rep",
 ) -> _MultiSubjectRSABenchmark:
     """Construct an RSA benchmark for one region across all subjects.
 
-    RSA is only registered for the shared pool (``LAION_fMRI``). The persubject
+    RSA is only registered for the shared pool (``Zerbe2026_fmri``). The persubject
     pool has subject-specific stimuli, which breaks cross-subject RDM
     comparison.
 

--- a/brainscore_vision/benchmarks/laion_fmri/test.py
+++ b/brainscore_vision/benchmarks/laion_fmri/test.py
@@ -25,7 +25,7 @@ from brainscore_vision import load_benchmark
 
 _RIDGE_REGIONS = ("V1", "V2", "V4", "IT")
 _RIDGE_SPLITS = ("tau", "ood")
-_RIDGE_FAMILIES = ("LAION_fMRI", "LAION_fMRI_persubject")
+_RIDGE_FAMILIES = ("Zerbe2026_fmri", "Zerbe2026_fmri_persubject")
 
 _RIDGE_VARIANTS = [
     f"{fam}.{region}-{split}-ridgecv"
@@ -35,7 +35,7 @@ _RIDGE_VARIANTS = [
 ]  # 2 * 4 * 2 = 16
 
 _RSA_VARIANTS = [
-    f"LAION_fMRI.{region}-rdm-pearson" for region in _RIDGE_REGIONS
+    f"Zerbe2026_fmri.{region}-rdm-pearson" for region in _RIDGE_REGIONS
 ]  # 4 (shared pool only — Nili ceiling requires shared stim across subjects)
 
 _ALL_HEADLINE_VARIANTS = _RIDGE_VARIANTS + _RSA_VARIANTS  # 20
@@ -52,11 +52,11 @@ class TestRegistry:
         )
 
     def test_registry_matches_expected(self):
-        """The registry's LAION_fMRI* entries exactly equal the headline set."""
+        """The registry's Zerbe2026_fmri* entries exactly equal the headline set."""
         from brainscore_vision import benchmark_registry
         import brainscore_vision.benchmarks.laion_fmri  # populate
 
-        registered = {k for k in benchmark_registry if k.startswith("LAION_fMRI")}
+        registered = {k for k in benchmark_registry if k.startswith("Zerbe2026_fmri")}
         expected = set(_ALL_HEADLINE_VARIANTS)
         missing = expected - registered
         extra = registered - expected
@@ -103,7 +103,7 @@ class TestNonHeadlineFactoriesConstruct:
         from brainscore_vision.benchmarks.laion_fmri.benchmark import LAIONfMRIClusterCV
 
         b = LAIONfMRIClusterCV("V4")
-        assert b.identifier == "LAION_fMRI.V4-cluster_k5-ridgecv"
+        assert b.identifier == "Zerbe2026_fmri.V4-cluster_k5-ridgecv"
 
     @pytest.mark.private_access
     def test_per_ood_category_constructs(self):
@@ -124,7 +124,7 @@ class TestNonHeadlineFactoriesConstruct:
         from brainscore_vision.benchmarks.laion_fmri.benchmark import LAIONfMRIRSA
 
         with pytest.raises(ValueError, match="shared pool"):
-            LAIONfMRIRSA("IT", dataset_prefix="LAION_fMRI_persubject")
+            LAIONfMRIRSA("IT", dataset_prefix="Zerbe2026_fmri_persubject")
 
 
 class TestAlexNetSmoke:
@@ -140,9 +140,9 @@ class TestAlexNetSmoke:
     @pytest.mark.parametrize(
         "identifier",
         [
-            "LAION_fMRI.V1-tau-ridgecv",                   # shared ridgecv
-            "LAION_fMRI_persubject.IT-tau-ridgecv",        # persubject ridgecv
-            "LAION_fMRI.IT-rdm-pearson",                   # shared RSA
+            "Zerbe2026_fmri.V1-tau-ridgecv",                   # shared ridgecv
+            "Zerbe2026_fmri_persubject.IT-tau-ridgecv",        # persubject ridgecv
+            "Zerbe2026_fmri.IT-rdm-pearson",                   # shared RSA
         ],
     )
     def test_model_runs(self, identifier):
@@ -168,8 +168,8 @@ class TestUncertaintyContract:
     @pytest.mark.parametrize(
         "identifier",
         [
-            "LAION_fMRI.V1-tau-ridgecv",     # MultiSubjectNeuralBenchmark wrapper
-            "LAION_fMRI.V1-rdm-pearson",     # _MultiSubjectRSABenchmark wrapper
+            "Zerbe2026_fmri.V1-tau-ridgecv",     # MultiSubjectNeuralBenchmark wrapper
+            "Zerbe2026_fmri.V1-rdm-pearson",     # _MultiSubjectRSABenchmark wrapper
         ],
     )
     def test_multisubject_wrapper_uncertainty(self, identifier):

--- a/brainscore_vision/benchmarks/laion_fmri/usage_examples.ipynb
+++ b/brainscore_vision/benchmarks/laion_fmri/usage_examples.ipynb
@@ -46,26 +46,26 @@
      "output_type": "stream",
      "text": [
       "Registered LAION-fMRI benchmarks: 20\n",
-      "  LAION_fMRI.IT-ood-ridge\n",
-      "  LAION_fMRI.IT-rdm-pearson\n",
-      "  LAION_fMRI.IT-tau-ridge\n",
-      "  LAION_fMRI.V1-ood-ridge\n",
-      "  LAION_fMRI.V1-rdm-pearson\n",
-      "  LAION_fMRI.V1-tau-ridge\n",
-      "  LAION_fMRI.V2-ood-ridge\n",
-      "  LAION_fMRI.V2-rdm-pearson\n",
-      "  LAION_fMRI.V2-tau-ridge\n",
-      "  LAION_fMRI.V4-ood-ridge\n",
-      "  LAION_fMRI.V4-rdm-pearson\n",
-      "  LAION_fMRI.V4-tau-ridge\n",
-      "  LAION_fMRI_persubject.IT-ood-ridge\n",
-      "  LAION_fMRI_persubject.IT-tau-ridge\n",
-      "  LAION_fMRI_persubject.V1-ood-ridge\n",
-      "  LAION_fMRI_persubject.V1-tau-ridge\n",
-      "  LAION_fMRI_persubject.V2-ood-ridge\n",
-      "  LAION_fMRI_persubject.V2-tau-ridge\n",
-      "  LAION_fMRI_persubject.V4-ood-ridge\n",
-      "  LAION_fMRI_persubject.V4-tau-ridge\n"
+      "  Zerbe2026_fmri.IT-ood-ridge\n",
+      "  Zerbe2026_fmri.IT-rdm-pearson\n",
+      "  Zerbe2026_fmri.IT-tau-ridge\n",
+      "  Zerbe2026_fmri.V1-ood-ridge\n",
+      "  Zerbe2026_fmri.V1-rdm-pearson\n",
+      "  Zerbe2026_fmri.V1-tau-ridge\n",
+      "  Zerbe2026_fmri.V2-ood-ridge\n",
+      "  Zerbe2026_fmri.V2-rdm-pearson\n",
+      "  Zerbe2026_fmri.V2-tau-ridge\n",
+      "  Zerbe2026_fmri.V4-ood-ridge\n",
+      "  Zerbe2026_fmri.V4-rdm-pearson\n",
+      "  Zerbe2026_fmri.V4-tau-ridge\n",
+      "  Zerbe2026_fmri_persubject.IT-ood-ridge\n",
+      "  Zerbe2026_fmri_persubject.IT-tau-ridge\n",
+      "  Zerbe2026_fmri_persubject.V1-ood-ridge\n",
+      "  Zerbe2026_fmri_persubject.V1-tau-ridge\n",
+      "  Zerbe2026_fmri_persubject.V2-ood-ridge\n",
+      "  Zerbe2026_fmri_persubject.V2-tau-ridge\n",
+      "  Zerbe2026_fmri_persubject.V4-ood-ridge\n",
+      "  Zerbe2026_fmri_persubject.V4-tau-ridge\n"
      ]
     }
    ],
@@ -73,7 +73,7 @@
     "from brainscore_vision import benchmark_registry\n",
     "import brainscore_vision.benchmarks.laion_fmri  # populates registry\n",
     "\n",
-    "laion_ids = sorted([k for k in benchmark_registry if k.startswith('LAION_fMRI')])\n",
+    "laion_ids = sorted([k for k in benchmark_registry if k.startswith('Zerbe2026_fmri')])\n",
     "print(f'Registered LAION-fMRI benchmarks: {len(laion_ids)}')\n",
     "for k in laion_ids:\n",
     "    print(f'  {k}')"
@@ -130,7 +130,7 @@
    "source": [
     "from brainscore_vision import _run_score\n",
     "\n",
-    "score = _run_score('alexnet', 'LAION_fMRI_persubject.IT-tau-ridge')\n",
+    "score = _run_score('alexnet', 'Zerbe2026_fmri_persubject.IT-tau-ridge')\n",
     "print(f\"ceiled: {float(score.values):.4f}\")\n",
     "print(f\"ceiling: {float(score.attrs['ceiling'].values):.4f}\")\n",
     "for sub in ['sub-01','sub-03','sub-05','sub-06','sub-07']:\n",
@@ -168,7 +168,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LAION_fMRI.IT-ood_gabor-ridge: 0.0410\n"
+      "Zerbe2026_fmri.IT-ood_gabor-ridge: 0.0410\n"
      ]
     },
     {
@@ -191,8 +191,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LAION_fMRI.V4-ood_illusion-natural-ridge: 0.2275\n",
-      "LAION_fMRI.IT_full-tau-ridge: 0.1451\n"
+      "Zerbe2026_fmri.V4-ood_illusion-natural-ridge: 0.2275\n",
+      "Zerbe2026_fmri.IT_full-tau-ridge: 0.1451\n"
      ]
     },
     {
@@ -215,7 +215,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LAION_fMRI_persubject.IT-ood-ridge: 0.0190\n"
+      "Zerbe2026_fmri_persubject.IT-ood-ridge: 0.0190\n"
      ]
     }
    ],
@@ -241,7 +241,7 @@
     "print(f'{bench.identifier}: {float(score.values):.4f}')\n",
     "\n",
     "# Persubject pool variant\n",
-    "bench = LAIONfMRI('IT', 'ood', dataset_prefix='LAION_fMRI_persubject')\n",
+    "bench = LAIONfMRI('IT', 'ood', dataset_prefix='Zerbe2026_fmri_persubject')\n",
     "score = bench(model)\n",
     "print(f'{bench.identifier}: {float(score.values):.4f}')"
    ]
@@ -308,7 +308,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LAION_fMRI.V4-cluster_k5-ridge: 0.2389\n",
+      "Zerbe2026_fmri.V4-cluster_k5-ridge: 0.2389\n",
       "per-fold scores: [0.29843910367219106, 0.23126798326222447, 0.30684717955407337, 0.15351057467280188, 0.20440844654499016]\n"
      ]
     },
@@ -359,7 +359,7 @@
     "print(f\"per-fold scores: {[float(s) for s in score.attrs['raw_folds'].values]}\")\n",
     "\n",
     "# Persubject pool \u2014 heaviest variant, takes ~30+ min per region\n",
-    "bench = LAIONfMRIClusterCV('IT', dataset_prefix='LAION_fMRI_persubject')\n",
+    "bench = LAIONfMRIClusterCV('IT', dataset_prefix='Zerbe2026_fmri_persubject')\n",
     "score = bench(model)"
    ]
   },
@@ -391,13 +391,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LAION_fMRI_persubject.V4-tau-ridge (sub-03 only): 0.1699\n"
+      "Zerbe2026_fmri_persubject.V4-tau-ridge (sub-03 only): 0.1699\n"
      ]
     }
    ],
    "source": [
     "# Score sub-03 alone on persubject V4-tau\n",
-    "bench = LAIONfMRI('V4', 'tau', dataset_prefix='LAION_fMRI_persubject', subjects=('sub-03',))\n",
+    "bench = LAIONfMRI('V4', 'tau', dataset_prefix='Zerbe2026_fmri_persubject', subjects=('sub-03',))\n",
     "score = bench(model)\n",
     "print(f'{bench.identifier} (sub-03 only): {float(score.values):.4f}')\n",
     "\n",
@@ -452,7 +452,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LAION_fMRI.IT-rdm-pearson: ceiled 0.3745  raw 0.2815\n",
+      "Zerbe2026_fmri.IT-rdm-pearson: ceiled 0.3745  raw 0.2815\n",
       "Expected error: LAIONfMRIRSA is only defined for the shared pool. Persubject stimuli differ across subjects \u2192 no Nili ceiling.\n"
      ]
     },
@@ -475,7 +475,7 @@
     "\n",
     "# Will raise ValueError on persubject:\n",
     "try:\n",
-    "    LAIONfMRIRSA('IT', dataset_prefix='LAION_fMRI_persubject')\n",
+    "    LAIONfMRIRSA('IT', dataset_prefix='Zerbe2026_fmri_persubject')\n",
     "except ValueError as e:\n",
     "    print(f'Expected error: {e}')"
    ]
@@ -806,7 +806,7 @@
     "\n",
     "If you want non-headline variants to behave like first-class registry entries (e.g., for batch scoring in your notebook), add them to `benchmark_registry` at import time:\n",
     "\n",
-    "> **Caveat:** Brain-Score's `_run_score` calls `import_plugin` which does a text-grep through plugin source files for `benchmark_registry['<id>']` literals. Runtime-added entries aren't text-discoverable, so `_run_score('alexnet', 'LAION_fMRI.IT-ood_gabor-ridge')` will fail with `No registrations found`. Invoke them via the registry dict directly: `benchmark_registry[<id>]()`. The factories return regular benchmark objects you can call with `benchmark(model)`."
+    "> **Caveat:** Brain-Score's `_run_score` calls `import_plugin` which does a text-grep through plugin source files for `benchmark_registry['<id>']` literals. Runtime-added entries aren't text-discoverable, so `_run_score('alexnet', 'Zerbe2026_fmri.IT-ood_gabor-ridge')` will fail with `No registrations found`. Invoke them via the registry dict directly: `benchmark_registry[<id>]()`. The factories return regular benchmark objects you can call with `benchmark(model)`."
    ]
   },
   {
@@ -831,7 +831,7 @@
     "\n",
     "# All cluster_k5 variants (8 \u2014 4 regions x 2 families)\n",
     "for region in ['V1', 'V2', 'V4', 'IT']:\n",
-    "    for fam in ['LAION_fMRI', 'LAION_fMRI_persubject']:\n",
+    "    for fam in ['Zerbe2026_fmri', 'Zerbe2026_fmri_persubject']:\n",
     "        bid = f'{fam}.{region}-cluster_k5-ridge'\n",
     "        benchmark_registry[bid] = (\n",
     "            lambda r=region, f=fam: LAIONfMRIClusterCV(r, dataset_prefix=f)\n",
@@ -840,16 +840,16 @@
     "# Per-OOD-category breakdowns (36 \u2014 4 regions x 9 categories, shared only)\n",
     "for region in ['V1', 'V2', 'V4', 'IT']:\n",
     "    for t in OOD_TYPES:\n",
-    "        bid = f'LAION_fMRI.{region}-ood_{t}-ridge'\n",
+    "        bid = f'Zerbe2026_fmri.{region}-ood_{t}-ridge'\n",
     "        benchmark_registry[bid] = (lambda r=region, t=t: LAIONfMRI(r, f'ood_{t}'))\n",
     "\n",
     "# IT_full (V4 union IT) for all splits\n",
     "for split in ['tau', 'ood'] + [f'ood_{t}' for t in OOD_TYPES]:\n",
-    "    bid = f'LAION_fMRI.IT_full-{split}-ridge'\n",
+    "    bid = f'Zerbe2026_fmri.IT_full-{split}-ridge'\n",
     "    benchmark_registry[bid] = (lambda s=split: LAIONfMRI('IT_full', s))\n",
     "\n",
     "print(f'Total LAION benchmarks now registered: '\n",
-    "      f'{len([k for k in benchmark_registry if k.startswith(\"LAION_fMRI\")])}')"
+    "      f'{len([k for k in benchmark_registry if k.startswith(\"Zerbe2026_fmri\")])}')"
    ]
   },
   {
@@ -871,7 +871,7 @@
     "# source files for `benchmark_registry['<id>']` literals to find the file owning\n",
     "# the benchmark \u2014 runtime-registered entries aren't text-discoverable. So for\n",
     "# runtime additions we skip that path and invoke from the registry dict directly:\n",
-    "benchmark = benchmark_registry['LAION_fMRI.IT-ood_gabor-ridge']()\n",
+    "benchmark = benchmark_registry['Zerbe2026_fmri.IT-ood_gabor-ridge']()\n",
     "score = benchmark(model)\n",
     "print(f'IT ood_gabor: {float(score.values):.4f}')"
    ]
@@ -893,7 +893,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 9. Gotchas\n\n- **First call per (model, stim_set) is slow**: activations get extracted and cached at `~/.result_caching/`. Subsequent calls hit the cache (~30s vs ~10min).\n- **Persubject cells download big**: each subject's `LAION_fMRI_persubject_full_sub-XX` assembly is ~400-800 MB. Cached at `~/.brainio/` after first fetch.\n- **Stimuli are DUA-gated**: AWS credentials needed for the private S3 prefix. Brain-Score will auto-download on first call if creds are configured.\n- **MacOS jetsam**: the heaviest cells (cluster_k5 persubject IT for big models) can hit ~30GB RAM during ridge fitting. macOS may SIGKILL them. Either use a single-process Python invocation per cell (see `baselines/sweep_per_cell.sh`) or run on a Linux box with more RAM headroom."
+   "source": "## 9. Gotchas\n\n- **First call per (model, stim_set) is slow**: activations get extracted and cached at `~/.result_caching/`. Subsequent calls hit the cache (~30s vs ~10min).\n- **Persubject cells download big**: each subject's `Zerbe2026_fmri_persubject_full_sub-XX` assembly is ~400-800 MB. Cached at `~/.brainio/` after first fetch.\n- **Stimuli are DUA-gated**: AWS credentials needed for the private S3 prefix. Brain-Score will auto-download on first call if creds are configured.\n- **MacOS jetsam**: the heaviest cells (cluster_k5 persubject IT for big models) can hit ~30GB RAM during ridge fitting. macOS may SIGKILL them. Either use a single-process Python invocation per cell (see `baselines/sweep_per_cell.sh`) or run on a Linux box with more RAM headroom."
   }
  ],
  "metadata": {

--- a/brainscore_vision/data/laion_fmri/__init__.py
+++ b/brainscore_vision/data/laion_fmri/__init__.py
@@ -25,21 +25,21 @@ SUBJECTS = ("sub-01", "sub-03", "sub-05", "sub-06", "sub-07")
 
 
 # ── Shared-pool assemblies (1,492 stim seen by every subject) ─────────────
-data_registry['LAION_fMRI_full_sub-01'] = make_shared_loader('sub-01')
-data_registry['LAION_fMRI_full_sub-03'] = make_shared_loader('sub-03')
-data_registry['LAION_fMRI_full_sub-05'] = make_shared_loader('sub-05')
-data_registry['LAION_fMRI_full_sub-06'] = make_shared_loader('sub-06')
-data_registry['LAION_fMRI_full_sub-07'] = make_shared_loader('sub-07')
+data_registry['Zerbe2026_fmri_full_sub-01'] = make_shared_loader('sub-01')
+data_registry['Zerbe2026_fmri_full_sub-03'] = make_shared_loader('sub-03')
+data_registry['Zerbe2026_fmri_full_sub-05'] = make_shared_loader('sub-05')
+data_registry['Zerbe2026_fmri_full_sub-06'] = make_shared_loader('sub-06')
+data_registry['Zerbe2026_fmri_full_sub-07'] = make_shared_loader('sub-07')
 
 # ── Per-subject pool assemblies (5,833 stim/subj: 1,121 shared + 4,712 unique) ──
-data_registry['LAION_fMRI_persubject_full_sub-01'] = make_persubject_loader('sub-01')
-data_registry['LAION_fMRI_persubject_full_sub-03'] = make_persubject_loader('sub-03')
-data_registry['LAION_fMRI_persubject_full_sub-05'] = make_persubject_loader('sub-05')
-data_registry['LAION_fMRI_persubject_full_sub-06'] = make_persubject_loader('sub-06')
-data_registry['LAION_fMRI_persubject_full_sub-07'] = make_persubject_loader('sub-07')
+data_registry['Zerbe2026_fmri_persubject_full_sub-01'] = make_persubject_loader('sub-01')
+data_registry['Zerbe2026_fmri_persubject_full_sub-03'] = make_persubject_loader('sub-03')
+data_registry['Zerbe2026_fmri_persubject_full_sub-05'] = make_persubject_loader('sub-05')
+data_registry['Zerbe2026_fmri_persubject_full_sub-06'] = make_persubject_loader('sub-06')
+data_registry['Zerbe2026_fmri_persubject_full_sub-07'] = make_persubject_loader('sub-07')
 
 # ── Stimulus set (DUA-gated; loader probes local paths then private S3) ──
 # Registered under both family names because benchmark.py derives the
 # stim-set identifier from `f"{dataset_prefix}_stim_full"`.
-stimulus_set_registry['LAION_fMRI_stim_full'] = load_stimulus_set
-stimulus_set_registry['LAION_fMRI_persubject_stim_full'] = load_stimulus_set
+stimulus_set_registry['Zerbe2026_fmri_stim_full'] = load_stimulus_set
+stimulus_set_registry['Zerbe2026_fmri_persubject_stim_full'] = load_stimulus_set

--- a/brainscore_vision/data/laion_fmri/_helpers/assemblies.py
+++ b/brainscore_vision/data/laion_fmri/_helpers/assemblies.py
@@ -87,7 +87,7 @@ def make_shared_loader(sub_id: str):
             sha1=cfg["sha1"],
             bucket=_BUCKET,
             cls=NeuroidAssembly,
-            stimulus_set_loader=lambda: load_stimulus_set("LAION_fMRI_stim_full"),
+            stimulus_set_loader=lambda: load_stimulus_set("Zerbe2026_fmri_stim_full"),
             # Presentation dim already carries `stimulus_id`; merging stim_set
             # metadata (image dimensions, etc.) into the assembly isn't needed.
             merge_stimulus_set_meta=False,
@@ -107,7 +107,7 @@ def make_persubject_loader(sub_id: str):
         da = load_assembly_from_s3(
             identifier=cfg["identifier"], version_id=cfg["version_id"],
             sha1=cfg["sha1"], bucket=_BUCKET, cls=NeuroidAssembly,
-            stimulus_set_loader=lambda: load_stimulus_set("LAION_fMRI_stim_full"),
+            stimulus_set_loader=lambda: load_stimulus_set("Zerbe2026_fmri_stim_full"),
             merge_stimulus_set_meta=False,
         )
         # 1. Strip session/run/beta_index so `average_repetition` actually averages.

--- a/brainscore_vision/data/laion_fmri/_helpers/stimuli.py
+++ b/brainscore_vision/data/laion_fmri/_helpers/stimuli.py
@@ -28,7 +28,7 @@ from brainscore_core.supported_data_standards.brainio.stimuli import StimulusSet
 
 
 _STIMULI_S3_BUCKET = "brainscore-storage"
-_STIMULI_S3_KEY = "brainscore-vision/benchmarks/Zerbe2026_fmri/stimuli/images_extracted.zip"
+_STIMULI_S3_KEY = "brainscore-vision/benchmarks/LAION_fMRI/stimuli/images_extracted.zip"
 
 
 def _stimuli_dir_candidates() -> list[Path]:

--- a/brainscore_vision/data/laion_fmri/_helpers/stimuli.py
+++ b/brainscore_vision/data/laion_fmri/_helpers/stimuli.py
@@ -28,7 +28,7 @@ from brainscore_core.supported_data_standards.brainio.stimuli import StimulusSet
 
 
 _STIMULI_S3_BUCKET = "brainscore-storage"
-_STIMULI_S3_KEY = "brainscore-vision/benchmarks/LAION_fMRI/stimuli/images_extracted.zip"
+_STIMULI_S3_KEY = "brainscore-vision/benchmarks/Zerbe2026_fmri/stimuli/images_extracted.zip"
 
 
 def _stimuli_dir_candidates() -> list[Path]:
@@ -85,6 +85,6 @@ def load_stimulus_set() -> StimulusSet:
     manifest = pd.read_csv(stim_dir / "manifest.csv")
     manifest["path"] = manifest["filename"].apply(lambda f: str(stim_dir / f))
     stim = StimulusSet(manifest.drop(columns=["path"]))
-    stim.identifier = "LAION_fMRI_stim_full"
+    stim.identifier = "Zerbe2026_fmri_stim_full"
     stim.stimulus_paths = dict(zip(manifest["stimulus_id"], manifest["path"]))
     return stim

--- a/brainscore_vision/data/laion_fmri/data_packaging/upload_to_s3.py
+++ b/brainscore_vision/data/laion_fmri/data_packaging/upload_to_s3.py
@@ -6,8 +6,8 @@ out of the box.
 
 Walks both pool families produced by the rebuild pipeline:
 
-  - ``shared_sub-XX_brainscore.nc``      ->  ``LAION_fMRI_full_sub-XX_Assembly``
-  - ``persubject_sub-XX_brainscore.nc``  ->  ``LAION_fMRI_persubject_sub-XX_Assembly``
+  - ``shared_sub-XX_brainscore.nc``      ->  ``Zerbe2026_fmri_full_sub-XX_Assembly``
+  - ``persubject_sub-XX_brainscore.nc``  ->  ``Zerbe2026_fmri_persubject_sub-XX_Assembly``
 
 Does NOT upload stimuli (gated by the LAION-fMRI Data Use Agreement -- stays
 local via the manifest in ``stimuli/images_extracted/``).
@@ -31,7 +31,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 log = logging.getLogger("upload_to_s3")
 
 DEFAULT_BUCKET = "brainscore-storage"
-DEFAULT_PREFIX = "brainscore-vision/benchmarks/LAION_fMRI"
+DEFAULT_PREFIX = "brainscore-vision/benchmarks/Zerbe2026_fmri"
 SUBJECTS = ("sub-01", "sub-03", "sub-05", "sub-06", "sub-07")
 
 
@@ -46,10 +46,10 @@ class Family:
 
 FAMILIES = (
     Family(name="shared", file_prefix="shared_",
-           identifier_tmpl="LAION_fMRI_full_{sub}_Assembly",
+           identifier_tmpl="Zerbe2026_fmri_full_{sub}_Assembly",
            registry_var="_S3_ASSEMBLIES_SHARED"),
     Family(name="persubject", file_prefix="persubject_",
-           identifier_tmpl="LAION_fMRI_persubject_{sub}_Assembly",
+           identifier_tmpl="Zerbe2026_fmri_persubject_{sub}_Assembly",
            registry_var="_S3_ASSEMBLIES_PERSUBJECT"),
 )
 

--- a/brainscore_vision/data/laion_fmri/data_packaging/upload_to_s3.py
+++ b/brainscore_vision/data/laion_fmri/data_packaging/upload_to_s3.py
@@ -6,8 +6,8 @@ out of the box.
 
 Walks both pool families produced by the rebuild pipeline:
 
-  - ``shared_sub-XX_brainscore.nc``      ->  ``Zerbe2026_fmri_full_sub-XX_Assembly``
-  - ``persubject_sub-XX_brainscore.nc``  ->  ``Zerbe2026_fmri_persubject_sub-XX_Assembly``
+  - ``shared_sub-XX_brainscore.nc``      ->  ``LAION_fMRI_full_sub-XX_Assembly``
+  - ``persubject_sub-XX_brainscore.nc``  ->  ``LAION_fMRI_persubject_sub-XX_Assembly``
 
 Does NOT upload stimuli (gated by the LAION-fMRI Data Use Agreement -- stays
 local via the manifest in ``stimuli/images_extracted/``).
@@ -31,7 +31,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 log = logging.getLogger("upload_to_s3")
 
 DEFAULT_BUCKET = "brainscore-storage"
-DEFAULT_PREFIX = "brainscore-vision/benchmarks/Zerbe2026_fmri"
+DEFAULT_PREFIX = "brainscore-vision/benchmarks/LAION_fMRI"
 SUBJECTS = ("sub-01", "sub-03", "sub-05", "sub-06", "sub-07")
 
 
@@ -46,10 +46,10 @@ class Family:
 
 FAMILIES = (
     Family(name="shared", file_prefix="shared_",
-           identifier_tmpl="Zerbe2026_fmri_full_{sub}_Assembly",
+           identifier_tmpl="LAION_fMRI_full_{sub}_Assembly",
            registry_var="_S3_ASSEMBLIES_SHARED"),
     Family(name="persubject", file_prefix="persubject_",
-           identifier_tmpl="Zerbe2026_fmri_persubject_{sub}_Assembly",
+           identifier_tmpl="LAION_fMRI_persubject_{sub}_Assembly",
            registry_var="_S3_ASSEMBLIES_PERSUBJECT"),
 )
 


### PR DESCRIPTION
Follow-up to #2394 (merged today).

## What's preserved as-is

- **Dataset name \`LAION-fMRI\`** (hyphen form) in docstrings, BibTeX, METHODS title, citations. That is what Zerbe et al. call their dataset; renaming it would falsely imply a different dataset.
- **S3 paths and brainio Assembly identifiers** — the actual data on S3 is at \`s3://brainscore-storage/brainscore-vision/benchmarks/LAION_fMRI/assy_LAION_fMRI_full_sub-XX_Assembly.nc\`. The brainio lookup key (Assembly \`identifier=\"LAION_fMRI_full_sub-XX_Assembly\"\`) stays the old name so the existing S3 files are still resolvable; only the brain-score-side \`data_registry\` key (the indirection layer) is renamed.
- **\`baselines/\` historical sweep CSVs and dev scripts** — those are snapshots of past scoring under the original identifier and are kept as a historical record.

## Tests

\`TestRegistry\` (22) and \`TestSplitResolution\` + \`TestNonHeadlineFactoriesConstruct\` (9) pass locally. \`@pytest.mark.private_access\` smoke + uncertainty tests will run on Jenkins.

## Migration impact

Since the original #2394 was merged less than 24 hours ago, no submissions have scored against \`LAION_fMRI.*\` in the production scoring DB. Renaming now has zero historical-score impact. After this merges, scoring runs should target the \`Zerbe2026_fmri.*\` identifiers.