### PR TITLE
preflight: emit sentinel even when preallocate_memory skips

### DIFF
--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -165,6 +165,30 @@ def save_calibration(costs: dict, path: Optional[str] = None) -> None:
     _logger.info(f"Calibration saved → {path}  ({len(costs)} benchmarks)")
 
 
+def _emit_skipped_preflight(benchmark, reason: str) -> None:
+    """Emit a ``BRAINSCORE_PREFLIGHT`` sentinel for paths that don't compute
+    an estimate (env-skip, unsupported benchmark type).
+
+    Keeps the parser-side schema consistent — the orchestrator now sees a
+    sentinel for every preallocate_memory call, with ``estimate_gb=null`` and
+    ``formula_type='skipped'`` distinguishing "tried, no estimate" from
+    "container was too old to even attempt" (which leaves preflight_*
+    columns NULL in the DB).
+    """
+    payload = {
+        'estimate_gb': None,
+        'available_gb': None,
+        'formula_type': 'skipped',
+        'will_oom': False,
+        'num_features': None,
+        'num_stimuli': None,
+        'reason': reason,
+        'benchmark_identifier': str(getattr(benchmark, 'identifier', '')) or None,
+        'benchmark_type': type(benchmark).__name__,
+    }
+    print(f"BRAINSCORE_PREFLIGHT {json.dumps(payload)}", flush=True)
+
+
 def _is_pls_benchmark(benchmark) -> bool:
     """Return True if the benchmark uses PLS regression.
 
@@ -283,6 +307,7 @@ def preallocate_memory(
     """
     if os.environ.get('BRAINSCORE_SKIP_MEMORY_CHECK', '0') == '1':
         _logger.debug("BRAINSCORE_SKIP_MEMORY_CHECK is set — skipping memory pre-check.")
+        _emit_skipped_preflight(benchmark, reason='env_skip')
         return None
 
     # ------------------------------------------------------------------ #
@@ -322,6 +347,12 @@ def preallocate_memory(
         _logger.debug(
             f"preallocate_memory: unsupported benchmark type {type(benchmark).__name__}, skipping."
         )
+        # Still emit a sentinel so the resource-usage row records that
+        # preflight WAS attempted (formula_type=skipped, estimate=null).
+        # Without this, behavioral / engineering / wrapper benchmarks land
+        # in the DB with preflight_formula_type=NULL — indistinguishable
+        # from older container images where preflight wasn't wired up.
+        _emit_skipped_preflight(benchmark, reason='unsupported_benchmark_type')
         return None
 
     # ------------------------------------------------------------------ #

--- a/tests/test_plugin_management/test_memory_precheck.py
+++ b/tests/test_plugin_management/test_memory_precheck.py
@@ -313,6 +313,59 @@ class TestUnsupportedBenchmarkType(unittest.TestCase):
         model = _make_model()
         self.assertIsNone(preallocate_memory(model, WeirdBenchmark()))
 
+    def test_unsupported_benchmark_emits_skipped_sentinel(self):
+        """Behavioral / engineering / wrapper benchmarks return None from
+        preallocate_memory because they don't have an activation-based
+        formula. They must still emit a BRAINSCORE_PREFLIGHT sentinel with
+        ``formula_type='skipped'`` so the downstream ResourceUsage row
+        records that preflight WAS attempted on this run -- distinguishing
+        it from older container images where preflight was never wired up
+        (which leaves the column NULL). Surfaced in infrastructure #48
+        diagnosis where 17/26 production rows had a NULL
+        preflight_formula_type for exactly this reason."""
+        class BehavioralBenchmark:
+            identifier = 'Geirhos2021edge-error_consistency'
+
+        model = _make_model()
+        with patch('builtins.print') as mock_print:
+            result = preallocate_memory(model, BehavioralBenchmark())
+
+        self.assertIsNone(result)
+        # The sentinel goes to stdout via print() -- inspect the captured calls.
+        sentinel_lines = [
+            args[0] for (args, kwargs) in mock_print.call_args_list
+            if args and isinstance(args[0], str)
+            and args[0].startswith('BRAINSCORE_PREFLIGHT')
+        ]
+        self.assertEqual(len(sentinel_lines), 1,
+                         f"expected one preflight sentinel, got {sentinel_lines}")
+        payload = json.loads(sentinel_lines[0].split(' ', 1)[1])
+        self.assertEqual(payload['formula_type'], 'skipped')
+        self.assertEqual(payload['reason'], 'unsupported_benchmark_type')
+        self.assertEqual(payload['benchmark_type'], 'BehavioralBenchmark')
+        self.assertIsNone(payload['estimate_gb'])
+        self.assertFalse(payload['will_oom'])
+
+    def test_env_skip_also_emits_skipped_sentinel(self):
+        """BRAINSCORE_SKIP_MEMORY_CHECK=1 short-circuits preflight, but the
+        sentinel still goes out so the row records that the path was
+        traversed and intentionally bypassed."""
+        bm = _make_neural_benchmark()
+        model = _make_model()
+        with patch.dict(os.environ, {'BRAINSCORE_SKIP_MEMORY_CHECK': '1'}):
+            with patch('builtins.print') as mock_print:
+                result = preallocate_memory(model, bm, raise_if_oom=False)
+        self.assertIsNone(result)
+        sentinel_lines = [
+            args[0] for (args, kwargs) in mock_print.call_args_list
+            if args and isinstance(args[0], str)
+            and args[0].startswith('BRAINSCORE_PREFLIGHT')
+        ]
+        self.assertEqual(len(sentinel_lines), 1)
+        payload = json.loads(sentinel_lines[0].split(' ', 1)[1])
+        self.assertEqual(payload['formula_type'], 'skipped')
+        self.assertEqual(payload['reason'], 'env_skip')
+
 
 # ---------------------------------------------------------------------------
 # TestTrainTestNeuralBenchmark


### PR DESCRIPTION
Cause: `preallocate_memory` silently returns None from two paths:
- `BRAINSCORE_SKIP_MEMORY_CHECK=1`
- "unsupported benchmark type" (behavioral / engineering / wrapper benchmarks that don't have an activation-based formula)

Neither path emits a `BRAINSCORE_PREFLIGHT` sentinel, so the downstream parser sees nothing and the DB columns land NULL. That's indistinguishable from older containers where the preflight wasn't wired in at all.

Emit a sentinel on both paths with `formula_type='skipped'`, `estimate_gb=null`, and a `reason` field (`env_skip` or `unsupported_benchmark_type`). Parser-side schema unchanged — it already reads `formula_type` as a string. Future ResourceUsage rows will show `'skipped'` explicitly, distinguishing "preflight ran and bailed" from "preflight never ran".

Two new tests pin the sentinel payload for both skip paths.