### PR TITLE
Wire up brainscore_resource_tracking on import

### DIFF
--- a/brainscore_vision/__init__.py
+++ b/brainscore_vision/__init__.py
@@ -15,6 +15,12 @@ from brainscore_vision.model_interface import BrainModel
 
 _logger = logging.getLogger(__name__)
 
+try:
+    from brainscore_resource_tracking import enable_tracking as _enable_resource_tracking
+    _enable_resource_tracking()
+except ImportError:
+    pass
+
 data_registry: Dict[str, Callable[[], Union[DataAssembly, Any]]] = {}
 """ Pool of available data """
 

--- a/brainscore_vision/__init__.py
+++ b/brainscore_vision/__init__.py
@@ -15,12 +15,6 @@ from brainscore_vision.model_interface import BrainModel
 
 _logger = logging.getLogger(__name__)
 
-try:
-    from brainscore_resource_tracking import enable_tracking as _enable_resource_tracking
-    _enable_resource_tracking()
-except ImportError:
-    pass
-
 data_registry: Dict[str, Callable[[], Union[DataAssembly, Any]]] = {}
 """ Pool of available data """
 

--- a/brainscore_vision/submission/endpoints.py
+++ b/brainscore_vision/submission/endpoints.py
@@ -42,6 +42,15 @@ def send_email_to_submitter(uid: int, domain: str, pr_number: str,
 
 
 if __name__ == '__main__':
+    # Wire up resource-usage tracking ONLY in the scoring-container entrypoint.
+    # Keeping this out of brainscore_vision/__init__.py so regular imports
+    # (tests, notebooks, REPL) don't register an atexit stdout-emitter hook.
+    try:
+        from brainscore_resource_tracking import enable_tracking as _enable_resource_tracking
+        _enable_resource_tracking()
+    except ImportError:
+        pass
+
     parser = make_argparser()
     args, remaining_args = parser.parse_known_args()
     args_dict = vars(args)


### PR DESCRIPTION
## Summary

- Soft import `brainscore_resource_tracking.enable_tracking()` at the top of `brainscore_vision/__init__.py`
- Registers an atexit hook that emits `BRAINSCORE_PEAK_RSS` to stdout when the scoring container's Python process exits
- The scoring orchestrator parses that sentinel along with `BRAINSCORE_CGROUP_PEAK` (emitted by the container entrypoint) into ResourceUsage rows

## Why

Per-job memory telemetry. The orchestrator already persists ResourceUsage rows for every terminal Batch job; without this hook, the \`max_memory_gb\` (process RSS) column lands as NULL. With it, every scoring run records its actual peak memory, which feeds the gate calibration analysis and the eventual memoized-peak dispatcher (Track 4).

## Why soft import

\`brainscore-resource-tracking\` lives as a sibling package in the \`brain-score/infrastructure\` repo and is not on PyPI. Listing it as a hard dep in pyproject would either break the wheel build (no direct-URL deps allowed on PyPI) or pull a non-existent package on \`pip install brainscore-vision\`. The scoring container's Dockerfile installs it from the local checkout (\`pip install -e /resource_tracking/\`), so the import succeeds inside Batch and silently falls through everywhere else.

## Test plan

- [ ] Local dev install (\`pip install -e .\`) — import succeeds, no behavior change (soft fallback)
- [ ] Inside a scoring Batch container after merge — \`BRAINSCORE_PEAK_RSS\` sentinel appears in CloudWatch logs on job exit
- [ ] Orchestrator parses the sentinel into a \`max_memory_gb\` column in \`brainscore_resource_usage\` (verified against deit_large canary)