### PR TITLE
submission: map plugin_info keys to gated Jenkinsfile parameter names

### DIFF
--- a/brainscore_vision/submission/jenkins.py
+++ b/brainscore_vision/submission/jenkins.py
@@ -22,6 +22,28 @@ import requests
 from requests.auth import HTTPBasicAuth
 
 
+# The GHA workflow's ``plugin_info`` payload uses the lowercase parameter
+# names the legacy ``dev_score_plugins`` freestyle job exposed (``email``,
+# ``new_models`` etc). The gated pipeline's Jenkinsfile (``scoring/Jenkinsfile``
+# in brain-score/infrastructure) declares uppercase string parameters
+# (``AUTHOR_EMAIL``, ``NEW_MODELS`` etc), so the lowercase payload keys would
+# get silently dropped and the Validate stage trips on the empty AUTHOR_EMAIL.
+# Translate at the trigger boundary — the Jenkinsfile's contract is the
+# stable one and shouldn't be loosened just because the legacy GHA payload
+# spells things differently.
+_PLUGIN_INFO_TO_JENKINS_PARAM = {
+    "email": "AUTHOR_EMAIL",
+    "new_models": "NEW_MODELS",
+    "new_benchmarks": "NEW_BENCHMARKS",
+    "user_id": "USER_ID",
+    "public": "PUBLIC",
+    "domain": "DOMAIN",
+    "competition": "COMPETITION",
+    "specified_only": "SPECIFIED_ONLY",
+    "disable_gates": "DISABLE_GATES",
+}
+
+
 def call_jenkins_vision_gated(plugin_info: Union[str, Dict[str, Union[List[str], str]]]) -> None:
     """Trigger the ``core/job/gated_score_plugins`` Jenkins job for vision submissions.
 
@@ -42,7 +64,16 @@ def call_jenkins_vision_gated(plugin_info: Union[str, Dict[str, Union[List[str],
     if isinstance(plugin_info, str):
         plugin_info = json.loads(plugin_info)
 
-    payload = {k: v for k, v in plugin_info.items() if plugin_info[k]}
+    # Drop empty values (matches legacy behaviour) and rename to the
+    # Jenkinsfile-declared parameter names; pass any unrecognised keys
+    # through unchanged so future Jenkinsfile additions don't require a
+    # parallel update here.
+    payload = {}
+    for key, value in plugin_info.items():
+        if not value:
+            continue
+        payload[_PLUGIN_INFO_TO_JENKINS_PARAM.get(key, key)] = value
+
     try:
         auth_basic = HTTPBasicAuth(username=jenkins_user, password=jenkins_token)
         requests.get(url, params=payload, auth=auth_basic)


### PR DESCRIPTION
Follow-up to #2415 / #2424 — first real trigger after the cutover failed at the Jenkins Validate stage with `ERROR: AUTHOR_EMAIL is required`.

Cause: GHA workflow's `plugin_info` JSON uses the lowercase parameter names that the legacy `dev_score_plugins` freestyle job accepted (`email`, `new_models`, `user_id`, `public`, `domain`, `competition`). The new `gated_score_plugins` Jenkinsfile (in brain-score/infrastructure) declares its parameters as uppercase strings (`AUTHOR_EMAIL`, `NEW_MODELS`, `USER_ID`, etc.). Jenkins' `buildWithParameters` silently drops unrecognised keys, so every required param landed empty and Validate tripped on the first one.

Translate at the trigger boundary — the Jenkinsfile contract is the stable surface and shouldn't be loosened. A small translation map covers the seven legacy keys; anything not in the map passes through unchanged so future Jenkinsfile additions don't require a parallel update here.

Verified locally that the translated payload matches the Jenkinsfile's declared param names exactly.