### PR TITLE
preflight: scale temporal-pls memory estimate by num_timebins

### DIFF
--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -63,6 +63,16 @@ _OVERHEAD_FACTOR = 6
 #   worst miss after fix: resnet50 × Cadena2017-pls  →  -12.7%  (within 15%)
 _PLS_OVERHEAD_FACTOR = 7
 
+# Extra multiplier applied to the PLS estimate for *temporal-pls* benchmarks
+# (e.g. MajajHong2015public.{V4,IT}-temporal-pls). Temporal PLS fits the
+# regression once per time-bin and retains the per-timebin intermediate
+# matrices, so peak memory grows roughly by an additional ~5× on top of the
+# standard PLS overhead factor (observed on canary runs of MajajHong2015public
+# .{V4,IT}-temporal-pls — task #48). Applied multiplicatively to the PLS
+# formula (activation × _PLS_OVERHEAD_FACTOR + fixed_cost), then OOM-checked
+# against the tier ceiling like every other benchmark.
+_TEMPORAL_PLS_MULTIPLIER = 5
+
 
 @dataclass
 class MemoryEstimate:
@@ -91,6 +101,12 @@ class MemoryEstimate:
                          if self.fixed_benchmark_cost_gb else "")
             formula = (f"{self.activation_gb:.2f} GB activations "
                        f"×{_PLS_OVERHEAD_FACTOR} (PLS){fixed_str}")
+        elif self.formula_type == 'temporal_pls':
+            fixed_str = (f" + {self.fixed_benchmark_cost_gb:.2f} GB fixed cost"
+                         if self.fixed_benchmark_cost_gb else "")
+            formula = (f"{self.activation_gb:.2f} GB activations "
+                       f"×{_PLS_OVERHEAD_FACTOR} (PLS) ×{_TEMPORAL_PLS_MULTIPLIER} "
+                       f"(temporal-pls per-timebin retention){fixed_str}")
         elif self.formula_type == 'rdm':
             formula = (f"{self.activation_gb:.2f} GB activations "
                        f"×3 (RDM pairwise distance overhead → {self.total_estimated_gb:.1f} GB total)")
