### PR TITLE
submission: move call_jenkins_vision_gated out of endpoints.py to avoid DB-connect at import

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -274,8 +274,12 @@ jobs:
           python -m pip install "."
 
       - name: Run scoring
+        # Import the trigger from the lightweight ``submission.jenkins`` module
+        # rather than ``submission.endpoints``. The latter instantiates
+        # RunScoringEndpoint at import time → connects to the prod DB →
+        # NoCredentialsError on this runner.
         run: |
-          python -c 'from brainscore_vision.submission.endpoints import call_jenkins_vision_gated; call_jenkins_vision_gated('\''${{ env.PLUGIN_INFO }}'\'')'
+          python -c 'from brainscore_vision.submission.jenkins import call_jenkins_vision_gated; call_jenkins_vision_gated('\''${{ env.PLUGIN_INFO }}'\'')'
 
   process_metadata:
     name: Process metadata changes

--- a/brainscore_vision/submission/endpoints.py
+++ b/brainscore_vision/submission/endpoints.py
@@ -41,37 +41,14 @@ def send_email_to_submitter(uid: int, domain: str, pr_number: str,
                                  mail_username=mail_username, mail_password=mail_password)
 
 
-def call_jenkins_vision_gated(plugin_info: Union[str, Dict[str, Union[List[str], str]]]):
-    """Trigger the ``core/job/gated_score_plugins`` Jenkins job for vision submissions.
-
-    Mirrors :func:`brainscore_core.submission.endpoints.call_jenkins` but routes
-    to the gated orchestrator (`brainscore-scoring` CLI) instead of the legacy
-    ``dev_score_plugins`` bash pipeline. Owning the trigger here lets vision
-    cut over independently of language, which keeps its own
-    :func:`call_jenkins_language` override in brain-score/language.
-    """
-    import json
-    import os
-    import requests
-    from requests.auth import HTTPBasicAuth
-
-    jenkins_base = "http://www.brain-score-jenkins.com:8080"
-    jenkins_user = os.environ['JENKINS_USER']
-    jenkins_token = os.environ['JENKINS_TOKEN']
-    jenkins_trigger = os.environ['JENKINS_TRIGGER']
-    jenkins_job = "core/job/gated_score_plugins"
-
-    url = f'{jenkins_base}/job/{jenkins_job}/buildWithParameters?token={jenkins_trigger}'
-
-    if isinstance(plugin_info, str):
-        plugin_info = json.loads(plugin_info)
-
-    payload = {k: v for k, v in plugin_info.items() if plugin_info[k]}
-    try:
-        auth_basic = HTTPBasicAuth(username=jenkins_user, password=jenkins_token)
-        requests.get(url, params=payload, auth=auth_basic)
-    except Exception as e:
-        print(f'Could not initiate Jenkins job because of {e}')
+# NOTE: ``call_jenkins_vision_gated`` used to live here, but importing this
+# module instantiates ``RunScoringEndpoint`` at line 23, which connects to
+# the production DB and therefore requires AWS credentials. The GitHub
+# Actions runner that triggers the post-merge Jenkins build has no AWS
+# access (by design), so the trigger function was moved to
+# ``brainscore_vision.submission.jenkins`` where it can be imported by
+# CI without dragging in any DB side effects. Update workflow imports
+# to ``from brainscore_vision.submission.jenkins import call_jenkins_vision_gated``.
 
 
 if __name__ == '__main__':

--- a/brainscore_vision/submission/jenkins.py
+++ b/brainscore_vision/submission/jenkins.py
@@ -1,0 +1,50 @@
+"""Standalone Jenkins-trigger entrypoint for vision submissions.
+
+Lives apart from :mod:`brainscore_vision.submission.endpoints` on purpose:
+that module instantiates ``RunScoringEndpoint`` at import time, which connects
+to the production DB and therefore requires AWS credentials. The GitHub
+Actions runner that fires the post-merge scoring trigger has no AWS access
+(by design — its only job is to POST to Jenkins), so importing the heavyweight
+module from CI fails with ``NoCredentialsError`` before the trigger function
+even runs.
+
+Mirrors the pattern used by ``brainscore_language.submission.endpoints`` where
+``call_jenkins_language`` lives alongside lightweight code that doesn't touch
+the DB at import.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List, Union
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+def call_jenkins_vision_gated(plugin_info: Union[str, Dict[str, Union[List[str], str]]]) -> None:
+    """Trigger the ``core/job/gated_score_plugins`` Jenkins job for vision submissions.
+
+    Mirrors :func:`brainscore_core.submission.endpoints.call_jenkins` but routes
+    to the gated orchestrator (``brainscore-scoring`` CLI) instead of the legacy
+    ``dev_score_plugins`` bash pipeline. Owning the trigger inside vision lets
+    this domain cut over independently of language, which keeps its own
+    :func:`call_jenkins_language` override in brain-score/language.
+    """
+    jenkins_base = "http://www.brain-score-jenkins.com:8080"
+    jenkins_user = os.environ['JENKINS_USER']
+    jenkins_token = os.environ['JENKINS_TOKEN']
+    jenkins_trigger = os.environ['JENKINS_TRIGGER']
+    jenkins_job = "core/job/gated_score_plugins"
+
+    url = f'{jenkins_base}/job/{jenkins_job}/buildWithParameters?token={jenkins_trigger}'
+
+    if isinstance(plugin_info, str):
+        plugin_info = json.loads(plugin_info)
+
+    payload = {k: v for k, v in plugin_info.items() if plugin_info[k]}
+    try:
+        auth_basic = HTTPBasicAuth(username=jenkins_user, password=jenkins_token)
+        requests.get(url, params=payload, auth=auth_basic)
+    except Exception as e:
+        print(f'Could not initiate Jenkins job because of {e}')


### PR DESCRIPTION
Follow-up to #2415. The first post-cutover model submission merge failed at the `Run scoring` step with `NoCredentialsError: Unable to locate credentials`, before `call_jenkins_vision_gated` even ran.

Cause: importing `brainscore_vision.submission.endpoints` executes
```python
run_scoring_endpoint = RunScoringEndpoint(vision_plugins, db_secret=config.get_database_secret())
```
at module level, which connects to Secrets Manager → prod DB. The GHA runner that posts to Jenkins has no AWS credentials and shouldn't need them.

Fix: move `call_jenkins_vision_gated` to a new lightweight module `brainscore_vision/submission/jenkins.py` containing only the function and its small imports. Workflow updated to import from there. A breadcrumb comment in the old location points future readers at the new module so this trap isn't re-laid.

Mirrors the language repo's pattern: `call_jenkins_language` already lives apart from any DB-touching code, which is why language's equivalent GHA step doesn't hit this.

Verified locally that the new module imports cleanly with `AWS_*` and `BSC_DATABASESECRET` unset.