### PR TITLE
Add Qwen3.6-27B vision encoder

### DIFF
--- a/brainscore_vision/models/qwen3_6_27b/__init__.py
+++ b/brainscore_vision/models/qwen3_6_27b/__init__.py
@@ -1,0 +1,12 @@
+from brainscore_vision import model_registry
+from brainscore_vision.model_helpers.brain_transformation import ModelCommitment
+
+from .model import IDENTIFIER, get_layers, get_model
+
+
+model_registry['qwen3.6-27b'] = lambda: ModelCommitment(
+    identifier=IDENTIFIER,
+    activations_model=get_model(IDENTIFIER),
+    layers=get_layers(IDENTIFIER),
+    behavioral_readout_layer=get_layers(IDENTIFIER)[-1],
+)

--- a/brainscore_vision/models/qwen3_6_27b/metadata.yml
+++ b/brainscore_vision/models/qwen3_6_27b/metadata.yml
@@ -1,0 +1,19 @@
+models:
+    qwen3.6-27b:
+        architecture: Transformer
+        model_family: qwen
+        total_parameter_count: 460730096
+        trainable_parameter_count: 460730096
+        total_layers: 282
+        trainable_layers: 112
+        model_size_mb: 921.46
+        training_dataset: null
+        task_specialization: vision-language modeling
+        brainscore_link: https://github.com/brain-score/vision/tree/master/brainscore_vision/models/qwen3_6_27b
+        huggingface_link: https://huggingface.co/Qwen/Qwen3.6-27B
+        extra_notes: >-
+            Brain-Score loads only the pretrained vision encoder from the Qwen3.6-27B
+            checkpoint and evaluates six visual transformer blocks at a fixed 256 x 256
+            input resolution. Two mixed checkpoint shards are downloaded, but their
+            language tensors and the 27B language backbone are not loaded into memory.
+        runnable: true

