### PR TITLE
laion_fmri: set scalar 'raw' on multi-subject/fold wrappers for DB recorder

### DIFF
--- a/brainscore_vision/benchmark_helpers/multi_subject.py
+++ b/brainscore_vision/benchmark_helpers/multi_subject.py
@@ -55,6 +55,24 @@ def _release(child) -> None:
             except AttributeError:
                 pass
 
+
+def _child_raw_scalar(child_score) -> float:
+    """Extract a scalar ``raw`` correlation from a child Score.
+
+    brainscore_core's submission DB calls ``_retrieve_score_center(score.raw)``
+    which assumes ``raw`` is reducible to a Python scalar. Children typically
+    expose their uncieled raw correlation under ``attrs['raw']`` as a 0-d or
+    1-d array; this helper coerces it to a float.
+    """
+    raw = child_score.attrs.get("raw")
+    if raw is None:
+        return float("nan")
+    try:
+        vals = raw.values if hasattr(raw, "values") else np.asarray(raw)
+        return float(np.asarray(vals).mean())
+    except Exception:
+        return float("nan")
+
 WRAPPER_N_BOOTSTRAP = 200
 
 
@@ -172,10 +190,13 @@ class KFoldNeuralBenchmark:
     def __call__(self, candidate) -> Score:
         fold_scores = []
         fold_ceilings = np.empty(self._n_folds, dtype=np.float64)
+        fold_raws = np.empty(self._n_folds, dtype=np.float64)
         for k in range(self._n_folds):
             child = self._factory(k)
-            fold_scores.append(child(candidate))
+            child_score = child(candidate)
+            fold_scores.append(child_score)
             fold_ceilings[k] = float(child.ceiling.values)
+            fold_raws[k] = _child_raw_scalar(child_score)
             _release(child)
             del child
             gc.collect()
@@ -185,6 +206,9 @@ class KFoldNeuralBenchmark:
             values, dims=("fold",), coords={"fold": np.arange(len(values))},
             name=f"{self.identifier}_per_fold",
         )
+        # Pre-set 'raw' as a scalar so attach_error won't overwrite it with the
+        # disaggregated array; brainscore_core's DB recorder requires scalar.
+        score.attrs["raw"] = float(np.nanmean(fold_raws))
         score.attrs["raw_folds"] = raw_folds
         score.attrs["sem_folds"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0
@@ -264,10 +288,13 @@ class MultiSubjectNeuralBenchmark:
     def __call__(self, candidate) -> Score:
         per_subject_scores = []
         ceil_values = np.empty(len(self._subjects), dtype=np.float64)
+        raw_values = np.empty(len(self._subjects), dtype=np.float64)
         for i, sub_id in enumerate(self._subjects):
             child = self._factory(sub_id)
-            per_subject_scores.append(child(candidate))
+            child_score = child(candidate)
+            per_subject_scores.append(child_score)
             ceil_values[i] = float(child.ceiling.values)
+            raw_values[i] = _child_raw_scalar(child_score)
             _release(child)
             del child
             gc.collect()
@@ -277,6 +304,9 @@ class MultiSubjectNeuralBenchmark:
             values, dims=("subject",), coords={"subject": self._subjects},
             name=f"{self.identifier}_per_subject",
         )
+        # Pre-set 'raw' as a scalar so attach_error won't overwrite it with the
+        # disaggregated array; brainscore_core's DB recorder requires scalar.
+        score.attrs["raw"] = float(np.nanmean(raw_values))
         score.attrs["raw_subjects"] = raw_subjects
         score.attrs["sem_subjects"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -671,12 +671,16 @@ class _MultiSubjectRSABenchmark:
         return score
 
     def __call__(self, candidate) -> Score:
+        from brainscore_vision.benchmark_helpers.multi_subject import _child_raw_scalar
         per_subject_scores = []
         ceil_values = np.empty(len(self._subjects), dtype=np.float64)
+        raw_values = np.empty(len(self._subjects), dtype=np.float64)
         for i, sub_id in enumerate(self._subjects):
             child = self._factory(sub_id)
-            per_subject_scores.append(child(candidate))
+            child_score = child(candidate)
+            per_subject_scores.append(child_score)
             ceil_values[i] = float(child.ceiling.values)
+            raw_values[i] = _child_raw_scalar(child_score)
             _release(child)
             del child
             gc.collect()
@@ -686,6 +690,9 @@ class _MultiSubjectRSABenchmark:
             values, dims=("subject",), coords={"subject": self._subjects},
             name=f"{self.identifier}_per_subject",
         )
