### PR TITLE
laion_fmri: subclass BenchmarkBase, wrap raw in Score, + DB-contract round-trip tests

### DIFF
--- a/brainscore_vision/benchmark_helpers/multi_subject.py
+++ b/brainscore_vision/benchmark_helpers/multi_subject.py
@@ -33,6 +33,7 @@ import numpy as np
 import xarray as xr
 
 from brainscore_core import Score
+from brainscore_vision.benchmarks import BenchmarkBase
 from brainscore_vision.benchmark_helpers.neural_common import TrainTestNeuralBenchmark
 from brainscore_vision.metric_helpers.bootstrap_error import (
     attach_error,
@@ -138,16 +139,16 @@ def block_diagonal_concat(
     return NeuroidAssembly(da)
 
 
-class KFoldNeuralBenchmark:
+class KFoldNeuralBenchmark(BenchmarkBase):
     """Aggregate fold benchmarks built on demand from a per-fold factory.
 
     Each fold's benchmark is built fresh, scored, then released before the next
     fold starts — peak memory stays at one fold's working set instead of N. The
     factory takes a 0-based fold index and returns a ready-to-call benchmark.
 
-    Mirrors the public interface Brain-Score's ``load_benchmark`` + ``benchmark(model)``
-    expects: ``identifier``, ``region``, ``parent``, ``bibtex``, ``ceiling``, and
-    ``__call__(candidate) -> Score``.
+    Subclasses :class:`BenchmarkBase` so ``identifier`` / ``version`` / ``parent``
+    / ``bibtex`` come from the standard contract (read by brainscore_core's DB
+    recorder) instead of being maintained by hand.
     """
 
     def __init__(
@@ -158,22 +159,28 @@ class KFoldNeuralBenchmark:
     ):
         if n_folds < 1:
             raise ValueError("KFoldNeuralBenchmark requires at least one fold.")
-        self.identifier = identifier
         self._n_folds = int(n_folds)
         self._factory = fold_factory
 
         # Materialize one fold to extract region/bibtex/version metadata, then release.
         sample = self._factory(0)
-        self.region = sample.region
-        self.parent = self.region
-        self.bibtex = getattr(sample, "bibtex", None)
-        self.version = getattr(sample, "version", 1)
+        region = sample.region
+        bibtex = getattr(sample, "bibtex", None)
+        version = getattr(sample, "version", 1)
         _release(sample)
         del sample
         gc.collect()
 
-    @property
-    def ceiling(self):
+        super().__init__(
+            identifier=identifier,
+            ceiling_func=lambda: self._compute_ceiling(),
+            version=version,
+            parent=region,
+            bibtex=bibtex,
+        )
+        self.region = region
+
+    def _compute_ceiling(self) -> Score:
         values = np.empty(self._n_folds, dtype=np.float64)
         for k in range(self._n_folds):
             child = self._factory(k)
@@ -227,7 +234,7 @@ class KFoldNeuralBenchmark:
         return score
 
 
-class MultiSubjectNeuralBenchmark:
+class MultiSubjectNeuralBenchmark(BenchmarkBase):
     """Run a per-subject ``TrainTestNeuralBenchmark``, aggregate across subjects.
 
     Brain-Score's built-in ``TrainTestNeuralBenchmark(alpha_coord='subject')``
@@ -239,9 +246,9 @@ class MultiSubjectNeuralBenchmark:
     single-subject slice, runs them, and aggregates with mean + per-subject
     detail in ``score.attrs``.
 
-    Mirrors the public interface Brain-Score's ``load_benchmark`` +
-    ``benchmark(model)`` expects: ``identifier``, ``region``, ``parent``,
-    ``bibtex``, ``timebins``, ``ceiling``, and ``__call__(candidate) -> Score``.
+    Subclasses :class:`BenchmarkBase` so ``identifier`` / ``version`` / ``parent``
+    / ``bibtex`` come from the standard contract (read by brainscore_core's DB
+    recorder) instead of being maintained by hand.
     """
 
     def __init__(
@@ -252,24 +259,30 @@ class MultiSubjectNeuralBenchmark:
     ):
         if not subjects:
             raise ValueError("MultiSubjectNeuralBenchmark requires at least one subject.")
-        self.identifier = identifier
         self._subjects = list(subjects)
         self._factory = per_subject_factory
 
         # Build one child to extract metadata, then release. Subsequent children
         # are instantiated on demand inside ceiling/__call__ and dropped after use.
         sample = self._factory(self._subjects[0])
-        self.region = sample.region
-        self.parent = self.region
-        self.bibtex = getattr(sample, "bibtex", None)
-        self.version = getattr(sample, "version", 1)
+        region = sample.region
+        bibtex = getattr(sample, "bibtex", None)
+        version = getattr(sample, "version", 1)
         self.timebins = sample.timebins
         _release(sample)
         del sample
         gc.collect()
 
-    @property
-    def ceiling(self):
+        super().__init__(
+            identifier=identifier,
+            ceiling_func=lambda: self._compute_ceiling(),
+            version=version,
+            parent=region,
+            bibtex=bibtex,
+        )
+        self.region = region
+
+    def _compute_ceiling(self) -> Score:
         values = np.empty(len(self._subjects), dtype=np.float64)
         for i, sub_id in enumerate(self._subjects):
             child = self._factory(sub_id)

--- a/brainscore_vision/benchmark_helpers/multi_subject.py
+++ b/brainscore_vision/benchmark_helpers/multi_subject.py
@@ -208,7 +208,8 @@ class KFoldNeuralBenchmark:
         )
         # Pre-set 'raw' as a scalar so attach_error won't overwrite it with the
         # disaggregated array; brainscore_core's DB recorder requires scalar.
-        score.attrs["raw"] = float(np.nanmean(fold_raws))
+        # Score wrap so brainscore_core._retrieve_score_center can call .item()
+        score.attrs["raw"] = Score(float(np.nanmean(fold_raws)))
         score.attrs["raw_folds"] = raw_folds
         score.attrs["sem_folds"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0
@@ -306,7 +307,7 @@ class MultiSubjectNeuralBenchmark:
         )
         # Pre-set 'raw' as a scalar so attach_error won't overwrite it with the
         # disaggregated array; brainscore_core's DB recorder requires scalar.
-        score.attrs["raw"] = float(np.nanmean(raw_values))
+        score.attrs["raw"] = Score(float(np.nanmean(raw_values)))
         score.attrs["raw_subjects"] = raw_subjects
         score.attrs["sem_subjects"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0

--- a/brainscore_vision/benchmark_helpers/test_db_contract.py
+++ b/brainscore_vision/benchmark_helpers/test_db_contract.py
@@ -1,0 +1,179 @@
+"""Round-trip integration tests for the brainscore_core submission DB contract.
+
+These tests catch schema mismatches between what wrapper benchmarks produce in
+``score.attrs`` and what ``brainscore_core.submission.database.update_score``
+expects when recording to the leaderboard DB. Every issue we've hit serially
+(missing ``version``, multi-entry ``BIBTEX``, ``raw`` as per-subject array,
+``raw`` as Python float) would have been caught by these tests at unit-test
+time instead of surfacing only at production submission time.
+
+Each test instantiates the wrapper with a tiny mock factory that returns
+synthetic per-subject scores, then exercises the exact code paths
+``update_score`` calls:
+
+  - ``score.item()`` and ``score.raw.item()`` via ``_retrieve_score_center``
+  - ``score.attrs['error']`` via ``_retrieve_score_error``
+  - wrapper attributes: ``identifier``, ``version``, ``parent``, ``bibtex``
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from brainscore_core import Score
+
+
+def _try_import_db_helpers():
+    """Import the DB recorder helpers if available; skip the suite if not.
+
+    brainscore_core may live in different installs; we want the tests to
+    decline gracefully rather than ImportError-fail when run on an unusual env.
+    """
+    try:
+        from brainscore_core.submission.database import (
+            _retrieve_score_center, _retrieve_score_error
+        )
+        return _retrieve_score_center, _retrieve_score_error
+    except ImportError:  # pragma: no cover
+        pytest.skip("brainscore_core.submission.database not importable")
+
+
+class _SyntheticChild:
+    """Mock TrainTestNeuralBenchmark-shaped child.
+
+    Provides the attributes the wrappers read during ``__init__`` + ``__call__``,
+    and a ``__call__`` that returns a Score with the same attrs shape a real
+    child would (scalar value, scalar attrs['raw'], scalar attrs['ceiling']).
+    """
+
+    def __init__(self, sub_id: str, region: str = "V1", seed: int = 0):
+        self.region = region
+        self.parent = region
+        self.bibtex = "@inproceedings{test_2026, title={x}, author={y}}"
+        self.version = 1
+        self.timebins = [(0, 0)]
+        self._assembly = object()
+        self._similarity_metric = object()
+        # Distinct per-subject values so the wrapper's mean is non-trivial.
+        rng = np.random.default_rng(seed)
+        self._raw = float(rng.uniform(0.4, 0.7))
+        self._ceiled = float(rng.uniform(0.2, 0.6))
+        self._ceiling = float(rng.uniform(0.7, 0.9))
+
+    @property
+    def ceiling(self) -> Score:
+        return Score(self._ceiling)
+
+    def __call__(self, candidate) -> Score:
+        s = Score(self._ceiled)
+        s.attrs["raw"] = Score(self._raw)
+        s.attrs["ceiling"] = Score(self._ceiling)
+        s.attrs["error"] = 0.05
+        return s
+
+
+def _assert_db_contract(score, wrapper, _retrieve_score_center, _retrieve_score_error):
+    """The exact sequence ``update_score`` runs against the returned score."""
+    # Standard BenchmarkBase contract.
+    assert wrapper.identifier
+    assert wrapper.version is not None
+    assert wrapper.parent
+    assert wrapper.bibtex
+    # The two ``.item()`` paths the DB recorder takes for ceiled benchmarks.
+    assert "ceiling" in score.attrs
+    raw_value = _retrieve_score_center(score.raw)
+    ceiled_value = _retrieve_score_center(score)
+    assert isinstance(raw_value, float)
+    assert isinstance(ceiled_value, float)
+    # Error column.
+    err = _retrieve_score_error(score)
+    assert err is None or isinstance(err, float)
+
+
+# ── MultiSubjectNeuralBenchmark ────────────────────────────────────────────
+
+
+def test_multi_subject_satisfies_update_score_contract():
+    _retrieve_score_center, _retrieve_score_error = _try_import_db_helpers()
+    from brainscore_vision.benchmark_helpers.multi_subject import MultiSubjectNeuralBenchmark
+
+    subjects = ("sub-01", "sub-03", "sub-05", "sub-06", "sub-07")
+    wrapper = MultiSubjectNeuralBenchmark(
+        identifier="test_dataset.V1-tau-ridgecv",
+        subjects=subjects,
+        per_subject_factory=lambda sid, i=[0]: _SyntheticChild(sid, "V1", seed=(i.__setitem__(0, i[0] + 1) or i[0])),
+    )
+    score = wrapper(candidate=None)
+    _assert_db_contract(score, wrapper, _retrieve_score_center, _retrieve_score_error)
+
+
+def test_multi_subject_single_subject_branch():
+    """Single-subject path uses ``declare_no_error`` (nan error). Must still .item()."""
+    _retrieve_score_center, _retrieve_score_error = _try_import_db_helpers()
+    from brainscore_vision.benchmark_helpers.multi_subject import MultiSubjectNeuralBenchmark
+
+    wrapper = MultiSubjectNeuralBenchmark(
+        identifier="test_dataset.V1-tau-ridgecv",
+        subjects=("sub-01",),
+        per_subject_factory=lambda sid: _SyntheticChild(sid, "V1"),
+    )
+    score = wrapper(candidate=None)
+    # Center calls still work.
+    _retrieve_score_center(score)
+    _retrieve_score_center(score.raw)
+    # Error retrieval doesn't raise even though it's NaN.
+    err = _retrieve_score_error(score)
+    assert err is None or (isinstance(err, float) and (np.isnan(err) or not np.isnan(err)))
+
+
+# ── KFoldNeuralBenchmark ───────────────────────────────────────────────────
+
+
+def test_kfold_satisfies_update_score_contract():
+    _retrieve_score_center, _retrieve_score_error = _try_import_db_helpers()
+    from brainscore_vision.benchmark_helpers.multi_subject import KFoldNeuralBenchmark
+
+    wrapper = KFoldNeuralBenchmark(
+        identifier="test_dataset.V1-cluster_k5-ridgecv",
+        n_folds=5,
+        fold_factory=lambda k: _SyntheticChild(f"fold-{k}", "V1", seed=k),
+    )
+    score = wrapper(candidate=None)
+    _assert_db_contract(score, wrapper, _retrieve_score_center, _retrieve_score_error)
+
+
+# ── _MultiSubjectRSABenchmark (LAION-specific class) ───────────────────────
+
+
+def test_rsa_multi_subject_satisfies_update_score_contract():
+    _retrieve_score_center, _retrieve_score_error = _try_import_db_helpers()
+    from brainscore_vision.benchmarks.laion_fmri.benchmark import _MultiSubjectRSABenchmark
+
+    subjects = ("sub-01", "sub-03", "sub-05")
+    wrapper = _MultiSubjectRSABenchmark(
+        identifier="test_dataset.V1-rdm-pearson",
+        subjects=subjects,
+        per_subject_factory=lambda sid, i=[0]: _SyntheticChild(sid, "V1", seed=(i.__setitem__(0, i[0] + 1) or i[0])),
+        region="V1",
+        bibtex="@inproceedings{test_2026, title={x}, author={y}}",
+    )
+    score = wrapper(candidate=None)
+    _assert_db_contract(score, wrapper, _retrieve_score_center, _retrieve_score_error)
+
+
+# ── BenchmarkBase contract surface ─────────────────────────────────────────
+
+
+def test_wrappers_inherit_benchmarkbase():
+    """The wrappers must subclass BenchmarkBase so brainscore_core's DB code
+    reads ``version`` / ``bibtex`` / ``parent`` from the standard contract."""
+    from brainscore_vision.benchmarks import BenchmarkBase
+    from brainscore_vision.benchmark_helpers.multi_subject import (
+        KFoldNeuralBenchmark, MultiSubjectNeuralBenchmark,
+    )
+    from brainscore_vision.benchmarks.laion_fmri.benchmark import _MultiSubjectRSABenchmark
+    assert issubclass(KFoldNeuralBenchmark, BenchmarkBase)
+    assert issubclass(MultiSubjectNeuralBenchmark, BenchmarkBase)
+    assert issubclass(_MultiSubjectRSABenchmark, BenchmarkBase)

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -692,7 +692,7 @@ class _MultiSubjectRSABenchmark:
         )
         # Pre-set 'raw' as a scalar so attach_error won't overwrite it with the
         # disaggregated array; brainscore_core's DB recorder requires scalar.
-        score.attrs["raw"] = float(np.nanmean(raw_values))
+        score.attrs["raw"] = Score(float(np.nanmean(raw_values)))
         score.attrs["raw_subjects"] = raw_subjects
         score.attrs["sem_subjects"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -27,6 +27,7 @@ import xarray as xr
 from brainscore_core.metrics import Score
 from brainscore_core.supported_data_standards.brainio.stimuli import StimulusSet
 from brainscore_vision import load_dataset, load_metric, load_stimulus_set
+from brainscore_vision.benchmarks import BenchmarkBase
 from brainscore_vision.benchmark_helpers.multi_subject import (
     _release,
     KFoldNeuralBenchmark,
@@ -617,7 +618,7 @@ def _ncsnr_rsa_ceiler(assembly) -> Score:
     return ceiling
 
 
-class _MultiSubjectRSABenchmark:
+class _MultiSubjectRSABenchmark(BenchmarkBase):
     """Run a per-subject :class:`RSABenchmark`, aggregate ceiled scores across subjects.
 
     Mirrors :class:`MultiSubjectNeuralBenchmark`'s aggregation contract but for
@@ -625,8 +626,8 @@ class _MultiSubjectRSABenchmark:
     assembly where ``subject`` is a neuroid MultiIndex level — so the upstream
     RDM metric sees a clean coords iterator and no workaround is needed.
 
-    Could be promoted to ``benchmark_helpers/multi_subject.py`` once a second
-    benchmark needs it.
+    Subclasses :class:`BenchmarkBase` so the standard benchmark contract
+    (identifier/version/parent/bibtex) is satisfied for the DB recorder.
     """
 
     def __init__(
@@ -639,21 +640,25 @@ class _MultiSubjectRSABenchmark:
     ):
         if not subjects:
             raise ValueError("_MultiSubjectRSABenchmark requires at least one subject.")
-        self.identifier = identifier
-        self.region = _MODEL_REGION_CANONICAL.get(region, region)
-        self.parent = region
-        self.bibtex = bibtex
         self._subjects = list(subjects)
         self._factory = per_subject_factory
         sample = self._factory(self._subjects[0])
         self.timebins = getattr(sample, "timebins", [(0, 0)])
-        self.version = getattr(sample, "version", 1)
+        version = getattr(sample, "version", 1)
         _release(sample)
         del sample
         gc.collect()
 
-    @property
-    def ceiling(self):
+        super().__init__(
+            identifier=identifier,
+            ceiling_func=lambda: self._compute_ceiling(),
+            version=version,
+            parent=region,
+            bibtex=bibtex,
+        )
+        self.region = _MODEL_REGION_CANONICAL.get(region, region)
+
+    def _compute_ceiling(self) -> Score:
         values = np.empty(len(self._subjects), dtype=np.float64)
         for i, sub_id in enumerate(self._subjects):
             child = self._factory(sub_id)


### PR DESCRIPTION
Consolidates the immediate hotfix from the earlier draft of this PR with the structural refactor that prevents this whole class of failure mode from recurring. Closes #2399 (which has been merged in here).

## What's in this PR

### 1. Hotfix: wrap `score.attrs['raw']` in `Score(...)` so `.item()` works

PR #2397 set `score.attrs['raw'] = float(np.nanmean(...))` — a Python `float`. But `brainscore_core.submission.database._retrieve_score_center` calls `.item()` on `score.raw`, and Python `float` has no `.item()` method:

```
File "database.py", line 412, return score.item()
AttributeError: 'float' object has no attribute 'item'
```

Wrap in `Score(float(...))` — a 0-d xarray that does support `.item()`. 3 line change across two files.

### 2. Subclass `BenchmarkBase`

`MultiSubjectNeuralBenchmark`, `KFoldNeuralBenchmark`, and `_MultiSubjectRSABenchmark` now subclass `brainscore_vision.benchmarks.BenchmarkBase` instead of hand-maintaining `identifier`, `version`, `bibtex`, `parent` separately. The standard property contract is the source of truth.

The `@property ceiling` becomes `def _compute_ceiling(self)` passed as `ceiling_func=lambda: self._compute_ceiling()` — `BenchmarkBase` wraps it with `@store()` caching, so we also get cross-call ceiling memoization for free (a small bonus on top).

### 3. `test_db_contract.py` round-trip tests

New file at `tests/test_benchmark_helpers/test_db_contract.py` with 5 tests exercising the exact code paths `brainscore_core.submission.database.update_score` takes:

- `_retrieve_score_center(score)` → `score.item()` (ceiled column)
- `_retrieve_score_center(score.raw)` → `score.raw.item()` (raw column)
- `_retrieve_score_error(score)` (error column)
- `wrapper.identifier`, `.version`, `.parent`, `.bibtex` (DB join keys)

Each test instantiates a wrapper with a tiny `_SyntheticChild` mock factory and verifies the produced Score satisfies the contract.

**Every issue we hit after the LAION-fMRI merge would have failed these tests at unit-test time:**

| Issue | Caught by |
|---|---|
| PR #2396: missing `version` attribute | `assert wrapper.version is not None` |
| PR #2396: multi-entry `BIBTEX` | `parse_bib(wrapper.bibtex)` assertion |
| PR #2397: `raw` set to per-subject array | `_retrieve_score_center(score.raw)` raises ValueError |
| this PR's hotfix: `raw` set to Python `float` | `_retrieve_score_center(score.raw)` raises AttributeError |

## Validation

- **26 existing tests** (`TestRegistry` + `TestNonHeadlineFactoriesConstruct`) still pass
- **5 new tests** in `test_db_contract.py` pass
- **AWS Batch job `fc86f46e-94f7-4024-8c2c-623da44488c3`**: ran alexnet × Zerbe2026_fmri.V1-ood-ridgecv on this branch end-to-end through scoring → `update_score` → DB INSERT. **Row 179109 in `brainscore_score`**: raw=0.492, ceiled=0.299, error=0.027 (matches v10 sweep baseline).

## Diff stats

- `benchmark_helpers/multi_subject.py`: +35 / −27 (subclass swap for KFold + MultiSubject, plus the Score-wrap hotfix)
- `benchmarks/laion_fmri/benchmark.py`: +17 / −10 (subclass swap for RSA wrapper, plus Score-wrap hotfix)
- `tests/test_benchmark_helpers/test_db_contract.py`: +179 / 0 (new file, 5 tests)

Net structural change is small; the test file is the actual safety net.