--- a/brainscore_vision/models/qwen3_6_27b/model.py
+++ b/brainscore_vision/models/qwen3_6_27b/model.py
@@ -1,0 +1,351 @@
+"""Qwen3.6-27B's pretrained vision encoder for Brain-Score Vision."""
+
+import functools
+import json
+import logging
+import threading
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch import nn
+from torchvision import transforms
+
+from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper, load_images
+from brainscore_vision.model_helpers.check_submission import check_models
+from brainscore_vision.model_helpers.utils import fullname
+
+
+IDENTIFIER = "qwen3.6-27b"
+MODEL_ID = "Qwen/Qwen3.6-27B"
+MODEL_REVISION = "6a9e13bd6fc8f0983b9b99948120bc37f49c13e9"
+IMAGE_SIZE = 256
+BATCH_SIZE = 4
+CHECKPOINT_PREFIX = "model.visual."
+
+# Vision architecture parameters from the pinned Qwen3.6-27B checkpoint.
+VISION_CONFIG = {
+    "depth": 27,
+    "hidden_act": "gelu_pytorch_tanh",
+    "hidden_size": 1152,
+    "in_channels": 3,
+    "initializer_range": 0.02,
+    "intermediate_size": 4304,
+    "num_heads": 16,
+    "num_position_embeddings": 2304,
+    "out_hidden_size": 5120,
+    "patch_size": 16,
+    "spatial_merge_size": 2,
+    "temporal_patch_size": 2,
+}
+
+
+class QwenVisionEncoder(nn.Module):
+    """
+    Adapt image tensors to Qwen's flattened-patch vision-tower interface.
+
+    Qwen groups patches by each spatial-merge cell and duplicates still-image
+    patches across the temporal-patch axis. The fixed input size gives every
+    image the same token count, allowing Brain-Score to retain patch-level
+    activations with a presentation-first shape.
+    """
+
+    def __init__(self, visual: nn.Module, image_size: int = IMAGE_SIZE):
+        super().__init__()
+        self.visual = visual
+        self.image_size = image_size
+        self.batch_size = None
+
+        config = visual.config
+        factor = config.patch_size * config.spatial_merge_size
+        if image_size % factor:
+            raise ValueError(
+                f"image size {image_size} must be divisible by patch size "
+                f"{config.patch_size} times merge size {config.spatial_merge_size}"
+            )
+
+    def _flatten_patches(self, images: torch.Tensor):
+        batch_size, channels, height, width = images.shape
+        config = self.visual.config
+        patch_size = config.patch_size
+        merge_size = config.spatial_merge_size
+        temporal_patch_size = config.temporal_patch_size
+
+        if channels != config.in_channels:
+            raise ValueError(f"expected {config.in_channels} channels, received {channels}")
+        if height != self.image_size or width != self.image_size:
+            raise ValueError(
+                f"expected {self.image_size}x{self.image_size} images, "
+                f"received {height}x{width}"
+            )
+
+        grid_h = height // patch_size
+        grid_w = width // patch_size
+        patches = images.reshape(
+            batch_size,
+            channels,
+            grid_h // merge_size,
+            merge_size,
+            patch_size,
+            grid_w // merge_size,
+            merge_size,
+            patch_size,
+        )
+        patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+        patches = (
+            patches.unsqueeze(6)
+            .expand(
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                temporal_patch_size,
+                -1,
+                -1,
+            )
+            .reshape(
+                batch_size * grid_h * grid_w,
+                channels * temporal_patch_size * patch_size * patch_size,
+            )
+        )
+        grid_thw = torch.tensor(
+            [[1, grid_h, grid_w]],
+            dtype=torch.long,
+            device=images.device,
+        ).repeat(batch_size, 1)
+        return patches, grid_thw
+
+    def forward(self, images: torch.Tensor):
+        self.batch_size = images.shape[0]
+        patches, grid_thw = self._flatten_patches(images)
+        return self.visual(hidden_states=patches, grid_thw=grid_thw)
+
+
+class QwenPytorchWrapper(PytorchWrapper):
+    """Brain-Score 2.0 wrapper for Qwen's packed visual-token activations."""
+
+    def __init__(
+        self,
+        model,
+        preprocessing,
+        model_loader,
+        identifier=None,
+        forward_kwargs=None,
+        *args,
+        **kwargs,
+    ):
+        self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        logging.getLogger(fullname(self)).debug(f"Using device {self._device}")
+        self._model = model
+        self._model_loader = model_loader
+        self._model_loaded = False
+        self._model_load_lock = threading.Lock()
+
+        identifier = identifier or model.__class__.__name__
+        self._extractor = self._build_extractor(
+            identifier=identifier,
+            preprocessing=preprocessing,
+            get_activations=self.get_activations,
+            *args,
+            **kwargs,
+        )
+        self._extractor.insert_attrs(self)
+        self._forward_kwargs = forward_kwargs or {}
+
+    def _ensure_model_loaded(self):
+        if self._model_loaded:
+            return
+        with self._model_load_lock:
+            if self._model_loaded:
+                return
+            self._model_loader()
+            meta_parameters = [
+                name for name, parameter in self._model.named_parameters() if parameter.is_meta
+            ]
+            if meta_parameters:
+                raise RuntimeError(
+                    "Qwen vision weights were not fully loaded: "
+                    + ", ".join(meta_parameters[:5])
+                )
+            self._model = self._model.to(self._device)
+            self._model_loaded = True
+
+    def get_activations(self, images, layer_names):
+        self._ensure_model_loaded()
+        return super().get_activations(images=images, layer_names=layer_names)
+
+    def register_hook(self, layer, layer_name, target_dict):
+        def hook_function(_layer, _input, output, name=layer_name):
+            if isinstance(output, (tuple, list)):
+                output = output[0]
+            if not isinstance(output, torch.Tensor):
+                raise TypeError(f"layer {name} returned unsupported output type {type(output)}")
+            if output.ndim != 2:
+                raise ValueError(
+                    f"layer {name} returned shape {tuple(output.shape)}; "
+                    "expected packed [tokens, channels] activations"
+                )
+
+            batch_size = self._model.batch_size
+            if not batch_size or output.shape[0] % batch_size:
+                raise ValueError(
+                    f"cannot split {output.shape[0]} tokens across batch size {batch_size}"
+                )
+            output = output.reshape(batch_size, -1, output.shape[-1])
+            target_dict[name] = output.detach().to(device="cpu", dtype=torch.float32).numpy()
+
+        return layer.register_forward_hook(hook_function)
+
+
+def _build_vision_skeleton():
+    from transformers import Qwen3_5VisionModel
+    from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5VisionConfig
+
+    config = Qwen3_5VisionConfig(**VISION_CONFIG)
+    with torch.device("meta"):
+        visual = Qwen3_5VisionModel(config)
+    return QwenVisionEncoder(visual=visual)
+
+
+def _load_sharded_vision_weights(
+    model,
+    index_path,
+    download_file,
+    safe_open_file,
+    checkpoint_prefix: str = CHECKPOINT_PREFIX,
+):
+    """Load only the visual tensors listed in a sharded checkpoint index."""
+    with Path(index_path).open(encoding="utf-8") as index_file:
+        checkpoint_index = json.load(index_file)
+
+    checkpoint_to_model_key = {
+        checkpoint_key: checkpoint_key.removeprefix(checkpoint_prefix)
+        for checkpoint_key in checkpoint_index["weight_map"]
+        if checkpoint_key.startswith(checkpoint_prefix)
+    }
+    expected_keys = set(model.state_dict())
+    checkpoint_keys = set(checkpoint_to_model_key.values())
+    if expected_keys != checkpoint_keys:
+        missing = sorted(expected_keys - checkpoint_keys)
+        unexpected = sorted(checkpoint_keys - expected_keys)
+        raise RuntimeError(
+            "Qwen vision checkpoint does not match the Transformers architecture. "
+            f"Missing keys: {missing[:5]}; unexpected keys: {unexpected[:5]}"
+        )
+
+    shard_entries = defaultdict(list)
+    for checkpoint_key, model_key in checkpoint_to_model_key.items():
+        shard = checkpoint_index["weight_map"][checkpoint_key]
+        shard_entries[shard].append((checkpoint_key, model_key))
+
+    for shard, entries in sorted(shard_entries.items()):
+        shard_path = download_file(filename=shard)
+        with safe_open_file(shard_path, framework="pt", device="cpu") as checkpoint:
+            shard_state = {
+                model_key: checkpoint.get_tensor(checkpoint_key)
+                for checkpoint_key, model_key in entries
+            }
+        model.load_state_dict(shard_state, strict=False, assign=True)
+
+    remaining_meta = [
+        name for name, parameter in model.named_parameters() if parameter.is_meta
+    ]
+    if remaining_meta:
+        raise RuntimeError(
+            "Qwen vision checkpoint left parameters on the meta device: "
+            + ", ".join(remaining_meta[:5])
+        )
+
+
+def _materialize_vision_buffers(model):
+    """Materialize the one non-persistent rotary buffer created on the meta device."""
+    rotary = model.rotary_pos_emb
+    inv_freq = 1.0 / (
+        rotary.theta ** (torch.arange(0, rotary.dim, 2, dtype=torch.float32) / rotary.dim)
+    )
+    rotary.register_buffer("inv_freq", inv_freq, persistent=False)
+
+
+def _load_vision_weights(model):
+    from huggingface_hub import hf_hub_download
+    from safetensors import safe_open
+
+    download_file = functools.partial(
+        hf_hub_download,
+        repo_id=MODEL_ID,
+        revision=MODEL_REVISION,
+    )
+    index_path = download_file(filename="model.safetensors.index.json")
+    _load_sharded_vision_weights(
+        model=model,
+        index_path=index_path,
+        download_file=download_file,
+        safe_open_file=safe_open,
+    )
+    _materialize_vision_buffers(model)
+    model.eval()
+
+
+def load_preprocess_images(image_filepaths):
+    preprocess = transforms.Compose(
+        [
+            transforms.Resize(
+                (IMAGE_SIZE, IMAGE_SIZE),
+                interpolation=transforms.InterpolationMode.BICUBIC,
+                antialias=True,
+            ),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=(0.5, 0.5, 0.5), std=(0.5, 0.5, 0.5)),
+            lambda image: image.unsqueeze(0),
+        ]
+    )
+    images = [preprocess(image) for image in load_images(image_filepaths)]
+    return np.concatenate(images)
+
+
+def get_model_list():
+    return [IDENTIFIER]
+
+
+def get_model(name):
+    assert name == IDENTIFIER
+    model = _build_vision_skeleton()
+    wrapper = QwenPytorchWrapper(
+        identifier=IDENTIFIER,
+        model=model,
+        model_loader=functools.partial(_load_vision_weights, model.visual),
+        preprocessing=load_preprocess_images,
+        batch_size=BATCH_SIZE,
+    )
+    wrapper.image_size = IMAGE_SIZE
+    return wrapper
+
+
+def get_layers(name):
+    assert name == IDENTIFIER
+    return [
+        "visual.blocks.3",
+        "visual.blocks.7",
+        "visual.blocks.12",
+        "visual.blocks.17",
+        "visual.blocks.22",
+        "visual.blocks.26",
+    ]
+
+
+def get_bibtex(model_identifier):
+    assert model_identifier == IDENTIFIER
+    return """@misc{qwen3.6-27b,
+  title = {{Qwen3.6-27B}: Flagship-Level Coding in a {27B} Dense Model},
+  author = {{Qwen Team}},
+  month = {April},
+  year = {2026},
+  url = {https://qwen.ai/blog?id=qwen3.6-27b}
+}"""
+
+
+if __name__ == "__main__":
+    check_models.check_base_models(__name__)