+        # Pre-set 'raw' as a scalar so attach_error won't overwrite it with the
+        # disaggregated array; brainscore_core's DB recorder requires scalar.
+        score.attrs["raw"] = float(np.nanmean(raw_values))
         score.attrs["raw_subjects"] = raw_subjects
         score.attrs["sem_subjects"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0


### PR DESCRIPTION
Follow-up to #2396. The merged commit fixed \`version\` + single-entry BIBTEX but the next failure surfaced one step further in scoring — \`brainscore_core.submission.database.update_score\` then chokes on \`score.raw\`.

## What's failing

\`\`\`python
# brainscore_core/submission/database.py
def update_score(score, entry):
    ...
    score_raw = _retrieve_score_center(score.raw)   # <-- here

def _retrieve_score_center(score):
    if hasattr(score, 'aggregation'):
        return score.sel(aggregation='center').item()
    return score.item()
\`\`\`

\`_retrieve_score_center\` requires \`score.raw\` to be reducible to a Python scalar (\`.item()\` works on size-1 arrays only). Our \`MultiSubjectNeuralBenchmark\` / \`KFoldNeuralBenchmark\` / \`_MultiSubjectRSABenchmark\` wrappers indirectly set \`attrs['raw']\` to the per-subject (or per-fold) **array** via \`attach_error()\`:

\`\`\`python
# bootstrap_error.py:attach_error
if Score.RAW_VALUES_KEY not in score.attrs:
    score.attrs[Score.RAW_VALUES_KEY] = values   # per-subject DataArray (n=5)
\`\`\`

That's the vision convention for preserving disaggregated values for downstream split-half analysis. It collides with brainscore_core's DB recorder, which expects a scalar.

Symptom on the alexnet × Zerbe2026_fmri.V1-tau-ridgecv run:
\`\`\`
ValueError: can only convert an array of size 1 to a Python scalar
\`\`\`

The score itself computed correctly first (\`0.402\`, matches the v10 baseline sweep). The failure is purely in the post-scoring DB write step.

## Fix

Pre-populate \`score.attrs['raw']\` with the scalar mean of per-child raw correlations **before** calling \`attach_error\` — which has \`if RAW_VALUES_KEY not in attrs\` guard, so it skips overwriting.

Disaggregated per-subject/fold values remain available via \`score.attrs['raw_subjects']\` / \`score.attrs['raw_folds']\` (already set independently, unchanged behavior).

Adds a \`_child_raw_scalar()\` helper in \`benchmark_helpers/multi_subject.py\` that coerces a child Score's \`attrs['raw']\` to a float (handles 0-d, 1-d, or missing).

## Schema reference

For posterity, the contract \`update_score\` expects from a Score:

| Field | Type | Used by |
|---|---|---|
| \`score\` main value | scalar (\`.item()\`) or has \`aggregation='center'\` | DB column \`score_ceiled\` |
| \`score.attrs['raw']\` | **scalar** | DB column \`score_raw\` (when \`ceiling\` is present) |
| \`score.attrs['ceiling']\` | Score-like, scalar | gates raw column |
| \`score.attrs['error']\` | scalar | DB column \`error\` |
| \`score.attrs['comment']\` | string | DB column \`comment\` |

Our wrappers already produce scalars for all but \`raw\`; this PR completes the contract.

## Test surface

\`TestRegistry\` + \`TestNonHeadlineFactoriesConstruct\` (26 tests) pass locally. Slow private_access smoke tests will exercise scoring end-to-end on Jenkins.