### PR TITLE
memory_precheck: per-benchmark scaffolding overhead correction

### DIFF
--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -63,25 +63,9 @@ _OVERHEAD_FACTOR = 6
 #   worst miss after fix: resnet50 × Cadena2017-pls  →  -12.7%  (within 15%)
 _PLS_OVERHEAD_FACTOR = 7
 
-# Per-benchmark scaffolding overhead the formula misses. Generated from the
-# brainscore_resource_usage table (production) on 2026-06-21 over ~1500 rows:
-#
-#   overhead_gb = median(actual_peak_when_successful) - median(formula_estimate)
-#
-# Only benchmarks where the delta exceeds 2 GB are listed (a smaller
-# correction wouldn't change tier selection). Most entries are recent
-# neural benchmarks the formula was never calibrated for (Zerbe2026,
-# Papale2025, parts of Allen2022). Regenerate via:
-#
-#   SELECT benchmark_id_str,
-#          round((p50_peak - p50_estimate)::numeric, 1)
-#   FROM (...)  -- see scoring fix PR for full query
-#
-# When the formula itself is restructured (e.g. to include brain-assembly
-# residency directly), most entries here become 0 and can be removed.
+# Empirical p50(real_peak) - p50(formula_estimate) per benchmark, GB.
+# Papale2025.V4-ridgecv omitted: dinov2-only data would over-allocate small models.
 _BENCHMARK_SCAFFOLDING_OVERHEAD_GB: dict[str, float] = {
-    # very-large under-estimators (Zerbe2026 ridgecv variants; brain-assembly
-    # tensors are large and held throughout)
     'Zerbe2026_fmri.V1-tau-ridgecv': 42.0,
     'Gifford2022.IT-ridgecv': 20.0,
     'Zerbe2026_fmri.V1-rdm-pearson': 19.0,
@@ -95,7 +79,6 @@ _BENCHMARK_SCAFFOLDING_OVERHEAD_GB: dict[str, float] = {
     'Zerbe2026_fmri.V2-rdm-pearson': 11.8,
     'Zerbe2026_fmri.V4-rdm-pearson': 11.8,
     'Zerbe2026_fmri.IT-rdm-pearson': 10.5,
-    # medium under-estimators
     'MajajHong2015public.IT-reverse_pls': 8.7,
     'FreemanZiemba2013.V1-pls': 7.6,
     'Papale2025.IT-ridgecv': 7.6,
@@ -104,19 +87,12 @@ _BENCHMARK_SCAFFOLDING_OVERHEAD_GB: dict[str, float] = {
     'Hebart2023_fmri.IT-ridgecv': 6.2,
     'FreemanZiemba2013.V2-pls': 5.6,
     'Allen2022_fmri_surface.V2-ridge': 4.7,
-    # small under-estimators (still meaningful for small-tier sizing)
     'MajajHong2015.V4-pls': 3.9,
     'Allen2022_fmri_surface.V4-ridge': 3.8,
     'Allen2022_fmri_surface.IT-ridge': 3.6,
     'Allen2022_fmri_surface.V4-rdm': 3.0,
     'Allen2022_fmri_surface.V2-rdm': 2.9,
     'Allen2022_fmri_surface.IT-rdm': 2.7,
-    # Papale2025.V4-ridgecv intentionally OMITTED: production data only
-    # has successful peaks from dinov2-at-large (126 GB). Adding a 57 GB
-    # scaffolding offset would force every model (including ~5 GB activation
-    # alexnet runs) directly to xlarge tier. Wait for more model-class
-    # coverage before correcting this entry; Fix 4's retry escalation
-    # handles the current over-estimation issue cheaply.
 }
 
 # For temporal-PLS benchmarks (e.g. MajajHong2015public.{V4,IT}-temporal-pls)
@@ -564,20 +540,7 @@ def preallocate_memory(
         total_estimated_gb = activation_gb * _OVERHEAD_FACTOR
         formula_type = 'fallback'
 
-    # Per-benchmark scaffolding overhead correction. Production data from
-    # ~1500 brainscore_resource_usage rows showed the formula systematically
-    # UNDER-estimates for neural benchmarks by 3-18x — driving the OS to
-    # kill containers (numpy ArrayMemoryError, ~217 cases on 2026-06-21
-    # snapshot) before the preflight check ever fired. The pattern is
-    # that the formula captures activation + algorithm overhead but
-    # misses brain-assembly residency, scoring scaffolding, and dataset
-    # caching that scale per-benchmark, not per-model.
-    #
-    # Correction = observed_p50(real_peak) - observed_p50(formula_estimate)
-    # clamped at 0. Added (not multiplied) so it captures the missing
-    # CONSTANT scaffolding without amplifying the formula's model-size
-    # scaling. Regenerate with the SQL in the PR description after another
-    # ~50 submissions land.
+    # Empirical per-benchmark scaffolding the formula misses (see table above).
     bench_id = str(getattr(benchmark, 'identifier', '') or '')
     overhead_gb = _BENCHMARK_SCAFFOLDING_OVERHEAD_GB.get(bench_id, 0.0)
     if overhead_gb > 0:

--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -63,6 +63,62 @@ _OVERHEAD_FACTOR = 6
 #   worst miss after fix: resnet50 × Cadena2017-pls  →  -12.7%  (within 15%)
 _PLS_OVERHEAD_FACTOR = 7
 
+# Per-benchmark scaffolding overhead the formula misses. Generated from the
+# brainscore_resource_usage table (production) on 2026-06-21 over ~1500 rows:
+#
+#   overhead_gb = median(actual_peak_when_successful) - median(formula_estimate)
+#
+# Only benchmarks where the delta exceeds 2 GB are listed (a smaller
+# correction wouldn't change tier selection). Most entries are recent
+# neural benchmarks the formula was never calibrated for (Zerbe2026,
+# Papale2025, parts of Allen2022). Regenerate via:
+#
+#   SELECT benchmark_id_str,
+#          round((p50_peak - p50_estimate)::numeric, 1)
+#   FROM (...)  -- see scoring fix PR for full query
+#
+# When the formula itself is restructured (e.g. to include brain-assembly
+# residency directly), most entries here become 0 and can be removed.
+_BENCHMARK_SCAFFOLDING_OVERHEAD_GB: dict[str, float] = {
+    # very-large under-estimators (Zerbe2026 ridgecv variants; brain-assembly
+    # tensors are large and held throughout)
+    'Zerbe2026_fmri.V1-tau-ridgecv': 42.0,
+    'Gifford2022.IT-ridgecv': 20.0,
+    'Zerbe2026_fmri.V1-rdm-pearson': 19.0,
+    'Zerbe2026_fmri.V2-ood-ridgecv': 16.5,
+    'Zerbe2026_fmri.V2-tau-ridgecv': 15.8,
+    'Zerbe2026_fmri.V4-ood-ridgecv': 14.4,
+    'Zerbe2026_fmri.V4-tau-ridgecv': 13.7,
+    'Zerbe2026_fmri.IT-tau-ridgecv': 13.7,
+    'Zerbe2026_fmri.IT-ood-ridgecv': 13.7,
+    'Allen2022_fmri_surface.V1-ridge': 12.4,
+    'Zerbe2026_fmri.V2-rdm-pearson': 11.8,
+    'Zerbe2026_fmri.V4-rdm-pearson': 11.8,
+    'Zerbe2026_fmri.IT-rdm-pearson': 10.5,
+    # medium under-estimators
+    'MajajHong2015public.IT-reverse_pls': 8.7,
+    'FreemanZiemba2013.V1-pls': 7.6,
+    'Papale2025.IT-ridgecv': 7.6,
+    'Sanghavi2020.V4-pls': 7.4,
+    'Allen2022_fmri_surface.V1-rdm': 6.4,
+    'Hebart2023_fmri.IT-ridgecv': 6.2,
+    'FreemanZiemba2013.V2-pls': 5.6,
+    'Allen2022_fmri_surface.V2-ridge': 4.7,
+    # small under-estimators (still meaningful for small-tier sizing)
+    'MajajHong2015.V4-pls': 3.9,
+    'Allen2022_fmri_surface.V4-ridge': 3.8,
+    'Allen2022_fmri_surface.IT-ridge': 3.6,
+    'Allen2022_fmri_surface.V4-rdm': 3.0,
+    'Allen2022_fmri_surface.V2-rdm': 2.9,
+    'Allen2022_fmri_surface.IT-rdm': 2.7,
+    # Papale2025.V4-ridgecv intentionally OMITTED: production data only
+    # has successful peaks from dinov2-at-large (126 GB). Adding a 57 GB
+    # scaffolding offset would force every model (including ~5 GB activation
+    # alexnet runs) directly to xlarge tier. Wait for more model-class
+    # coverage before correcting this entry; Fix 4's retry escalation
+    # handles the current over-estimation issue cheaply.
+}
+
 # For temporal-PLS benchmarks (e.g. MajajHong2015public.{V4,IT}-temporal-pls)
 # the PLS regression is fit once per time-bin and the per-timebin intermediate
 # matrices are retained simultaneously, so peak memory grows by an additional
@@ -507,6 +563,25 @@ def preallocate_memory(
     else:
         total_estimated_gb = activation_gb * _OVERHEAD_FACTOR
         formula_type = 'fallback'
+
+    # Per-benchmark scaffolding overhead correction. Production data from
+    # ~1500 brainscore_resource_usage rows showed the formula systematically
+    # UNDER-estimates for neural benchmarks by 3-18x — driving the OS to
+    # kill containers (numpy ArrayMemoryError, ~217 cases on 2026-06-21
+    # snapshot) before the preflight check ever fired. The pattern is
+    # that the formula captures activation + algorithm overhead but
+    # misses brain-assembly residency, scoring scaffolding, and dataset
+    # caching that scale per-benchmark, not per-model.
+    #
+    # Correction = observed_p50(real_peak) - observed_p50(formula_estimate)
+    # clamped at 0. Added (not multiplied) so it captures the missing
+    # CONSTANT scaffolding without amplifying the formula's model-size
+    # scaling. Regenerate with the SQL in the PR description after another
+    # ~50 submissions land.
+    bench_id = str(getattr(benchmark, 'identifier', '') or '')
+    overhead_gb = _BENCHMARK_SCAFFOLDING_OVERHEAD_GB.get(bench_id, 0.0)
+    if overhead_gb > 0:
+        total_estimated_gb += overhead_gb
 
     available_gb = psutil.virtual_memory().available / (1024 ** 3)
 

--- a/tests/test_plugin_management/test_memory_precheck.py
+++ b/tests/test_plugin_management/test_memory_precheck.py
@@ -684,3 +684,87 @@ class TestCalibratedIntegration(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestBenchmarkScaffoldingOverhead(unittest.TestCase):
+    """Per-benchmark overhead correction (Brain-Score infrastructure 2026-06-21).
+
+    Production data showed the formula systematically under-estimates for
+    neural benchmarks -- driving 217+ silent OS-OOM kills (numpy
+    ArrayMemoryError, classified as UNKNOWN failure_kind pre-fix). The
+    correction adds an observed delta on top of the formula based on real
+    cgroup peak measurements.
+
+    These tests pin: (a) the correction fires when benchmark_id matches an
+    entry in the table; (b) it adds rather than multiplies; (c) it doesn't
+    fire for benchmarks not in the table; (d) NEW benchmarks that score
+    quickly through the formula path still get the correction post-hoc."""
+
+    def _estimate(self, bm, model):
+        from brainscore_vision.benchmark_helpers.memory import preallocate_memory
+        with patch('psutil.virtual_memory') as mock_vm:
+            mock_vm.return_value.available = 256 * (1024 ** 3)  # ample headroom
+            with patch('brainscore_vision.benchmark_helpers.memory._DEFAULT_CALIBRATION_PATH',
+                       '/nonexistent'):
+                return preallocate_memory(model, bm, raise_if_oom=False)
+
+    def test_overhead_added_when_benchmark_in_table(self):
+        """Zerbe2026_fmri.V1-tau-ridgecv: production-observed +42 GB delta.
+        Patching the dict so the test isn't tied to a specific table value."""
+        bm = _make_neural_benchmark(n_stimuli=100)
+        bm._identifier = 'Zerbe2026_fmri.V1-tau-ridgecv'
+        model = _make_model(num_features=1024)
+
+        with patch.dict(
+                'brainscore_vision.benchmark_helpers.memory._BENCHMARK_SCAFFOLDING_OVERHEAD_GB',
+                {'Zerbe2026_fmri.V1-tau-ridgecv': 42.0}, clear=False):
+            est = self._estimate(bm, model)
+        baseline = est.activation_gb * _OVERHEAD_FACTOR  # ridge_formula path
+        # Total = formula + scaffolding. Looser tolerance because the formula
+        # path uses additive overhead too (rdm_overhead for ridge); we just
+        # require that the +42 lands somewhere in the total.
+        self.assertGreaterEqual(est.total_estimated_gb, baseline + 42.0 - 0.5)
+
+    def test_overhead_not_applied_when_benchmark_missing(self):
+        """A benchmark not in the table gets the formula estimate verbatim --
+        no surprise blow-ups on benchmarks the table doesn't know about."""
+        bm = _make_neural_benchmark(n_stimuli=10)
+        bm._identifier = 'BenchmarkNotInTable-pls'
+        model = _make_model(num_features=512)
+
+        with patch.dict(
+                'brainscore_vision.benchmark_helpers.memory._BENCHMARK_SCAFFOLDING_OVERHEAD_GB',
+                {'Zerbe2026_fmri.V1-tau-ridgecv': 42.0}, clear=True):
+            est = self._estimate(bm, model)
+        # Formula-only: activation_gb × _OVERHEAD_FACTOR (fallback path)
+        self.assertAlmostEqual(est.total_estimated_gb,
+                               est.activation_gb * _OVERHEAD_FACTOR, places=4)
+
+    def test_zero_overhead_entry_is_no_op(self):
+        """A table entry of 0 must not add anything (clamps the path that
+        only fires when overhead > 0)."""
+        bm = _make_neural_benchmark(n_stimuli=10)
+        bm._identifier = 'BenchmarkWithZero-pls'
+        model = _make_model(num_features=512)
+
+        with patch.dict(
+                'brainscore_vision.benchmark_helpers.memory._BENCHMARK_SCAFFOLDING_OVERHEAD_GB',
+                {'BenchmarkWithZero-pls': 0.0}, clear=False):
+            est = self._estimate(bm, model)
+        self.assertAlmostEqual(est.total_estimated_gb,
+                               est.activation_gb * _OVERHEAD_FACTOR, places=4)
+
+    def test_production_table_has_only_positive_corrections(self):
+        """Sanity: every entry in the shipping table is > 0. Negative entries
+        would reduce the formula estimate -- a strict regression on safety."""
+        from brainscore_vision.benchmark_helpers.memory import _BENCHMARK_SCAFFOLDING_OVERHEAD_GB
+        negative = {k: v for k, v in _BENCHMARK_SCAFFOLDING_OVERHEAD_GB.items() if v <= 0}
+        self.assertEqual(negative, {}, f"Non-positive overhead entries: {negative}")
+
+    def test_production_table_does_not_include_papale_v4_ridgecv(self):
+        """Papale2025.V4-ridgecv is intentionally OMITTED -- production data
+        only has dinov2-at-large peaks for it, so the observed delta would
+        force every model (including small-activation alexnet) to xlarge
+        tier on first try. See docstring comment in memory.py."""
+        from brainscore_vision.benchmark_helpers.memory import _BENCHMARK_SCAFFOLDING_OVERHEAD_GB
+        self.assertNotIn('Papale2025.V4-ridgecv', _BENCHMARK_SCAFFOLDING_OVERHEAD_GB)

--- a/tests/test_plugin_management/test_memory_precheck.py
+++ b/tests/test_plugin_management/test_memory_precheck.py
@@ -687,66 +687,41 @@ if __name__ == '__main__':
 
 
 class TestBenchmarkScaffoldingOverhead(unittest.TestCase):
-    """Per-benchmark overhead correction (Brain-Score infrastructure 2026-06-21).
-
-    Production data showed the formula systematically under-estimates for
-    neural benchmarks -- driving 217+ silent OS-OOM kills (numpy
-    ArrayMemoryError, classified as UNKNOWN failure_kind pre-fix). The
-    correction adds an observed delta on top of the formula based on real
-    cgroup peak measurements.
-
-    These tests pin: (a) the correction fires when benchmark_id matches an
-    entry in the table; (b) it adds rather than multiplies; (c) it doesn't
-    fire for benchmarks not in the table; (d) NEW benchmarks that score
-    quickly through the formula path still get the correction post-hoc."""
 
     def _estimate(self, bm, model):
         from brainscore_vision.benchmark_helpers.memory import preallocate_memory
         with patch('psutil.virtual_memory') as mock_vm:
-            mock_vm.return_value.available = 256 * (1024 ** 3)  # ample headroom
+            mock_vm.return_value.available = 256 * (1024 ** 3)
             with patch('brainscore_vision.benchmark_helpers.memory._DEFAULT_CALIBRATION_PATH',
                        '/nonexistent'):
                 return preallocate_memory(model, bm, raise_if_oom=False)
 
     def test_overhead_added_when_benchmark_in_table(self):
-        """Zerbe2026_fmri.V1-tau-ridgecv: production-observed +42 GB delta.
-        Patching the dict so the test isn't tied to a specific table value."""
         bm = _make_neural_benchmark(n_stimuli=100)
         bm._identifier = 'Zerbe2026_fmri.V1-tau-ridgecv'
         model = _make_model(num_features=1024)
-
         with patch.dict(
                 'brainscore_vision.benchmark_helpers.memory._BENCHMARK_SCAFFOLDING_OVERHEAD_GB',
                 {'Zerbe2026_fmri.V1-tau-ridgecv': 42.0}, clear=False):
             est = self._estimate(bm, model)
-        baseline = est.activation_gb * _OVERHEAD_FACTOR  # ridge_formula path
-        # Total = formula + scaffolding. Looser tolerance because the formula
-        # path uses additive overhead too (rdm_overhead for ridge); we just
-        # require that the +42 lands somewhere in the total.
+        baseline = est.activation_gb * _OVERHEAD_FACTOR
         self.assertGreaterEqual(est.total_estimated_gb, baseline + 42.0 - 0.5)
 
     def test_overhead_not_applied_when_benchmark_missing(self):
-        """A benchmark not in the table gets the formula estimate verbatim --
-        no surprise blow-ups on benchmarks the table doesn't know about."""
         bm = _make_neural_benchmark(n_stimuli=10)
         bm._identifier = 'BenchmarkNotInTable-pls'
         model = _make_model(num_features=512)
-
         with patch.dict(
                 'brainscore_vision.benchmark_helpers.memory._BENCHMARK_SCAFFOLDING_OVERHEAD_GB',
                 {'Zerbe2026_fmri.V1-tau-ridgecv': 42.0}, clear=True):
             est = self._estimate(bm, model)
-        # Formula-only: activation_gb × _OVERHEAD_FACTOR (fallback path)
         self.assertAlmostEqual(est.total_estimated_gb,
                                est.activation_gb * _OVERHEAD_FACTOR, places=4)
 
     def test_zero_overhead_entry_is_no_op(self):
-        """A table entry of 0 must not add anything (clamps the path that
-        only fires when overhead > 0)."""
         bm = _make_neural_benchmark(n_stimuli=10)
         bm._identifier = 'BenchmarkWithZero-pls'
         model = _make_model(num_features=512)
-
         with patch.dict(
                 'brainscore_vision.benchmark_helpers.memory._BENCHMARK_SCAFFOLDING_OVERHEAD_GB',
                 {'BenchmarkWithZero-pls': 0.0}, clear=False):
@@ -755,16 +730,9 @@ class TestBenchmarkScaffoldingOverhead(unittest.TestCase):
                                est.activation_gb * _OVERHEAD_FACTOR, places=4)
 
     def test_production_table_has_only_positive_corrections(self):
-        """Sanity: every entry in the shipping table is > 0. Negative entries
-        would reduce the formula estimate -- a strict regression on safety."""
         from brainscore_vision.benchmark_helpers.memory import _BENCHMARK_SCAFFOLDING_OVERHEAD_GB
-        negative = {k: v for k, v in _BENCHMARK_SCAFFOLDING_OVERHEAD_GB.items() if v <= 0}
-        self.assertEqual(negative, {}, f"Non-positive overhead entries: {negative}")
+        self.assertTrue(all(v > 0 for v in _BENCHMARK_SCAFFOLDING_OVERHEAD_GB.values()))
 
     def test_production_table_does_not_include_papale_v4_ridgecv(self):
-        """Papale2025.V4-ridgecv is intentionally OMITTED -- production data
-        only has dinov2-at-large peaks for it, so the observed delta would
-        force every model (including small-activation alexnet) to xlarge
-        tier on first try. See docstring comment in memory.py."""
         from brainscore_vision.benchmark_helpers.memory import _BENCHMARK_SCAFFOLDING_OVERHEAD_GB
         self.assertNotIn('Papale2025.V4-ridgecv', _BENCHMARK_SCAFFOLDING_OVERHEAD_GB)


### PR DESCRIPTION
Add per-benchmark scaffolding overhead on top of the formula. Production data showed the formula under-estimates by 3-18× for neural benchmarks (Zerbe2026, Allen2022_fmri, etc.) because it misses brain-assembly residency and scoring scaffolding -- caused 217+ silent OS-OOM kills (numpy ArrayMemoryError -> exit 0 -> no retry).

Correction = observed_p50(real_peak) - observed_p50(formula_estimate), clamped at 0, added (not multiplied) so model-size scaling is preserved.

27 entries from the 2026-06-21 `brainscore_resource_usage` snapshot. Papale2025.V4-ridgecv intentionally omitted (dinov2-only data would force small models to xlarge).

45/45 tests pass in test_memory_precheck.py.