### PR TITLE
laion_fmri: add version attr on MultiSubject/KFold/RSA wrappers + single-entry BIBTEX

### DIFF
--- a/brainscore_vision/benchmark_helpers/multi_subject.py
+++ b/brainscore_vision/benchmark_helpers/multi_subject.py
@@ -144,11 +144,12 @@ class KFoldNeuralBenchmark:
         self._n_folds = int(n_folds)
         self._factory = fold_factory
 
-        # Materialize one fold to extract region/bibtex metadata, then release.
+        # Materialize one fold to extract region/bibtex/version metadata, then release.
         sample = self._factory(0)
         self.region = sample.region
         self.parent = self.region
         self.bibtex = getattr(sample, "bibtex", None)
+        self.version = getattr(sample, "version", 1)
         _release(sample)
         del sample
         gc.collect()
@@ -236,6 +237,7 @@ class MultiSubjectNeuralBenchmark:
         self.region = sample.region
         self.parent = self.region
         self.bibtex = getattr(sample, "bibtex", None)
+        self.version = getattr(sample, "version", 1)
         self.timebins = sample.timebins
         _release(sample)
         del sample

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -55,20 +55,13 @@ from brainscore_vision.utils import LazyLoad
 LAION_ALPHA_LIST = [10.0 ** i for i in range(-10, 11)]
 
 
+# brainscore_core.submission.database.parse_bib accepts a single BibTeX entry.
+# Prince et al. 2022 (GLMsingle) preprocessing citation is kept in METHODS.md.
 BIBTEX = """@inproceedings{zerbe_laion-fmri_2026,
     title = {{LAION}-{fMRI}: A densely sampled 7T-fMRI dataset providing broad coverage of natural image diversity},
     author = {Zerbe, Josefine and Roth, Johannes and Mell, Maggie Mae and Herholz, Peer and Knapen, Tomas and Hebart, Martin N.},
     year = {2026},
     booktitle = {Vision Sciences Society Annual Meeting},
-}
-@article{prince2022glmsingle,
-    title = {Improving the accuracy of single-trial f{MRI} response estimates using {GLM}single},
-    author = {Prince, Jacob S. and Charest, Ian and Kurzawski, Jan W. and Pyles, John A. and Tarr, Michael J. and Kay, Kendrick N.},
-    journal = {eLife},
-    volume = {11},
-    pages = {e77599},
-    year = {2022},
-    doi = {10.7554/eLife.77599},
 }"""
 
 # Stimuli rendered 1000x1000 px on a BenQ-mirrored PROpixx projection at ~165 cm viewing distance
@@ -654,6 +647,7 @@ class _MultiSubjectRSABenchmark:
         self._factory = per_subject_factory
         sample = self._factory(self._subjects[0])
         self.timebins = getattr(sample, "timebins", [(0, 0)])
+        self.version = getattr(sample, "version", 1)
         _release(sample)
         del sample
         gc.collect()


### PR DESCRIPTION
Two scoring-side regressions from #2394 that only surface when \`brainscore_core.submission.endpoints\` actually tries to record a benchmark run.

## 1. \`MultiSubjectNeuralBenchmark.version\` (and \`KFoldNeuralBenchmark.version\`, \`_MultiSubjectRSABenchmark.version\`) was unset

\`brainscore_core.submission.database.benchmarkinstance_from_benchmark\` reads \`benchmark.version\` to record which version produced this score. Other benchmarks inherit it through \`BenchmarkBase\`. Our wrappers don't subclass BenchmarkBase (deliberate, to keep them framework-agnostic), so the attribute simply wasn't there. Symptom:
\`\`\`
AttributeError: 'MultiSubjectNeuralBenchmark' object has no attribute 'version'
\`\`\`

Fix: copy \`version\` from the first child constructed during \`__init__\` (falls back to \`1\` if the child doesn't have one).

## 2. \`BIBTEX\` had two entries; \`parse_bib\` expects exactly one

\`brainscore_core.submission.database.parse_bib\`:
\`\`\`python
assert len(entry) == 1
\`\`\`

Our \`BIBTEX\` constant held both the Zerbe et al. dataset citation and Prince et al. (GLMsingle preprocessing) — added in a previous commit for completeness. The Prince entry was used as part of \`benchmark.bibtex\` and tripped the assertion when the scoring submission tried to store the reference.

Fix: keep only the primary Zerbe et al. citation in \`BIBTEX\`. The Prince et al. GLMsingle citation is preserved in \`METHODS.md\` (preprocessing section), which is the standard convention for non-dataset citations.

## Test surface

\`TestRegistry\` + \`TestNonHeadlineFactoriesConstruct\` (26 tests) pass locally. Slow private_access smoke tests will exercise the scoring path end-to-end on Jenkins.