### PR TITLE
feat(activations): key the stored-activation cache on plugin revisions

### DIFF
--- a/brainscore_vision/model_helpers/activations/cache_key.py
+++ b/brainscore_vision/model_helpers/activations/cache_key.py
@@ -14,6 +14,24 @@ entirely normal. Appending a short revision string means a plugin revision
 lands under a *different* key rather than silently overwriting the meaning of
 the old one.
 
+Off by default — see :func:`revision_enabled`
+-----------------------------------------------
+``result_caching`` is enabled by default (``RESULTCACHING_DISABLE`` defaults to
+``'0'``), so developers already have warm local caches keyed on the bare
+identifiers. Revisioning unconditionally would turn every one of those cold,
+and would keep re-invalidating them on each commit that touches the plugin.
+
+Worse for local use, ``git log -1 -- <dir>`` reports the last *commit* touching
+the directory, so uncommitted working-tree edits resolve to the same revision:
+locally the revision is simultaneously too eager (churns on commit) and not
+eager enough (blind to the edit you are actually testing).
+
+So this is opt-in via ``BRAINSCORE_CACHE_PLUGIN_REVISION=1``. Production enables
+it together with the shared S3 backend, where the checkout is clean and the
+cache is long-lived and shared — the setting in which a stale hit actually
+matters. With it unset, keys are byte-for-byte what they were before this
+module existed.
+
 Resolution order, per plugin:
 
 1. ``BRAINSCORE_<TYPE>_PLUGIN_SHA`` environment variable. The scoring
@@ -45,8 +63,21 @@ _logger = logging.getLogger(__name__)
 _REVISION_CHARS = 12
 
 # Files whose contents cannot change what a model computes.
-_IGNORED_SUFFIXES = ('.pyc', '.pyo', '.md', '.txt.orig')
+_IGNORED_SUFFIXES = ('.pyc', '.pyo', '.md')
 _IGNORED_DIRS = ('__pycache__', '.git', '.pytest_cache')
+
+# Opt-in switch. Unset => keys are exactly what they were before this module.
+_ENABLE_VAR = 'BRAINSCORE_CACHE_PLUGIN_REVISION'
+
+
+def revision_enabled() -> bool:
+    """True if cache keys should carry plugin revisions.
+
+    Deliberately opt-in; see the module docstring. Any consumer that shares a
+    cache across machines or across plugin revisions (i.e. the production S3
+    backend) must enable this, and should refuse to start without it.
+    """
+    return os.environ.get(_ENABLE_VAR, '0').strip().lower() in ('1', 'true', 'yes')
 
 
 def model_cache_identifier(identifier: str) -> str:
@@ -68,6 +99,8 @@ def stimulus_set_cache_identifier(stimuli_identifier: str) -> str:
 
 
 def _with_revision(identifier, plugin_type: str, env_var: str, unresolved_is_notable: bool):
+    if not revision_enabled():
+        return identifier
     if not identifier or not isinstance(identifier, str):
         # `stimuli_identifier` is False when the caller disables storing.
         return identifier
@@ -108,10 +141,21 @@ def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
 
 def _locate_plugin_dir(plugin_type: str, identifier: str) -> Optional[Path]:
     try:
+        from brainscore_core.plugin_management import import_plugin as _import_plugin
         from brainscore_core.plugin_management.import_plugin import ImportPlugin
         importer = ImportPlugin(library_root='brainscore_vision', plugin_type=plugin_type,
                                 identifier=identifier)
-        dirname = importer.locate_plugin()
+        # locate_plugin scans every plugin directory and warns about each one
+        # missing an __init__.py. Those are pre-existing repo issues, not
+        # anything this lookup can act on, and they would appear in every
+        # container log. Silence them for the duration of the scan only.
+        resolver_logger = logging.getLogger(_import_plugin.__name__)
+        previous_level = resolver_logger.level
+        resolver_logger.setLevel(logging.ERROR)
+        try:
+            dirname = importer.locate_plugin()
+        finally:
+            resolver_logger.setLevel(previous_level)
         plugin_dir = Path(importer.plugins_dir) / dirname
         return plugin_dir if plugin_dir.is_dir() else None
     except Exception:

