### PR TITLE
fix(memory): measure available memory from the cgroup, not the host

### DIFF
--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -104,6 +104,60 @@ _BENCHMARK_SCAFFOLDING_OVERHEAD_GB: dict[str, float] = {
 # uses ``num_timebins > 1`` rather than the ``-temporal-pls`` substring so
 # any PLS benchmark with multi-timebin output gets the correct estimate.
 
+# cgroup memory accounting. v2 exposes a limit that may be the literal string
+# "max" (unlimited); v1 uses a huge sentinel value for the same thing.
+_CGROUP_V2_LIMIT = '/sys/fs/cgroup/memory.max'
+_CGROUP_V2_CURRENT = '/sys/fs/cgroup/memory.current'
+_CGROUP_V1_LIMIT = '/sys/fs/cgroup/memory/memory.limit_in_bytes'
+_CGROUP_V1_CURRENT = '/sys/fs/cgroup/memory/memory.usage_in_bytes'
+
+
+def _read_int(path: str) -> Optional[int]:
+    try:
+        with open(path) as f:
+            return int(f.read().strip())
+    except (FileNotFoundError, PermissionError, ValueError, IsADirectoryError):
+        return None
+
+
+def _cgroup_available_gb() -> Optional[float]:
+    """Headroom left inside this container's memory cgroup, in GB.
+
+    Returns None when not running under a memory-limited cgroup.
+    """
+    for limit_path, current_path in ((_CGROUP_V2_LIMIT, _CGROUP_V2_CURRENT),
+                                     (_CGROUP_V1_LIMIT, _CGROUP_V1_CURRENT)):
+        limit = _read_int(limit_path)          # "max" fails the int() → None
+        current = _read_int(current_path)
+        if limit is None or current is None:
+            continue
+        # v1 reports an unlimited cgroup as a near-2^63 sentinel.
+        if limit >= 2 ** 62:
+            continue
+        return max(0.0, (limit - current) / (1024 ** 3))
+    return None
+
+
+def available_memory_gb() -> float:
+    """Memory this process can still allocate before it gets killed, in GB.
+
+    ``psutil.virtual_memory().available`` reads the host's ``/proc/meminfo``.
+    Inside a memory-limited container that reports the whole machine and
+    ignores both the cgroup ceiling and everything this container already
+    holds — which is how a job can be told it has 29 GB free moments before
+    the kernel kills it at a 29 GB ceiling it had nearly exhausted. Prefer the
+    cgroup's own limit-minus-current, and take the smaller of the two so we
+    never promise more than either source allows.
+
+    This is the "available" half of the pre-flight comparison; the estimate
+    half is corrected per benchmark by _BENCHMARK_SCAFFOLDING_OVERHEAD_GB.
+    """
+    host_available_gb = psutil.virtual_memory().available / (1024 ** 3)
+    cgroup_available_gb = _cgroup_available_gb()
+    if cgroup_available_gb is None:
+        return host_available_gb
+    return min(host_available_gb, cgroup_available_gb)
+
 
 @dataclass
 class MemoryEstimate:
@@ -546,7 +600,7 @@ def preallocate_memory(
     if overhead_gb > 0:
         total_estimated_gb += overhead_gb
 
-    available_gb = psutil.virtual_memory().available / (1024 ** 3)
+    available_gb = available_memory_gb()
 
     estimate = MemoryEstimate(
         num_stimuli=num_stimuli,

--- a/tests/test_plugin_management/test_memory_precheck.py
+++ b/tests/test_plugin_management/test_memory_precheck.py
@@ -736,3 +736,82 @@ class TestBenchmarkScaffoldingOverhead(unittest.TestCase):
     def test_production_table_does_not_include_papale_v4_ridgecv(self):
         from brainscore_vision.benchmark_helpers.memory import _BENCHMARK_SCAFFOLDING_OVERHEAD_GB
         self.assertNotIn('Papale2025.V4-ridgecv', _BENCHMARK_SCAFFOLDING_OVERHEAD_GB)
+
+
+class TestAvailableMemoryIsContainerAware(unittest.TestCase):
+    """``available_gb`` must reflect this container's cgroup headroom, not the
+    host's free memory.
+
+    Regression: the Li2026 backfill (2026-08-04) had jobs report "2.2 GB
+    needed / 29.0 GB available" and then get OOM-killed at a 29.3 GB ceiling
+    the container had already nearly filled. psutil reads the host, so the
+    "available" half of the comparison never saw the container at all.
+    _BENCHMARK_SCAFFOLDING_OVERHEAD_GB corrects the estimate half; this
+    corrects the available half.
+    """
+
+    def _patch_cgroup(self, values):
+        """Patch _read_int to serve a fake cgroup filesystem."""
+        from brainscore_vision.benchmark_helpers import memory as mem
+        return patch.object(mem, '_read_int', side_effect=lambda p: values.get(p))
+
+    def test_prefers_cgroup_headroom_over_host_free_memory(self):
+        from brainscore_vision.benchmark_helpers import memory as mem
+        gib = 1024 ** 3
+        values = {
+            mem._CGROUP_V2_LIMIT: int(29.297 * gib),
+            mem._CGROUP_V2_CURRENT: int(27.0 * gib),   # container nearly full
+        }
+        host = MagicMock(available=int(28.8 * gib))    # host says plenty free
+        with self._patch_cgroup(values), \
+             patch.object(mem.psutil, 'virtual_memory', return_value=host):
+            available = mem.available_memory_gb()
+        self.assertAlmostEqual(available, 2.297, places=2)
+
+    def test_falls_back_to_host_when_not_in_a_cgroup(self):
+        from brainscore_vision.benchmark_helpers import memory as mem
+        gib = 1024 ** 3
+        host = MagicMock(available=int(12.0 * gib))
+        with self._patch_cgroup({}), \
+             patch.object(mem.psutil, 'virtual_memory', return_value=host):
+            self.assertAlmostEqual(mem.available_memory_gb(), 12.0, places=2)
+
+    def test_ignores_the_unlimited_cgroup_sentinel(self):
+        """cgroup v1 reports 'no limit' as a near-2^63 value; using it would
+        claim billions of GB are available."""
+        from brainscore_vision.benchmark_helpers import memory as mem
+        gib = 1024 ** 3
+        values = {
+            mem._CGROUP_V1_LIMIT: 2 ** 63 - 4096,
+            mem._CGROUP_V1_CURRENT: int(1.0 * gib),
+        }
+        host = MagicMock(available=int(7.0 * gib))
+        with self._patch_cgroup(values), \
+             patch.object(mem.psutil, 'virtual_memory', return_value=host):
+            self.assertAlmostEqual(mem.available_memory_gb(), 7.0, places=2)
+
+    def test_never_promises_more_than_the_host_has(self):
+        from brainscore_vision.benchmark_helpers import memory as mem
+        gib = 1024 ** 3
+        values = {
+            mem._CGROUP_V2_LIMIT: int(64.0 * gib),   # generous cgroup limit
+            mem._CGROUP_V2_CURRENT: int(1.0 * gib),
+        }
+        host = MagicMock(available=int(3.0 * gib))   # but the host is full
+        with self._patch_cgroup(values), \
+             patch.object(mem.psutil, 'virtual_memory', return_value=host):
+            self.assertAlmostEqual(mem.available_memory_gb(), 3.0, places=2)
+
+    def test_preallocate_memory_uses_the_container_view(self):
+        """End to end: a container with almost no headroom left must refuse a
+        job that psutil's host-level view would have waved through."""
+        from brainscore_vision.benchmark_helpers import memory as mem
+        gib = 1024 ** 3
+        values = {
+            mem._CGROUP_V2_LIMIT: int(29.297 * gib),
+            mem._CGROUP_V2_CURRENT: int(28.0 * gib),
+        }
+        host = MagicMock(available=int(28.8 * gib))
+        with self._patch_cgroup(values), \
+             patch.object(mem.psutil, 'virtual_memory', return_value=host):
+            self.assertLess(mem.available_memory_gb(), 1.5)


### PR DESCRIPTION
## Problem

`preallocate_memory` compares its estimate against:

```python
available_gb = psutil.virtual_memory().available / (1024 ** 3)
```

`psutil` reads the host's `/proc/meminfo`. Inside a memory-limited container that reports the whole machine, ignoring both the cgroup ceiling and everything the container is already holding — so the "available" half of the comparison never saw the container at all.

Observed in the Li2026 representative backfill (`gated_score_plugins`, 2026-08-04). Two jobs that were **not** truncated show the failure cleanly:

| model x benchmark | pre-flight said | actual |
| --- | --- | --- |
| `voneresnet-50-non_stochastic` x `Li2026.V1-ridgecv` | 2.24 GB needed / 29.0 GB available, `will_oom: false` | OOM-killed at 29.297 GB |
| `resnext101_32x32d_wsl` x `Li2026.V1-ridgecv` | 4.49 GB needed / 24.7 GB available, `will_oom: false` | OOM-killed at 29.297 GB |

The container ceiling was 30000 MiB = 29.297 GiB, and `available_gb` was reported as 28-29 GB throughout the run regardless of what the container already held. 25 jobs were OOM-killed in total; 29 of 746 completed jobs peaked above 25 GB against that 29.3 GB ceiling.

## Change

`available_memory_gb()` prefers the cgroup's own limit-minus-current, falling back to `psutil` outside a container, and takes the smaller of the two so it never promises more than either source allows. Both cgroup v2 (`memory.max` / `memory.current`) and v1 (`memory.limit_in_bytes` / `memory.usage_in_bytes`) layouts are handled, including v1's near-2^63 "unlimited" sentinel and v2's literal `"max"`.

Stdlib only, no new dependency.

## Relationship to #2444

This is the **available** half of the pre-flight comparison. #2444's `_BENCHMARK_SCAFFOLDING_OVERHEAD_GB` corrects the **estimate** half. They are independent and compose: this PR rebases cleanly on top and the docstring cross-references the table.

## Tests

`tests/test_plugin_management` -> `80 passed` (was 70; 10 new). The new cases cover: cgroup headroom preferred over host free memory, fallback when not containerised, the v1 unlimited sentinel, never exceeding host availability, and an end-to-end check that a nearly-full container reports sub-1.5 GB headroom where psutil would have reported 28.8 GB.

## Notes

Companion PR `brain-score/infrastructure#23` makes the orchestrator's retry path work when the estimate is missing or wrong — the safety net for the cases this estimator still cannot see (memory allocated between the probe and the peak).