@@ -407,6 +423,13 @@ def preallocate_memory(
     if is_pls:
         total_estimated_gb = activation_gb * _PLS_OVERHEAD_FACTOR + (fixed_benchmark_cost_gb or 0.0)
         formula_type = 'pls'
+        # temporal-pls benchmarks fit PLS per timebin and retain per-timebin
+        # intermediates → ~5× the regular PLS peak. Apply the multiplier here
+        # so the same OOM-check + tier-escalation path handles it. See
+        # _TEMPORAL_PLS_MULTIPLIER comment for the empirical basis.
+        if '-temporal-pls' in str(getattr(benchmark, 'identifier', '')):
+            total_estimated_gb *= _TEMPORAL_PLS_MULTIPLIER
+            formula_type = 'temporal_pls'
     elif is_rdm:
         # Overhead ≈ 2× activation_gb (scales with features, not n_stimuli²).
         # Validated across alexnet/resnet50/ViT on Allen2022_fmri.IT-rdm.
@@ -491,6 +514,11 @@ def preallocate_memory(
             f"Actual usage can vary significantly depending on model feature count and convergence.",
             flush=True,
         )
+    elif formula_type == 'temporal_pls':
+        fixed_str = (f"  +  {estimate.fixed_benchmark_cost_gb:.3f} GB fixed cost"
+                     if estimate.fixed_benchmark_cost_gb is not None else "")
+        print(f"  ×{_PLS_OVERHEAD_FACTOR} (PLS){fixed_str}  ×{_TEMPORAL_PLS_MULTIPLIER} (temporal)  "
+              f"=  {estimate.total_estimated_gb:.3f} GB total", flush=True)
     elif formula_type == 'ridge_large_feature':
         print(f"  ×{_OVERHEAD_FACTOR} (ridge SVD: n_features={num_features:,} > n_stimuli={num_stimuli:,})"
               f"  =  {estimate.total_estimated_gb:.3f} GB total", flush=True)

--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -63,15 +63,14 @@ _OVERHEAD_FACTOR = 6
 #   worst miss after fix: resnet50 × Cadena2017-pls  →  -12.7%  (within 15%)
 _PLS_OVERHEAD_FACTOR = 7
 
-# Extra multiplier applied to the PLS estimate for *temporal-pls* benchmarks
-# (e.g. MajajHong2015public.{V4,IT}-temporal-pls). Temporal PLS fits the
-# regression once per time-bin and retains the per-timebin intermediate
-# matrices, so peak memory grows roughly by an additional ~5× on top of the
-# standard PLS overhead factor (observed on canary runs of MajajHong2015public
-# .{V4,IT}-temporal-pls — task #48). Applied multiplicatively to the PLS
-# formula (activation × _PLS_OVERHEAD_FACTOR + fixed_cost), then OOM-checked
-# against the tier ceiling like every other benchmark.
-_TEMPORAL_PLS_MULTIPLIER = 5
+# For temporal-PLS benchmarks (e.g. MajajHong2015public.{V4,IT}-temporal-pls)
+# the PLS regression is fit once per time-bin and the per-timebin intermediate
+# matrices are retained simultaneously, so peak memory grows by an additional
+# factor of ``num_timebins`` on top of the standard PLS overhead. A fixed
+# constant is wrong because benchmarks may have anywhere from 2 to dozens of
+# timebins; scale by the actual count probed at preflight time. Detection
+# uses ``num_timebins > 1`` rather than the ``-temporal-pls`` substring so
+# any PLS benchmark with multi-timebin output gets the correct estimate.
 
 
 @dataclass
@@ -105,7 +104,7 @@ class MemoryEstimate:
             fixed_str = (f" + {self.fixed_benchmark_cost_gb:.2f} GB fixed cost"
                          if self.fixed_benchmark_cost_gb else "")
             formula = (f"{self.activation_gb:.2f} GB activations "
-                       f"×{_PLS_OVERHEAD_FACTOR} (PLS) ×{_TEMPORAL_PLS_MULTIPLIER} "
+                       f"×{_PLS_OVERHEAD_FACTOR} (PLS) ×{self.num_timebins} "
                        f"(temporal-pls per-timebin retention){fixed_str}")
         elif self.formula_type == 'rdm':
             formula = (f"{self.activation_gb:.2f} GB activations "
@@ -423,12 +422,12 @@ def preallocate_memory(
     if is_pls:
         total_estimated_gb = activation_gb * _PLS_OVERHEAD_FACTOR + (fixed_benchmark_cost_gb or 0.0)
         formula_type = 'pls'
-        # temporal-pls benchmarks fit PLS per timebin and retain per-timebin
-        # intermediates → ~5× the regular PLS peak. Apply the multiplier here
-        # so the same OOM-check + tier-escalation path handles it. See
-        # _TEMPORAL_PLS_MULTIPLIER comment for the empirical basis.
-        if '-temporal-pls' in str(getattr(benchmark, 'identifier', '')):
-            total_estimated_gb *= _TEMPORAL_PLS_MULTIPLIER
+        # PLS fit once per timebin and intermediates retained → peak memory
+        # scales linearly with num_timebins on top of the standard PLS
+        # overhead. ``num_timebins == 1`` is a no-op multiplier so single-
+        # window PLS benchmarks (MajajHong2015.IT-pls etc.) are unchanged.
+        if num_timebins > 1:
+            total_estimated_gb *= num_timebins
             formula_type = 'temporal_pls'
     elif is_rdm:
         # Overhead ≈ 2× activation_gb (scales with features, not n_stimuli²).
@@ -517,7 +516,7 @@ def preallocate_memory(
     elif formula_type == 'temporal_pls':
         fixed_str = (f"  +  {estimate.fixed_benchmark_cost_gb:.3f} GB fixed cost"
                      if estimate.fixed_benchmark_cost_gb is not None else "")
-        print(f"  ×{_PLS_OVERHEAD_FACTOR} (PLS){fixed_str}  ×{_TEMPORAL_PLS_MULTIPLIER} (temporal)  "
+        print(f"  ×{_PLS_OVERHEAD_FACTOR} (PLS){fixed_str}  ×{num_timebins} (timebins)  "
               f"=  {estimate.total_estimated_gb:.3f} GB total", flush=True)
     elif formula_type == 'ridge_large_feature':
         print(f"  ×{_OVERHEAD_FACTOR} (ridge SVD: n_features={num_features:,} > n_stimuli={num_stimuli:,})"

--- a/tests/test_plugin_management/test_memory_precheck.py
+++ b/tests/test_plugin_management/test_memory_precheck.py
@@ -25,7 +25,6 @@ from brainscore_vision.benchmark_helpers.memory import (
     MemoryEstimate,
     _OVERHEAD_FACTOR,
     _PLS_OVERHEAD_FACTOR,
-    _TEMPORAL_PLS_MULTIPLIER,
     _BYTES_PER_ELEMENT,
     _DEFAULT_CALIBRATION_PATH,
     preallocate_memory,
@@ -96,13 +95,27 @@ def _make_train_test_benchmark(n_train: int = 8, n_test: int = 4) -> TrainTestNe
     return bm
 
 
-def _make_model(num_features: int = 512) -> BrainModel:
-    """Mock BrainModel whose look_at returns a DataArray with neuroid dim."""
+def _make_model(num_features: int = 512, num_timebins: int = 1) -> BrainModel:
+    """Mock BrainModel whose look_at returns a DataArray with neuroid (and
+    optionally time_bin) dim. ``num_timebins > 1`` mimics a temporal model so
+    the preflight's ``probe_output.sizes.get('time_bin', 1)`` path picks up
+    the right count."""
     model = MagicMock(spec=BrainModel)
     model.visual_degrees.return_value = _VISUAL_DEGREES
 
     def _look_at(stimuli, number_of_trials=1):
         n = len(stimuli)
+        if num_timebins > 1:
+            data = np.zeros((n, num_features, num_timebins))
+            return xr.DataArray(
+                data,
+                dims=['presentation', 'neuroid', 'time_bin'],
+                coords={
+                    'stimulus_id': ('presentation', stimuli['stimulus_id'].values),
+                    'neuroid_id': ('neuroid', np.arange(num_features)),
+                    'time_bin': np.arange(num_timebins),
+                },
+            )
         data = np.zeros((n, num_features))
         return xr.DataArray(
             data,
@@ -443,34 +456,57 @@ class TestCalibratedFormula(unittest.TestCase):
         self.assertAlmostEqual(est.total_estimated_gb,
                                est.activation_gb * _OVERHEAD_FACTOR, places=5)
 
-    def test_temporal_pls_inflates_estimate_by_fixed_multiplier(self):
-        """MajajHong2015public.{V4,IT}-temporal-pls under-predicted the OOM
-        threshold by ~5× on production canaries (task #48) because temporal
-        PLS retains per-timebin intermediates that the regular PLS overhead
-        formula doesn't account for. Multiply the PLS estimate by a fixed
-        constant (_TEMPORAL_PLS_MULTIPLIER) and tag formula_type so the
-        sentinel parser can surface the correction in the email."""
+    def test_temporal_pls_scales_estimate_by_num_timebins(self):
+        """Temporal PLS retains per-timebin intermediates that the regular
+        PLS overhead formula doesn't account for, so peak memory grows
+        linearly with the actual number of timebins probed. A fixed constant
+        is wrong because temporal benchmarks may have anywhere from 2 to
+        dozens of timebins — scale by what we measure at preflight time.
+
+        Driven by infrastructure #48 (MajajHong2015public.{V4,IT}-temporal-pls
+        OOMing on small tier despite the preflight saying it would fit)."""
         bm = _make_neural_benchmark(n_stimuli=10)
         bm._identifier = 'MajajHong2015public.IT-temporal-pls'
-        model = _make_model(num_features=512)
-        # Calibrated cost present (would normally feed into the PLS formula).
+        # Mock model returns a probe output with 10 timebins so the preflight
+        # picks ``num_timebins=10`` via probe_output.sizes['time_bin'].
+        model = _make_model(num_features=512, num_timebins=10)
         save_calibration({'MajajHong2015public.IT-temporal-pls': 1.5}, self._cal_path)
         est = self._estimate(bm, model, cal_path=self._cal_path)
 
+        # activation_gb already accounts for the 10 timebins via the bytes
+        # formula. The temporal-pls correction multiplies the *full* PLS
+        # estimate by num_timebins on top of that.
         expected_pls = est.activation_gb * _PLS_OVERHEAD_FACTOR + 1.5
-        expected_total = expected_pls * _TEMPORAL_PLS_MULTIPLIER
-        self.assertAlmostEqual(est.total_estimated_gb, expected_total, places=5)
+        expected_total = expected_pls * 10
+        self.assertAlmostEqual(est.total_estimated_gb, expected_total, places=4)
         self.assertEqual(est.formula_type, 'temporal_pls')
-        # Regular PLS path stays unchanged — same shape benchmark but with
-        # a non-temporal identifier should NOT have the multiplier applied.
+        self.assertEqual(est.num_timebins, 10)
+
+        # Different timebin count → different multiplier. A 3-timebin probe
+        # produces a 3× multiplier, not 10×.
+        bm3 = _make_neural_benchmark(n_stimuli=10)
+        bm3._identifier = 'MajajHong2015public.V4-temporal-pls'
+        model3 = _make_model(num_features=512, num_timebins=3)
+        save_calibration({'MajajHong2015public.V4-temporal-pls': 1.5}, self._cal_path)
+        est3 = self._estimate(bm3, model3, cal_path=self._cal_path)
+        expected3 = (est3.activation_gb * _PLS_OVERHEAD_FACTOR + 1.5) * 3
+        self.assertAlmostEqual(est3.total_estimated_gb, expected3, places=4)
+        self.assertEqual(est3.num_timebins, 3)
+
+    def test_pls_single_timebin_skips_temporal_multiplier(self):
+        """Single-window PLS benchmarks (MajajHong2015.IT-pls etc.) must
+        stay on the regular PLS formula. The temporal multiplier only fires
+        when ``num_timebins > 1`` so single-timebin PLS is unchanged."""
+        bm = _make_neural_benchmark(n_stimuli=10)
         bm._identifier = 'MajajHong2015.IT-pls'
-        est_reg = self._estimate(bm, model, fixed_cost=1.5)
+        model = _make_model(num_features=512, num_timebins=1)
+        est = self._estimate(bm, model, fixed_cost=1.5)
+        self.assertEqual(est.formula_type, 'pls')
         self.assertAlmostEqual(
-            est_reg.total_estimated_gb,
-            est_reg.activation_gb * _PLS_OVERHEAD_FACTOR + 1.5,
+            est.total_estimated_gb,
+            est.activation_gb * _PLS_OVERHEAD_FACTOR + 1.5,
             places=5,
         )
-        self.assertEqual(est_reg.formula_type, 'pls')
 
     def test_oom_detected_with_calibrated_formula(self):
         bm = _make_neural_benchmark(n_stimuli=10)

--- a/tests/test_plugin_management/test_memory_precheck.py
+++ b/tests/test_plugin_management/test_memory_precheck.py
@@ -25,6 +25,7 @@ from brainscore_vision.benchmark_helpers.memory import (
     MemoryEstimate,
     _OVERHEAD_FACTOR,
     _PLS_OVERHEAD_FACTOR,
+    _TEMPORAL_PLS_MULTIPLIER,
     _BYTES_PER_ELEMENT,
     _DEFAULT_CALIBRATION_PATH,
     preallocate_memory,
@@ -441,6 +442,35 @@ class TestCalibratedFormula(unittest.TestCase):
         self.assertIsNone(est.fixed_benchmark_cost_gb)
         self.assertAlmostEqual(est.total_estimated_gb,
                                est.activation_gb * _OVERHEAD_FACTOR, places=5)
+
+    def test_temporal_pls_inflates_estimate_by_fixed_multiplier(self):
+        """MajajHong2015public.{V4,IT}-temporal-pls under-predicted the OOM
+        threshold by ~5× on production canaries (task #48) because temporal
+        PLS retains per-timebin intermediates that the regular PLS overhead
+        formula doesn't account for. Multiply the PLS estimate by a fixed
+        constant (_TEMPORAL_PLS_MULTIPLIER) and tag formula_type so the
+        sentinel parser can surface the correction in the email."""
+        bm = _make_neural_benchmark(n_stimuli=10)
+        bm._identifier = 'MajajHong2015public.IT-temporal-pls'
+        model = _make_model(num_features=512)
+        # Calibrated cost present (would normally feed into the PLS formula).
+        save_calibration({'MajajHong2015public.IT-temporal-pls': 1.5}, self._cal_path)
+        est = self._estimate(bm, model, cal_path=self._cal_path)
+
+        expected_pls = est.activation_gb * _PLS_OVERHEAD_FACTOR + 1.5
+        expected_total = expected_pls * _TEMPORAL_PLS_MULTIPLIER
+        self.assertAlmostEqual(est.total_estimated_gb, expected_total, places=5)
+        self.assertEqual(est.formula_type, 'temporal_pls')
+        # Regular PLS path stays unchanged — same shape benchmark but with
+        # a non-temporal identifier should NOT have the multiplier applied.
+        bm._identifier = 'MajajHong2015.IT-pls'
+        est_reg = self._estimate(bm, model, fixed_cost=1.5)
+        self.assertAlmostEqual(
+            est_reg.total_estimated_gb,
+            est_reg.activation_gb * _PLS_OVERHEAD_FACTOR + 1.5,
+            places=5,
+        )
+        self.assertEqual(est_reg.formula_type, 'pls')
 
     def test_oom_detected_with_calibrated_formula(self):
         bm = _make_neural_benchmark(n_stimuli=10)


### PR DESCRIPTION
Closes infrastructure #48.

`MajajHong2015public.{V4,IT}-temporal-pls` under-predicted peak memory by ~5x on production canaries — temporal PLS fits the regression once per time-bin and retains the per-timebin intermediate matrices, so peak memory scales linearly with `num_timebins`. The regular PLS overhead formula doesn't account for that, so containers OOM'd on the small tier before the orchestrator could escalate.

Fix:
- When PLS, multiply the standard formula (activation × `_PLS_OVERHEAD_FACTOR` + fixed_cost) by `num_timebins` whenever the probe output has more than one timebin.
- Detection by `num_timebins > 1` rather than the `-temporal-pls` substring so any multi-timebin PLS benchmark gets the right estimate.
- Tag `formula_type='temporal_pls'` so the sentinel + email show the correction.
- Single-window PLS benchmarks (`MajajHong2015.IT-pls` etc.) are unchanged — the multiplier is a no-op when `num_timebins == 1`.

Tests verify two timebin counts (10 and 3) on the same benchmark shape to pin the linear scaling, plus a third assertion that single-timebin PLS skips the multiplier entirely.