--- a/brainscore_vision/model_helpers/activations/cache_key.py
+++ b/brainscore_vision/model_helpers/activations/cache_key.py
@@ -1,0 +1,158 @@
+"""Content revisions for the stored-activation cache key.
+
+``ActivationsExtractorHelper._from_paths_stored`` is decorated with
+``@store_xarray``, which builds its cache key from the call arguments —
+principally ``identifier`` (the model) and ``stimuli_identifier``. Neither of
+those changes when the *contents* behind them change: a model plugin can be
+revised to load different weights or apply different preprocessing while still
+registering as ``alexnet``, and a stimulus set can be re-uploaded under the
+same name.
+
+A cache keyed on the bare identifiers would then hand back activations
+produced by code that no longer exists, and the resulting score would look
+entirely normal. Appending a short revision string means a plugin revision
+lands under a *different* key rather than silently overwriting the meaning of
+the old one.
+
+Resolution order, per plugin:
+
+1. ``BRAINSCORE_<TYPE>_PLUGIN_SHA`` environment variable. The scoring
+   orchestrator knows the revision already and can inject it, which avoids a
+   ``git`` call inside every container.
+2. The git commit that last touched the plugin directory. Only that plugin's
+   history counts — using the repository HEAD would invalidate every model's
+   cache on every unrelated commit.
+3. A content hash of the plugin directory, for installs that are not a git
+   checkout.
+4. Nothing. The identifier is returned unchanged, which reproduces the
+   pre-existing (revision-blind) key, and a warning is logged.
+
+Step 4 is deliberately not an error: this module must never be able to fail a
+scoring run. It degrades to exactly the behaviour that shipped before it.
+"""
+import hashlib
+import logging
+import os
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+_logger = logging.getLogger(__name__)
+
+# Length of the revision appended to an identifier. 12 hex chars is the git
+# short-sha convention and is far beyond collision risk for this population.
+_REVISION_CHARS = 12
+
+# Files whose contents cannot change what a model computes.
+_IGNORED_SUFFIXES = ('.pyc', '.pyo', '.md', '.txt.orig')
+_IGNORED_DIRS = ('__pycache__', '.git', '.pytest_cache')
+
+
+def model_cache_identifier(identifier: str) -> str:
+    """Model identifier with its plugin revision appended, for cache keying."""
+    return _with_revision(identifier, plugin_type='models',
+                          env_var='BRAINSCORE_MODEL_PLUGIN_SHA', unresolved_is_notable=True)
+
+
+def stimulus_set_cache_identifier(stimuli_identifier: str) -> str:
+    """Stimulus-set identifier with its data-plugin revision appended.
+
+    Stimulus sets reach the extractor through several routes (a registered
+    data plugin, a benchmark-local assembly, a screen-converted derivative),
+    so a revision is often unavailable. That is expected rather than notable —
+    an unresolved stimulus set simply keys as it does today.
+    """
+    return _with_revision(stimuli_identifier, plugin_type='data',
+                          env_var='BRAINSCORE_DATA_PLUGIN_SHA', unresolved_is_notable=False)
+
+
+def _with_revision(identifier, plugin_type: str, env_var: str, unresolved_is_notable: bool):
+    if not identifier or not isinstance(identifier, str):
+        # `stimuli_identifier` is False when the caller disables storing.
+        return identifier
+    revision = _plugin_revision(plugin_type=plugin_type, identifier=identifier, env_var=env_var,
+                               unresolved_is_notable=unresolved_is_notable)
+    return f"{identifier}@{revision}" if revision else identifier
+
+
+@lru_cache(maxsize=None)
+def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
+                     unresolved_is_notable: bool = True) -> Optional[str]:
+    """Short revision string for a plugin, or None if it cannot be determined.
+
+    Cached per process, which also means the "unresolved" log line is emitted
+    once per plugin rather than on every ``from_paths`` call — layer
+    commitment calls into here repeatedly and a per-call warning would be
+    hundreds of lines in the container log.
+    """
+    from_env = os.environ.get(env_var)
+    if from_env:
+        return from_env.strip()[:_REVISION_CHARS]
+
+    plugin_dir = _locate_plugin_dir(plugin_type=plugin_type, identifier=identifier)
+    revision = None
+    if plugin_dir is not None:
+        revision = _git_revision(plugin_dir) or _content_revision(plugin_dir)
+    if not revision:
+        # An unresolved *model* revision means the cache cannot tell two
+        # revisions of the same plugin apart, which is the failure this module
+        # exists to prevent -- worth surfacing. An unresolved stimulus set is
+        # routine.
+        log = _logger.warning if unresolved_is_notable else _logger.debug
+        log(f"Could not resolve a {plugin_type} revision for '{identifier}'; the activation "
+            f"cache key cannot distinguish revisions of this plugin. "
+            f"Set {env_var} to make it explicit.")
+    return revision
+
+
+def _locate_plugin_dir(plugin_type: str, identifier: str) -> Optional[Path]:
+    try:
+        from brainscore_core.plugin_management.import_plugin import ImportPlugin
+        importer = ImportPlugin(library_root='brainscore_vision', plugin_type=plugin_type,
+                                identifier=identifier)
+        dirname = importer.locate_plugin()
+        plugin_dir = Path(importer.plugins_dir) / dirname
+        return plugin_dir if plugin_dir.is_dir() else None
+    except Exception:
+        # Unregistered identifier, ambiguous registration, or a layout this
+        # resolver does not understand. Not fatal — the caller degrades.
+        _logger.debug(f"Could not locate {plugin_type} plugin dir for '{identifier}'", exc_info=True)
+        return None
+
+
+def _git_revision(plugin_dir: Path) -> Optional[str]:
+    """Commit that last touched ``plugin_dir``, or None outside a git checkout.
+
+    Scoped to the directory on purpose. The repository HEAD would change on
+    every unrelated commit and invalidate the whole cache each time.
+    """
+    try:
+        result = subprocess.run(
+            ['git', 'log', '-1', '--format=%H', '--', str(plugin_dir)],
+            cwd=str(plugin_dir), capture_output=True, text=True, timeout=30, check=True,
+        )
+    except Exception:
+        _logger.debug(f"git revision unavailable for {plugin_dir}", exc_info=True)
+        return None
+    sha = result.stdout.strip()
+    # An empty result means the path is untracked — fall through to the
+    # content hash rather than returning a revision that means "unknown".
+    return sha[:_REVISION_CHARS] if len(sha) == 40 else None
+
+
+def _content_revision(plugin_dir: Path) -> Optional[str]:
+    """sha256 over the plugin's source files, for non-git installs."""
+    digest = hashlib.sha256()
+    try:
+        for path in sorted(p for p in plugin_dir.rglob('*') if p.is_file()):
+            if any(part in _IGNORED_DIRS for part in path.parts):
+                continue
+            if path.suffix in _IGNORED_SUFFIXES:
+                continue
+            digest.update(str(path.relative_to(plugin_dir)).encode())
+            digest.update(path.read_bytes())
+    except Exception:
+        _logger.debug(f"content revision failed for {plugin_dir}", exc_info=True)
+        return None
+    return digest.hexdigest()[:_REVISION_CHARS]