--- a/brainscore_vision/models/qwen3_6_27b/requirements.txt
+++ b/brainscore_vision/models/qwen3_6_27b/requirements.txt
@@ -1,0 +1,3 @@
+huggingface_hub>=1.5,<2
+safetensors>=0.8,<1
+transformers==5.14.1

--- a/brainscore_vision/models/qwen3_6_27b/test.py
+++ b/brainscore_vision/models/qwen3_6_27b/test.py
@@ -1,0 +1,299 @@
+import json
+from collections import OrderedDict
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from torch import nn
+
+import brainscore_vision
+from brainscore_vision.models.qwen3_6_27b.model import (
+    IDENTIFIER,
+    QwenPytorchWrapper,
+    QwenVisionEncoder,
+    _load_sharded_vision_weights,
+    _materialize_vision_buffers,
+    get_layers,
+    load_preprocess_images,
+)
+
+
+class RecordingVisionModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(
+            in_channels=3,
+            patch_size=2,
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+        )
+        self.recorded_patches = None
+        self.recorded_grid = None
+
+    def forward(self, hidden_states, grid_thw):
+        self.recorded_patches = hidden_states
+        self.recorded_grid = grid_thw
+        return hidden_states
+
+
+class PackedLayerModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Identity()
+        self.anchor = nn.Parameter(torch.zeros(1))
+        self.batch_size = 2
+
+    def forward(self, inputs):
+        return self.layer(inputs)
+
+
+class FakeSafeFile:
+    def __init__(self, tensors):
+        self.tensors = tensors
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def get_tensor(self, key):
+        return self.tensors[key]
+
+
+def test_layers_span_vision_tower():
+    assert get_layers(IDENTIFIER) == [
+        "visual.blocks.3",
+        "visual.blocks.7",
+        "visual.blocks.12",
+        "visual.blocks.17",
+        "visual.blocks.22",
+        "visual.blocks.26",
+    ]
+
+
+def test_flattens_images_in_qwen_patch_order():
+    visual = RecordingVisionModel()
+    model = QwenVisionEncoder(visual=visual, image_size=4)
+    images = torch.arange(2 * 3 * 4 * 4, dtype=torch.float32).reshape(2, 3, 4, 4)
+
+    model(images)
+
+    assert visual.recorded_patches.shape == (8, 24)
+    assert torch.equal(
+        visual.recorded_grid,
+        torch.tensor([[1, 2, 2], [1, 2, 2]]),
+    )
+    patches = visual.recorded_patches.reshape(2, 4, 3, 2, 2, 2)
+    assert torch.equal(patches[:, :, :, 0], patches[:, :, :, 1])
+
+
+def test_patch_layout_matches_transformers_processor(tmp_path):
+    from transformers.models.qwen2_vl.image_processing_qwen2_vl import (
+        Qwen2VLImageProcessor,
+    )
+
+    image_path = tmp_path / "gradient.png"
+    pixels = np.arange(256 * 256 * 3, dtype=np.uint32).reshape(256, 256, 3) % 256
+    Image.fromarray(pixels.astype(np.uint8)).save(image_path)
+
+    visual = RecordingVisionModel()
+    visual.config.patch_size = 16
+    visual.config.spatial_merge_size = 2
+    model = QwenVisionEncoder(visual=visual, image_size=256)
+    model(torch.from_numpy(load_preprocess_images([image_path])))
+
+    processor = Qwen2VLImageProcessor(
+        do_resize=False,
+        patch_size=16,
+        temporal_patch_size=2,
+        merge_size=2,
+        image_mean=[0.5, 0.5, 0.5],
+        image_std=[0.5, 0.5, 0.5],
+    )
+    with Image.open(image_path) as image:
+        official = processor(
+            images=[image.convert("RGB")],
+            return_tensors="pt",
+        )
+
+    assert torch.equal(visual.recorded_grid, official["image_grid_thw"])
+    torch.testing.assert_close(
+        visual.recorded_patches,
+        official["pixel_values"],
+        rtol=0,
+        atol=1e-7,
+    )
+
+
+def test_hook_restores_presentation_dimension():
+    model = PackedLayerModel()
+    wrapper = QwenPytorchWrapper(
+        identifier="test-qwen",
+        model=model,
+        model_loader=lambda: None,
+        preprocessing=None,
+        batch_size=2,
+    )
+    wrapper._model_loaded = True
+    target = OrderedDict()
+    hook = wrapper.register_hook(model.layer, "layer", target)
+
+    model.layer(torch.arange(24, dtype=torch.bfloat16).reshape(6, 4))
+    hook.remove()
+
+    assert target["layer"].shape == (2, 3, 4)
+    assert target["layer"].dtype == np.float32
+
+
+def test_wrapper_extracts_qwen_vision_block():
+    from transformers import Qwen3_5VisionModel
+    from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5VisionConfig
+
+    config = Qwen3_5VisionConfig(
+        depth=1,
+        hidden_size=32,
+        intermediate_size=64,
+        num_heads=4,
+        out_hidden_size=16,
+        num_position_embeddings=64,
+        patch_size=4,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+    )
+    model = QwenVisionEncoder(
+        visual=Qwen3_5VisionModel(config),
+        image_size=32,
+    )
+    wrapper = QwenPytorchWrapper(
+        identifier="tiny-qwen",
+        model=model,
+        model_loader=lambda: None,
+        preprocessing=None,
+        batch_size=2,
+    )
+
+    activations = wrapper.get_activations(
+        images=[torch.zeros(3, 32, 32), torch.ones(3, 32, 32)],
+        layer_names=["visual.blocks.0"],
+    )
+
+    assert activations["visual.blocks.0"].shape == (2, 64, 32)
+    assert activations["visual.blocks.0"].dtype == np.float32
+
+
+def test_loads_only_prefixed_visual_weights(tmp_path):
+    index_path = tmp_path / "model.safetensors.index.json"
+    index_path.write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.language_model.weight": "language.safetensors",
+                    "model.visual.weight": "vision-1.safetensors",
+                    "model.visual.bias": "vision-2.safetensors",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    tensors = {
+        "vision-1.safetensors": {
+            "model.visual.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        },
+        "vision-2.safetensors": {
+            "model.visual.bias": torch.tensor([5.0, 6.0])
+        },
+    }
+    downloaded = []
+
+    def download_file(filename):
+        downloaded.append(filename)
+        return tmp_path / filename
+
+    def safe_open_file(path, framework, device):
+        assert framework == "pt"
+        assert device == "cpu"
+        return FakeSafeFile(tensors[Path(path).name])
+
+    with torch.device("meta"):
+        model = nn.Linear(2, 2)
+    _load_sharded_vision_weights(
+        model=model,
+        index_path=index_path,
+        download_file=download_file,
+        safe_open_file=safe_open_file,
+    )
+
+    assert downloaded == ["vision-1.safetensors", "vision-2.safetensors"]
+    assert torch.equal(model.weight, tensors["vision-1.safetensors"]["model.visual.weight"])
+    assert torch.equal(model.bias, tensors["vision-2.safetensors"]["model.visual.bias"])
+
+
+def test_hydrates_tiny_qwen_vision_model_from_meta(tmp_path):
+    from transformers import Qwen3_5VisionModel
+    from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5VisionConfig
+
+    config = Qwen3_5VisionConfig(
+        depth=1,
+        hidden_size=32,
+        intermediate_size=64,
+        num_heads=4,
+        out_hidden_size=16,
+        num_position_embeddings=64,
+        patch_size=4,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+    )
+    reference = Qwen3_5VisionModel(config).to(dtype=torch.bfloat16)
+    checkpoint_tensors = {
+        f"model.visual.{key}": tensor.detach().clone()
+        for key, tensor in reference.state_dict().items()
+    }
+    shard_name = "vision.safetensors"
+    index_path = tmp_path / "model.safetensors.index.json"
+    index_path.write_text(
+        json.dumps({"weight_map": {key: shard_name for key in checkpoint_tensors}}),
+        encoding="utf-8",
+    )
+
+    with torch.device("meta"):
+        visual = Qwen3_5VisionModel(config)
+    assert visual.rotary_pos_emb.inv_freq.is_meta
+
+    _load_sharded_vision_weights(
+        model=visual,
+        index_path=index_path,
+        download_file=lambda filename: tmp_path / filename,
+        safe_open_file=lambda path, framework, device: FakeSafeFile(checkpoint_tensors),
+    )
+    _materialize_vision_buffers(visual)
+
+    assert not visual.rotary_pos_emb.inv_freq.is_meta
+    assert all(not parameter.is_meta for parameter in visual.parameters())
+    assert all(parameter.dtype == torch.bfloat16 for parameter in visual.parameters())
+
+    model = QwenVisionEncoder(visual=visual, image_size=32)
+    output = model(torch.zeros(2, 3, 32, 32, dtype=torch.bfloat16))
+    assert output.last_hidden_state.shape == (128, 32)
+    assert output.last_hidden_state.dtype == torch.bfloat16
+
+
+def test_preprocessing_is_fixed_size_and_normalized(tmp_path):
+    image_path = tmp_path / "black.png"
+    Image.new("RGB", (320, 180), color=(0, 0, 0)).save(image_path)
+
+    result = load_preprocess_images([image_path])
+
+    assert result.shape == (1, 3, 256, 256)
+    assert result.dtype == np.float32
+    assert np.all(result == -1)
+
+
+@pytest.mark.travis_slow
+@pytest.mark.memory_intense
+def test_has_identifier():
+    model = brainscore_vision.load_model(IDENTIFIER)
+    assert model.identifier == IDENTIFIER


### PR DESCRIPTION
Adds the Qwen3.6-27B pretrained vision encoder as a Brain-Score Vision model using the existing `PytorchWrapper` and `ModelCommitment`.

- Lazily loads only visual checkpoint tensors
- Exposes six visual transformer blocks
- Adds metadata and focused preprocessing, activation, and loading tests

Tests: `pytest brainscore_vision/models/qwen3_6_27b/test.py -q` (9 passed)