### PR TITLE
Update laion-fmri dependency source in requirements

### DIFF
--- a/brainscore_vision/benchmarks/laion_fmri/requirements.txt
+++ b/brainscore_vision/benchmarks/laion_fmri/requirements.txt
@@ -1,3 +1,3 @@
-laion-fmri @ git+https://github.com/KartikP/LAION-fMRI.git@fix/duplicate-force-include
+laion-fmri @ git+https://github.com/ViCCo-Group/LAION-fMRI.git@main
 numpy<2.0
 pandas<3.0


### PR DESCRIPTION
Following their recent merge (https://github.com/ViCCo-Group/LAION-fMRI/pull/11)

requirements.txt temporarily pins laion-fmri to my fork (KartikP/LAION-fMRI@fix/duplicate-force-include) because the upstream pyproject.toml has a redundant [tool.hatch.build.targets.wheel.force-include] that breaks wheel builds with hatchling 1.18+.