--- a/brainscore_vision/model_helpers/activations/core.py
+++ b/brainscore_vision/model_helpers/activations/core.py
@@ -15,6 +15,8 @@ import xarray as xr
 
 from brainscore_core.supported_data_standards.brainio.assemblies import NeuroidAssembly, walk_coords
 from brainscore_core.supported_data_standards.brainio.stimuli import StimulusSet
+from brainscore_vision.model_helpers.activations.cache_key import (
+    model_cache_identifier, stimulus_set_cache_identifier)
 from brainscore_vision.model_helpers.utils import fullname
 from result_caching import store_xarray
 
@@ -85,9 +87,14 @@ class ActivationsExtractorHelper:
         if layers is None:
             layers = ['logits']
         if self.identifier and stimuli_identifier:
+            # Identifiers alone do not distinguish plugin revisions, so a cache
+            # keyed on them would serve activations from code that no longer
+            # exists. Append a content revision to each. These values are used
+            # *only* to build the cache key -- _from_paths_stored ignores them
+            # otherwise -- so the returned assembly is unaffected.
             fnc = functools.partial(self._from_paths_stored,
-                                    identifier=self.identifier,
-                                    stimuli_identifier=stimuli_identifier,
+                                    identifier=model_cache_identifier(self.identifier),
+                                    stimuli_identifier=stimulus_set_cache_identifier(stimuli_identifier),
                                     require_variance=require_variance)
         else:
             self._logger.debug(f"self.identifier `{self.identifier}` or stimuli_identifier {stimuli_identifier} "

--- a/tests/test_model_helpers/activations/test_cache_key.py
+++ b/tests/test_model_helpers/activations/test_cache_key.py
@@ -1,0 +1,229 @@
+"""Cache-key revisions for stored activations.
+
+The property under test throughout: this module must never be able to fail a
+scoring run. Every resolution path that cannot produce a revision degrades to
+the bare identifier, which reproduces the behaviour that shipped before it.
+"""
+import subprocess
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+from brainscore_vision.model_helpers.activations import cache_key
+from brainscore_vision.model_helpers.activations.cache_key import (
+    _content_revision, _git_revision, model_cache_identifier,
+    stimulus_set_cache_identifier)
+
+
+@pytest.fixture(autouse=True)
+def _clear_revision_cache():
+    """_plugin_revision is lru_cached per process; isolate the tests."""
+    cache_key._plugin_revision.cache_clear()
+    yield
+    cache_key._plugin_revision.cache_clear()
+
+
+class TestEnvironmentOverride:
+    def test_env_var_wins_without_touching_git(self, monkeypatch):
+        monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
+        with mock.patch.object(cache_key, '_locate_plugin_dir') as locate:
+            assert model_cache_identifier('alexnet') == 'alexnet@' + 'a' * 12
+            locate.assert_not_called(), "env var should short-circuit plugin lookup"
+
+    def test_data_plugin_uses_its_own_env_var(self, monkeypatch):
+        monkeypatch.setenv('BRAINSCORE_DATA_PLUGIN_SHA', 'b' * 40)
+        assert stimulus_set_cache_identifier('Papale2025') == 'Papale2025@' + 'b' * 12
+
+    def test_model_env_var_does_not_leak_into_stimuli(self, monkeypatch):
+        """A shared env var would make every stimulus set key on the model."""
+        monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
+            assert stimulus_set_cache_identifier('Papale2025') == 'Papale2025'
+
+
+class TestDegradesInsteadOfFailing:
+    """None of these may raise, and none may invent a revision."""
+
+    def test_unresolvable_plugin_returns_bare_identifier(self, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
+            assert model_cache_identifier('nonexistent_model') == 'nonexistent_model'
+
+    def test_locate_plugin_raising_is_swallowed(self, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
+        from brainscore_core.plugin_management import import_plugin
+        with mock.patch.object(import_plugin.ImportPlugin, 'locate_plugin',
+                               side_effect=AssertionError("No registrations found")):
+            assert model_cache_identifier('alexnet') == 'alexnet'
+
+    def test_git_failure_falls_through_to_content_hash(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
+        (tmp_path / 'model.py').write_text('weights = "v1"')
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=tmp_path), \
+             mock.patch.object(cache_key, '_git_revision', return_value=None):
+            result = model_cache_identifier('alexnet')
+        assert result.startswith('alexnet@') and len(result) == len('alexnet@') + 12
+
+    def test_everything_failing_still_returns_identifier(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=tmp_path), \
+             mock.patch.object(cache_key, '_git_revision', return_value=None), \
+             mock.patch.object(cache_key, '_content_revision', return_value=None):
+            assert model_cache_identifier('alexnet') == 'alexnet'
+
+    def test_falsy_identifier_passes_through(self):
+        """`stimuli_identifier=False` is how callers disable storing."""
+        assert stimulus_set_cache_identifier(False) is False
+        assert stimulus_set_cache_identifier(None) is None
+        assert stimulus_set_cache_identifier('') == ''
+
+
+class TestGitRevisionIsScopedToThePlugin:
+    def test_uses_a_path_scoped_git_log(self, tmp_path):
+        """Repo HEAD would invalidate every model on every unrelated commit."""
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured['cmd'] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout='c' * 40 + '\n', stderr='')
+
+        with mock.patch('subprocess.run', side_effect=fake_run):
+            assert _git_revision(tmp_path) == 'c' * 12
+        assert captured['cmd'][:4] == ['git', 'log', '-1', '--format=%H']
+        assert '--' in captured['cmd'] and str(tmp_path) in captured['cmd'], \
+            "must be scoped to the plugin path, not the whole repository"
+
+    def test_untracked_path_returns_none(self, tmp_path):
+        """Empty git output means untracked; must not be read as a revision."""
+        completed = subprocess.CompletedProcess([], 0, stdout='\n', stderr='')
+        with mock.patch('subprocess.run', return_value=completed):
+            assert _git_revision(tmp_path) is None
+
+    def test_git_absent_returns_none(self, tmp_path):
+        with mock.patch('subprocess.run', side_effect=FileNotFoundError('git')):
+            assert _git_revision(tmp_path) is None
+
+
+class TestContentRevisionTracksContent:
+    def test_changing_a_source_file_changes_the_revision(self, tmp_path):
+        f = tmp_path / 'model.py'
+        f.write_text('weights = "v1"')
+        first = _content_revision(tmp_path)
+        f.write_text('weights = "v2"')
+        assert _content_revision(tmp_path) != first, \
+            "a revised plugin must not reuse the previous cache key"
+
+    def test_identical_contents_give_identical_revisions(self, tmp_path):
+        a, b = tmp_path / 'a', tmp_path / 'b'
+        for d in (a, b):
+            d.mkdir()
+            (d / 'model.py').write_text('weights = "v1"')
+        assert _content_revision(a) == _content_revision(b)
+
+    def test_pycache_is_ignored(self, tmp_path):
+        (tmp_path / 'model.py').write_text('weights = "v1"')
+        before = _content_revision(tmp_path)
+        cachedir = tmp_path / '__pycache__'
+        cachedir.mkdir()
+        (cachedir / 'model.cpython-311.pyc').write_bytes(b'\x00\x01compiled')
+        assert _content_revision(tmp_path) == before, \
+            "recompiling must not invalidate the cache"
+
+    def test_filename_is_part_of_the_hash(self, tmp_path):
+        (tmp_path / 'a.py').write_text('x = 1')
+        first = _content_revision(tmp_path)
+        (tmp_path / 'a.py').unlink()
+        (tmp_path / 'b.py').write_text('x = 1')
+        assert _content_revision(tmp_path) != first
+
+
+class TestKeyActuallyChangesTheStoredIdentifier:
+    """The point of the change: two revisions must not share a cache key."""
+
+    def test_two_revisions_produce_different_keys(self, tmp_path, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
+        (tmp_path / 'model.py').write_text('weights = "v1"')
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=tmp_path), \
+             mock.patch.object(cache_key, '_git_revision', return_value=None):
+            key_v1 = model_cache_identifier('alexnet')
+            cache_key._plugin_revision.cache_clear()
+            (tmp_path / 'model.py').write_text('weights = "v2"')
+            key_v2 = model_cache_identifier('alexnet')
+        assert key_v1 != key_v2, "revising a plugin must land under a new cache key"
+        assert key_v1.startswith('alexnet@') and key_v2.startswith('alexnet@')
+
+
+class TestLogNoise:
+    """Layer commitment calls from_paths repeatedly; an unresolved revision
+    must not emit a line per call, and the routine stimulus-set case must not
+    emit a warning at all."""
+
+    def test_unresolved_model_warns_once_not_per_call(self, monkeypatch, caplog):
+        monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
+            with caplog.at_level('WARNING'):
+                for _ in range(25):
+                    model_cache_identifier('unresolvable_model')
+        warnings = [r for r in caplog.records if r.levelname == 'WARNING']
+        assert len(warnings) == 1, f"expected one warning, got {len(warnings)}"
+
+    def test_unresolved_stimulus_set_does_not_warn(self, monkeypatch, caplog):
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
+            with caplog.at_level('WARNING'):
+                stimulus_set_cache_identifier('SomeBenchmarkLocalStimuli')
+        assert [r for r in caplog.records if r.levelname == 'WARNING'] == [], \
+            "unresolvable stimulus sets are routine; warning on them is log noise"
+
+
+class TestExtractorIntegration:
+    """The enriched identifiers must reach the cache key and nothing else.
+
+    `_from_paths_stored` uses `identifier` / `stimuli_identifier` solely to
+    build the storage key -- it forwards neither into `_from_paths` -- so
+    enriching them must not perturb the returned assembly. These use a stub
+    extractor rather than a real model: the point is the call path, and
+    loading models here would make the suite unrunnable locally.
+    """
+
+    def _stub_extractor(self):
+        from brainscore_vision.model_helpers.activations.core import ActivationsExtractorHelper
+        extractor = ActivationsExtractorHelper.__new__(ActivationsExtractorHelper)
+        extractor.identifier = 'alexnet'
+        extractor._logger = mock.Mock()
+        extractor._from_paths_stored = mock.Mock(return_value='ASSEMBLY')
+        extractor._from_paths = mock.Mock(return_value='ASSEMBLY')
+        extractor._reduce_paths = lambda paths: paths
+        extractor._expand_paths = lambda a, original_paths: a
+        return extractor
+
+    def test_enriched_identifiers_are_passed_to_the_stored_call(self, monkeypatch):
+        monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
+        monkeypatch.setenv('BRAINSCORE_DATA_PLUGIN_SHA', 'b' * 40)
+        extractor = self._stub_extractor()
+        result = extractor.from_paths(stimuli_paths=['x.png'], layers=['fc'],
+                                      stimuli_identifier='Papale2025')
+        assert result == 'ASSEMBLY', "the returned assembly must be untouched"
+        kwargs = extractor._from_paths_stored.call_args[1]
+        assert kwargs['identifier'] == 'alexnet@' + 'a' * 12
+        assert kwargs['stimuli_identifier'] == 'Papale2025@' + 'b' * 12
+
+    def test_model_identifier_attribute_is_not_mutated(self, monkeypatch):
+        """Only the cache key carries the revision; self.identifier is used
+        elsewhere (assembly metadata, logging) and must stay clean."""
+        monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
+        extractor = self._stub_extractor()
+        extractor.from_paths(stimuli_paths=['x.png'], layers=['fc'],
+                             stimuli_identifier='Papale2025')
+        assert extractor.identifier == 'alexnet'
+
+    def test_unstored_path_is_untouched(self):
+        """No stimuli_identifier -> no storing -> cache_key never involved."""
+        extractor = self._stub_extractor()
+        result = extractor.from_paths(stimuli_paths=['x.png'], layers=['fc'],
+                                      stimuli_identifier=None)
+        assert result == 'ASSEMBLY'
+        extractor._from_paths_stored.assert_not_called()
+        extractor._from_paths.assert_called_once()

--- a/tests/test_model_helpers/activations/test_cache_key.py
+++ b/tests/test_model_helpers/activations/test_cache_key.py
@@ -24,18 +24,51 @@ def _clear_revision_cache():
     cache_key._plugin_revision.cache_clear()
 
 
+@pytest.fixture
+def revisioning_on(monkeypatch):
+    """Revisioning is opt-in; most tests here are about what it does when on."""
+    monkeypatch.setenv('BRAINSCORE_CACHE_PLUGIN_REVISION', '1')
+
+
+class TestDisabledByDefault:
+    """result_caching is enabled by default (RESULTCACHING_DISABLE defaults to
+    '0'), so developers have warm local caches keyed on bare identifiers.
+    Revisioning must not silently invalidate them."""
+
+    def test_off_by_default(self, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_CACHE_PLUGIN_REVISION', raising=False)
+        monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
+        assert model_cache_identifier('alexnet') == 'alexnet', \
+            "keys must be byte-for-byte unchanged unless revisioning is opted into"
+        assert stimulus_set_cache_identifier('Papale2025') == 'Papale2025'
+
+    def test_off_does_not_even_look_up_the_plugin(self, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_CACHE_PLUGIN_REVISION', raising=False)
+        with mock.patch.object(cache_key, '_locate_plugin_dir') as locate:
+            model_cache_identifier('alexnet')
+            locate.assert_not_called()
+
+    @pytest.mark.parametrize('value,expected_on', [
+        ('1', True), ('true', True), ('TRUE', True), ('yes', True),
+        ('0', False), ('false', False), ('', False), ('no', False),
+    ])
+    def test_flag_parsing(self, monkeypatch, value, expected_on):
+        monkeypatch.setenv('BRAINSCORE_CACHE_PLUGIN_REVISION', value)
+        assert cache_key.revision_enabled() is expected_on
+
+
 class TestEnvironmentOverride:
-    def test_env_var_wins_without_touching_git(self, monkeypatch):
+    def test_env_var_wins_without_touching_git(self, revisioning_on, monkeypatch):
         monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
         with mock.patch.object(cache_key, '_locate_plugin_dir') as locate:
             assert model_cache_identifier('alexnet') == 'alexnet@' + 'a' * 12
             locate.assert_not_called(), "env var should short-circuit plugin lookup"
 
-    def test_data_plugin_uses_its_own_env_var(self, monkeypatch):
+    def test_data_plugin_uses_its_own_env_var(self, revisioning_on, monkeypatch):
         monkeypatch.setenv('BRAINSCORE_DATA_PLUGIN_SHA', 'b' * 40)
         assert stimulus_set_cache_identifier('Papale2025') == 'Papale2025@' + 'b' * 12
 
-    def test_model_env_var_does_not_leak_into_stimuli(self, monkeypatch):
+    def test_model_env_var_does_not_leak_into_stimuli(self, revisioning_on, monkeypatch):
         """A shared env var would make every stimulus set key on the model."""
         monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
         monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
@@ -46,19 +79,19 @@ class TestEnvironmentOverride:
 class TestDegradesInsteadOfFailing:
     """None of these may raise, and none may invent a revision."""
 
-    def test_unresolvable_plugin_returns_bare_identifier(self, monkeypatch):
+    def test_unresolvable_plugin_returns_bare_identifier(self, revisioning_on, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
             assert model_cache_identifier('nonexistent_model') == 'nonexistent_model'
 
-    def test_locate_plugin_raising_is_swallowed(self, monkeypatch):
+    def test_locate_plugin_raising_is_swallowed(self, revisioning_on, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         from brainscore_core.plugin_management import import_plugin
         with mock.patch.object(import_plugin.ImportPlugin, 'locate_plugin',
                                side_effect=AssertionError("No registrations found")):
             assert model_cache_identifier('alexnet') == 'alexnet'
 
-    def test_git_failure_falls_through_to_content_hash(self, tmp_path, monkeypatch):
+    def test_git_failure_falls_through_to_content_hash(self, revisioning_on, tmp_path, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         (tmp_path / 'model.py').write_text('weights = "v1"')
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=tmp_path), \
@@ -66,14 +99,14 @@ class TestDegradesInsteadOfFailing:
             result = model_cache_identifier('alexnet')
         assert result.startswith('alexnet@') and len(result) == len('alexnet@') + 12
 
-    def test_everything_failing_still_returns_identifier(self, tmp_path, monkeypatch):
+    def test_everything_failing_still_returns_identifier(self, revisioning_on, tmp_path, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=tmp_path), \
              mock.patch.object(cache_key, '_git_revision', return_value=None), \
              mock.patch.object(cache_key, '_content_revision', return_value=None):
             assert model_cache_identifier('alexnet') == 'alexnet'
 
-    def test_falsy_identifier_passes_through(self):
+    def test_falsy_identifier_passes_through(self, revisioning_on):
         """`stimuli_identifier=False` is how callers disable storing."""
         assert stimulus_set_cache_identifier(False) is False
         assert stimulus_set_cache_identifier(None) is None
@@ -142,7 +175,7 @@ class TestContentRevisionTracksContent:
 class TestKeyActuallyChangesTheStoredIdentifier:
     """The point of the change: two revisions must not share a cache key."""
 
-    def test_two_revisions_produce_different_keys(self, tmp_path, monkeypatch):
+    def test_two_revisions_produce_different_keys(self, revisioning_on, tmp_path, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         (tmp_path / 'model.py').write_text('weights = "v1"')
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=tmp_path), \
@@ -160,7 +193,7 @@ class TestLogNoise:
     must not emit a line per call, and the routine stimulus-set case must not
     emit a warning at all."""
 
-    def test_unresolved_model_warns_once_not_per_call(self, monkeypatch, caplog):
+    def test_unresolved_model_warns_once_not_per_call(self, revisioning_on, monkeypatch, caplog):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
             with caplog.at_level('WARNING'):
@@ -169,7 +202,7 @@ class TestLogNoise:
         warnings = [r for r in caplog.records if r.levelname == 'WARNING']
         assert len(warnings) == 1, f"expected one warning, got {len(warnings)}"
 
-    def test_unresolved_stimulus_set_does_not_warn(self, monkeypatch, caplog):
+    def test_unresolved_stimulus_set_does_not_warn(self, revisioning_on, monkeypatch, caplog):
         monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
             with caplog.at_level('WARNING'):
@@ -199,7 +232,7 @@ class TestExtractorIntegration:
         extractor._expand_paths = lambda a, original_paths: a
         return extractor
 
-    def test_enriched_identifiers_are_passed_to_the_stored_call(self, monkeypatch):
+    def test_enriched_identifiers_are_passed_to_the_stored_call(self, revisioning_on, monkeypatch):
         monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
         monkeypatch.setenv('BRAINSCORE_DATA_PLUGIN_SHA', 'b' * 40)
         extractor = self._stub_extractor()
@@ -210,7 +243,7 @@ class TestExtractorIntegration:
         assert kwargs['identifier'] == 'alexnet@' + 'a' * 12
         assert kwargs['stimuli_identifier'] == 'Papale2025@' + 'b' * 12
 
-    def test_model_identifier_attribute_is_not_mutated(self, monkeypatch):
+    def test_model_identifier_attribute_is_not_mutated(self, revisioning_on, monkeypatch):
         """Only the cache key carries the revision; self.identifier is used
         elsewhere (assembly metadata, logging) and must stay clean."""
         monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
@@ -219,7 +252,7 @@ class TestExtractorIntegration:
                              stimuli_identifier='Papale2025')
         assert extractor.identifier == 'alexnet'
 
-    def test_unstored_path_is_untouched(self):
+    def test_unstored_path_is_untouched(self, revisioning_on):
         """No stimuli_identifier -> no storing -> cache_key never involved."""
         extractor = self._stub_extractor()
         result = extractor.from_paths(stimuli_paths=['x.png'], layers=['fc'],


### PR DESCRIPTION
Phase 0 of `tasks/activation_cache_plan.md`. Lands the correctness precondition for the activation cache, **opt-in and off by default**, so nothing changes until production explicitly enables it.

## Why this is a blocker, not a nicety

The extractor is *already* cached — `model_helpers/activations/core.py:112`:

```python
@store_xarray(identifier_ignore=['stimuli_paths', 'layers'],
              combine_fields={'layers': 'layer'})
def _from_paths_stored(self, identifier, layers, stimuli_identifier, ...)
```

`store_xarray` builds its key from the call arguments, principally `identifier` and `stimuli_identifier`. **Neither changes when the contents behind them change.** A model plugin can be revised to load different weights or apply different preprocessing while still registering as `alexnet`.

Enabling a shared cache on that basis would hand back activations produced by code that no longer exists, and the resulting score would look entirely normal on the leaderboard. That is a data-integrity bug, not a performance one, which is why it goes first.

## Opt-in, and why

`result_caching` is enabled by default — `RESULTCACHING_DISABLE` defaults to `'0'` — so developers already hold warm local caches keyed on the bare identifiers. **An earlier revision of this PR claimed "no behaviour change"; that was wrong.** Revisioning unconditionally turns every local cache cold and keeps re-invalidating it on each commit touching the plugin.

Locally the revision is also wrong in both directions at once: `git log -1 -- <dir>` reports the last *commit* touching the directory, so uncommitted working-tree edits resolve to the same revision. It churns on commit while staying blind to the edit actually under test.

So it is gated on `BRAINSCORE_CACHE_PLUGIN_REVISION`:

| | key | plugin lookup |
| --- | --- | --- |
| unset (default, local dev) | `alexnet` | not attempted |
| `=1` (production) | `alexnet@ce04678279e9` | resolved |

Production enables it alongside the shared S3 backend, where the checkout is clean and the cache is long-lived and shared — the only setting where a stale hit can reach a score. **Phase 2 should refuse to start the S3 backend without this flag set**, so the unsafe combination cannot be deployed by omission.

## What the revision is

Resolution order per plugin:

1. `BRAINSCORE_MODEL_PLUGIN_SHA` / `BRAINSCORE_DATA_PLUGIN_SHA` — the orchestrator knows the revision already and can inject it, avoiding a `git` call inside every container.
2. The commit that last touched the plugin directory.
3. A content hash of that directory, for non-git installs.
4. Nothing — the bare identifier.

**The git lookup is scoped to the plugin path deliberately.** Repository HEAD (what `model_plugin_sha` in `brainscore_resource_usage` records) would invalidate every model on every unrelated vision commit, leaving the hit rate near zero and defeating the feature.

Verified against real plugins — `CORnet-S` resolves to directory `cornet_s`, so the registry lookup is genuinely needed rather than a naming convention:

```
alexnet            dir=…/models/alexnet            key=alexnet@ce04678279e9
resnet50_tutorial  dir=…/models/resnet50_tutorial  key=resnet50_tutorial@b87c6ec5797a
CORnet-S           dir=…/models/cornet_s           key=CORnet-S@a58d38198b7a
```

0.12–0.25s per plugin, memoised per process. Content hashing is cheap — there are zero files above 5 MB in any model plugin directory (weights download at runtime).

## Safety properties, each tested

- **Cannot fail a scoring run.** Unregistered model, ambiguous registration, no git, unreadable directory — every path returns the bare identifier.
- **Cannot perturb scores.** `_from_paths_stored` forwards neither value into `_from_paths`; they exist only to build the key. Tests assert the returned assembly is untouched and `self.identifier` is not mutated.
- **Cannot add log noise.** Memoised, so an unresolved *model* revision warns once per process rather than once per `from_paths` call — layer commitment calls in repeatedly. Unresolved *stimulus sets* are routine (benchmark-local assemblies, screen-converted derivatives) and log at debug. Also silences the plugin resolver's `No __init__.py in …` warnings during lookup — pre-existing repo issues this code cannot act on, which would otherwise appear in every container log.

## Tests

`31 passed` in `tests/test_model_helpers/activations/test_cache_key.py`: default-off behaviour and flag parsing; env override short-circuits the lookup; the two env vars do not leak into each other; every failure path degrades instead of raising; the git call is path-scoped and an untracked path is not misread as a revision; content revision tracks contents while ignoring `__pycache__`; two revisions produce different keys; and the extractor call path passes enriched identifiers without touching the assembly.

Extractor integration uses a stub — the existing `tests/test_model_helpers/activations/` suite downloads and runs real models, which is not viable locally.

## Known limitation

`Papale2025` currently resolves to a **bare** stimulus identifier: its stimuli do not come from a registered data plugin under that name, so `_locate_plugin_dir` finds nothing and it degrades as designed. Phase 2 therefore cannot rely on stimulus-set revisions for Papale specifically — if a Papale stimulus set were revised in place, the key would not notice. Phase 1 should decide whether to derive a revision from the assembly's brainio version instead.

## Next

Phase 1: netCDF + manifest + checksum + fail-safe load, replacing the pickle backend that makes caches unusable across pandas/xarray upgrades. Nothing enables the cache until Phase 4.