### PR TITLE
Preflight: use calibrated cost for multi-child wrappers

### DIFF
--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -413,6 +413,15 @@ def preallocate_memory(
         rdm_overhead_gb = 2 * activation_gb
         total_estimated_gb = activation_gb + rdm_overhead_gb  # = 3 × activation_gb
         formula_type = 'rdm'
+    elif fixed_benchmark_cost_gb is not None:
+        # Calibrated value present — trust it over the ridge_large_feature
+        # heuristic. The calibration script measured actual peak RSS on the
+        # benchmark end-to-end, so the value reflects the real working set
+        # better than the ×6 fallback can predict. Wrapper benchmarks
+        # (MultiSubjectNeuralBenchmark, KFoldNeuralBenchmark) pass their own
+        # wrapper-level fixed_cost here to short-circuit the per-child scale.
+        total_estimated_gb = activation_gb + fixed_benchmark_cost_gb
+        formula_type = 'calibrated'
     elif ridge_large_feature:
         # n_features > n_stimuli: sklearn SVD path — overhead ≈ 5× activation_gb.
         # Validated: resnet50/ViT × Gifford2022.IT-ridgecv both gave exactly 5.1×.
@@ -420,17 +429,11 @@ def preallocate_memory(
         # the pre-flight MemoryError fires before the OS kills the container.
         total_estimated_gb = activation_gb * _OVERHEAD_FACTOR
         formula_type = 'ridge_large_feature'
-    elif is_ridge and fixed_benchmark_cost_gb is not None:
-        total_estimated_gb = activation_gb + fixed_benchmark_cost_gb
-        formula_type = 'calibrated'
     elif is_ridge:
         # No calibration entry, primal regime: gram matrix is n_stimuli×n_stimuli
         rdm_overhead_gb = (num_stimuli ** 2) * _BYTES_PER_ELEMENT / (1024 ** 3)
         total_estimated_gb = activation_gb + rdm_overhead_gb
         formula_type = 'ridge_formula'
-    elif fixed_benchmark_cost_gb is not None:
-        total_estimated_gb = activation_gb + fixed_benchmark_cost_gb
-        formula_type = 'calibrated'
     else:
         total_estimated_gb = activation_gb * _OVERHEAD_FACTOR
         formula_type = 'fallback'

--- a/brainscore_vision/benchmark_helpers/multi_subject.py
+++ b/brainscore_vision/benchmark_helpers/multi_subject.py
@@ -78,23 +78,54 @@ WRAPPER_N_BOOTSTRAP = 200
 
 
 def _scaled_preallocate_memory(wrapper, candidate, child_factory, raise_if_oom: bool):
-    """Probe one representative child and scale by ``wrapper._peak_aggregation``.
+    """Estimate memory for a multi-child wrapper.
 
-    Returns the child's unscaled :class:`MemoryEstimate` so callers can read
-    formula details; raises :exc:`MemoryError` when the *scaled* estimate
-    exceeds available RAM. Returns ``None`` when the probe itself is skipped
-    (e.g. ``BRAINSCORE_SKIP_MEMORY_CHECK=1``).
+    Precedence:
+
+    1. If the wrapper has a calibrated ``fixed_benchmark_cost_gb`` entry
+       (i.e. ``benchmark_costs.json[wrapper.identifier]``), pass it directly
+       to the per-child probe — the calibrated value was measured
+       end-to-end on the wrapper, so it already captures peak_aggregation
+       and any cross-child cache accumulation. The returned estimate uses
+       ``formula_type='calibrated'`` and is NOT multiplied by
+       ``peak_aggregation`` (would double-count).
+    2. Otherwise, fall back to probing one representative child with the
+       formula path and scaling by ``wrapper._peak_aggregation``.
+
+    Returns the per-child :class:`MemoryEstimate` (with the wrapper's
+    fixed_cost baked in if calibrated), or ``None`` when probing is
+    skipped (``BRAINSCORE_SKIP_MEMORY_CHECK=1``).
     """
-    from brainscore_vision.benchmark_helpers.memory import preallocate_memory as _probe
+    from brainscore_vision.benchmark_helpers.memory import (
+        load_calibration,
+        preallocate_memory as _probe,
+    )
+    wrapper_fixed_cost = load_calibration().get(wrapper.identifier)
     child = child_factory()
     try:
-        estimate = _probe(candidate, child, raise_if_oom=False)
+        estimate = _probe(
+            candidate, child, raise_if_oom=False,
+            fixed_benchmark_cost_gb=wrapper_fixed_cost,
+        )
     finally:
         _release(child)
         del child
         gc.collect()
     if estimate is None:
         return None
+
+    if wrapper_fixed_cost is not None:
+        # Calibrated path — the value already reflects peak_aggregation.
+        if estimate.total_estimated_gb > estimate.available_gb and raise_if_oom:
+            raise MemoryError(
+                f"preallocate_memory ({type(wrapper).__name__} '{wrapper.identifier}'): "
+                f"calibrated estimate {estimate.total_estimated_gb:.1f} GB "
+                f"(activation {estimate.activation_gb:.2f} + fixed_cost "
+                f"{wrapper_fixed_cost:.2f}) > {estimate.available_gb:.1f} GB available"
+            )
+        return estimate
+
+    # Formula path — scale per-child by peak_aggregation.
     scaled_gb = estimate.total_estimated_gb * wrapper._peak_aggregation
     if scaled_gb > estimate.available_gb and raise_if_oom:
         raise MemoryError(


### PR DESCRIPTION
## Summary

Follow-up to #2409. The Zerbe2026 (LAION-fMRI) wrapper benchmarks couldn't reach their calibrated \`fixed_cost\` values from \`benchmark_costs.json\` because of two formula dispatch issues:

1. \`_scaled_preallocate_memory\` probed the **per-subject child** — the child's identifier (not the wrapper's) is what the calibration table key would need to match, but only the wrapper has an entry.
2. Even if you passed the wrapper's fixed_cost explicitly, the top-level \`preallocate_memory\` formula chain checked the \`ridge_large_feature\` branch **before** the calibrated branch, so the heuristic ×6 fallback fired regardless.

## Changes

- **\`multi_subject.py\`** — \`_scaled_preallocate_memory\` looks up \`benchmark_costs.json[wrapper.identifier]\` and passes the value into the per-child probe as \`fixed_benchmark_cost_gb\`. When calibrated, the per-child estimate becomes \`activation + wrapper_fixed_cost\` directly (with \`formula_type='calibrated'\`); we skip the \`× peak_aggregation\` scale because the calibrated value already captures cross-child cache accumulation end-to-end. Falls back to existing behavior when no calibration entry exists.
- **\`memory.py\`** — formula dispatch now prefers an explicitly-passed \`fixed_benchmark_cost_gb\` over the \`ridge_large_feature\` heuristic. This is what makes the \`multi_subject\` change effective. Existing PLS and RDM paths unchanged.

## Why this matters

Yesterday's validation canary on
\`deit_large_imagenet_full_seed-0 × Zerbe2026_fmri_persubject.V2-ood-ridgecv\`
fired:

\`\`\`
BRAINSCORE_PREFLIGHT { formula_type: "ridge_large_feature", estimate_gb: 27.974, will_oom: true }
MemoryError: aggregated estimate 139.9 GB (per-child 28.0 × 5.0) > 26.8 GB available
→ "Submission is stored as failure"  ← caught inside scoring endpoint, container exit 0
\`\`\`

After this PR, the same canary should yield:

\`\`\`
BRAINSCORE_PREFLIGHT { formula_type: "calibrated", estimate_gb: ~19, ... }
\`\`\`

Predicting activation + 13.76 GB (the calibrated value from PR #2409), which fits the medium tier comfortably.

## Test plan

- [x] All 58 tests in \`tests/test_plugin_management/test_memory_*.py\` pass
- [ ] Validation canary: same benchmark on \`deit_large\` — confirm \`formula_type='calibrated'\` and scoring proceeds (will run after merge)