### PR TITLE
behavior: clearer error when model logits aren't 1000-dim

### DIFF
--- a/brainscore_vision/__init__.py
+++ b/brainscore_vision/__init__.py
@@ -79,18 +79,25 @@ def _run_score(model_identifier: str, benchmark_identifier: str) -> Score:
     try:
         score: Score = score_benchmark(benchmark, model)
     except AssertionError as e:
-        cache_dir = os.path.expanduser(
-            '~/.result_caching/brainscore_vision.model_helpers.activations.core'
-            '.ActivationsExtractorHelper._from_paths_stored'
-        )
-        raise AssertionError(
-            f"{e}\n\n"
-            f"If this is a stale activations cache (cached stimulus paths no longer match "
-            f"current locations, e.g. temp directory changed between runs), fix with:\n"
-            f"  rm {cache_dir}/identifier={model_identifier},stimuli_identifier=*.pkl\n\n"
-            f"Or to clear the entire activations cache:\n"
-            f"  rm {cache_dir}/*.pkl"
-        ) from e
+        # Only append the cache-clearing hint when the AssertionError actually
+        # looks like a stimulus-path mismatch from a stale activations cache.
+        # Other AssertionErrors (e.g. logits-dim mismatch) have nothing to do
+        # with caching and the hint misleads users into deleting good data.
+        msg = str(e)
+        if 'stimulus' in msg.lower() or 'path' in msg.lower():
+            cache_dir = os.path.expanduser(
+                '~/.result_caching/brainscore_vision.model_helpers.activations.core'
+                '.ActivationsExtractorHelper._from_paths_stored'
+            )
+            raise AssertionError(
+                f"{e}\n\n"
+                f"If this is a stale activations cache (cached stimulus paths no longer match "
+                f"current locations, e.g. temp directory changed between runs), fix with:\n"
+                f"  rm {cache_dir}/identifier={model_identifier},stimuli_identifier=*.pkl\n\n"
+                f"Or to clear the entire activations cache:\n"
+                f"  rm {cache_dir}/*.pkl"
+            ) from e
+        raise
     score.attrs['model_identifier'] = model_identifier
     score.attrs['benchmark_identifier'] = benchmark_identifier
     try:  # attempt to look up the layer commitment if model uses a standard layer model

--- a/brainscore_vision/model_helpers/brain_transformation/behavior.py
+++ b/brainscore_vision/model_helpers/brain_transformation/behavior.py
@@ -45,12 +45,30 @@ class LabelBehavior(BrainModel):
 
     def look_at(self, stimuli, number_of_trials: int = 1, require_variance: bool = False):
         assert self.current_task == BrainModel.Task.label
+        # Probe one stimulus first to catch missing 1000-dim classification
+        # heads before paying full inference (otherwise ~40 min wasted per
+        # attempt on feature-reader submissions). Uses _from_paths directly
+        # to skip the result cache; full run is unaffected.
+        self._probe_logits_dim(stimuli)
         logits = self.activations_model(stimuli, layers=['logits'], number_of_trials=number_of_trials,
                                         require_variance=require_variance)
         choices = self.logits_to_choice(logits)
         return choices
 
-    def logits_to_choice(self, logits):
+    def _probe_logits_dim(self, stimuli):
+        extractor = getattr(self.activations_model, '_extractor', None)
+        if extractor is None or not hasattr(stimuli, 'get_stimulus'):
+            return  # graceful skip — defensive check still fires post-inference
+        try:
+            probe_id = stimuli['stimulus_id'].values[0]
+            probe_path = str(stimuli.get_stimulus(probe_id))
+            probe_output = extractor._from_paths(layers=['logits'], stimuli_paths=[probe_path])
+        except Exception:
+            return  # don't let probe failure break a run; let main path raise
+        self._check_logits_dim(probe_output)
+
+    @staticmethod
+    def _check_logits_dim(logits):
         n = len(logits['neuroid'])
         if n != 1000:
             raise ValueError(
@@ -59,6 +77,9 @@ class LabelBehavior(BrainModel):
                 f"1000-class predictions (feature-extractor-only models cannot run behavioral "
                 f"benchmarks)."
             )
+
+    def logits_to_choice(self, logits):
+        self._check_logits_dim(logits)
         logits = logits.transpose(..., 'neuroid')  # move neuroid dimension last
         extra_coords = {}
         if self.choice_labels == 'imagenet':

--- a/brainscore_vision/model_helpers/brain_transformation/behavior.py
+++ b/brainscore_vision/model_helpers/brain_transformation/behavior.py
@@ -51,7 +51,14 @@ class LabelBehavior(BrainModel):
         return choices
 
     def logits_to_choice(self, logits):
-        assert len(logits['neuroid']) == 1000
+        n = len(logits['neuroid'])
+        if n != 1000:
+            raise ValueError(
+                f"Behavioral benchmarks require a 1000-dim ImageNet classification head, "
+                f"got {n}-dim logits. The model's `logits` layer must output ImageNet "
+                f"1000-class predictions (feature-extractor-only models cannot run behavioral "
+                f"benchmarks)."
+            )
         logits = logits.transpose(..., 'neuroid')  # move neuroid dimension last
         extra_coords = {}
         if self.choice_labels == 'imagenet':


### PR DESCRIPTION
Three small changes for behavioral benchmarks:

1. `logits_to_choice` replaces the bare assert with a ValueError that names the actual mismatch ("got N-dim logits, need 1000").
2. `look_at` now probes the model with one stimulus first via the extractor's cache-bypassing `_from_paths` (same pattern as `preallocate_memory`). On a mismatched head the run fails in seconds instead of after full inference (~40 min avg per attempt, up to 2.5h on ImageNet-C variants).
3. The `score()` wrapper's cache-clearing hint now only fires for stimulus/path-related AssertionErrors. Other errors re-raise verbatim instead of being buried under the misleading "clear your activations cache" message.