### PR TITLE
fix(activations): resolve stimulus-set revisions for registered stimuli

### DIFF
--- a/brainscore_vision/model_helpers/activations/cache_key.py
+++ b/brainscore_vision/model_helpers/activations/cache_key.py
@@ -89,29 +89,51 @@ def model_cache_identifier(identifier: str) -> str:
 def stimulus_set_cache_identifier(stimuli_identifier: str) -> str:
     """Stimulus-set identifier with its data-plugin revision appended.
 
-    Stimulus sets reach the extractor through several routes (a registered
-    data plugin, a benchmark-local assembly, a screen-converted derivative),
-    so a revision is often unavailable. That is expected rather than notable —
-    an unresolved stimulus set simply keys as it does today.
+    The identifier arriving here is usually a screen-converted derivative:
+    ``place_on_screen`` rewrites it to
+    ``<base>--target<degrees>--source<degrees>``. Those visual-degree
+    parameters genuinely change the activations, so they stay in the key; only
+    the *revision* is resolved from the base stimulus set.
+
+    Stimulus sets register under ``stimulus_set_registry``, not the
+    ``data_registry`` that ``ImportPlugin`` would infer from the ``data``
+    plugin directory, hence the explicit prefix.
     """
     return _with_revision(stimuli_identifier, plugin_type='data',
-                          env_var='BRAINSCORE_DATA_PLUGIN_SHA', unresolved_is_notable=False)
+                          env_var='BRAINSCORE_DATA_PLUGIN_SHA', unresolved_is_notable=False,
+                          registry_prefix='stimulus_set', base_of=_strip_screen_suffix)
 
 
-def _with_revision(identifier, plugin_type: str, env_var: str, unresolved_is_notable: bool):
+# place_on_screen builds `f"{identifier}--target{...:.2f}--source{...}"`.
+_SCREEN_SUFFIX = '--target'
+
+
+def _strip_screen_suffix(stimuli_identifier: str) -> str:
+    """Base stimulus-set identifier, with any screen conversion suffix removed."""
+    return stimuli_identifier.split(_SCREEN_SUFFIX, 1)[0]
+
+
+def _with_revision(identifier, plugin_type: str, env_var: str, unresolved_is_notable: bool,
+                   registry_prefix: Optional[str] = None, base_of=None):
     if not revision_enabled():
         return identifier
     if not identifier or not isinstance(identifier, str):
         # `stimuli_identifier` is False when the caller disables storing.
         return identifier
-    revision = _plugin_revision(plugin_type=plugin_type, identifier=identifier, env_var=env_var,
-                               unresolved_is_notable=unresolved_is_notable)
+    # The revision is resolved from the base plugin, but the *full* identifier
+    # stays in the key: derived parameters (e.g. visual degrees) change the
+    # activations and must not collapse onto the same entry.
+    lookup_identifier = base_of(identifier) if base_of else identifier
+    revision = _plugin_revision(plugin_type=plugin_type, identifier=lookup_identifier,
+                               env_var=env_var, unresolved_is_notable=unresolved_is_notable,
+                               registry_prefix=registry_prefix)
     return f"{identifier}@{revision}" if revision else identifier
 
 
 @lru_cache(maxsize=None)
 def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
-                     unresolved_is_notable: bool = True) -> Optional[str]:
+                     unresolved_is_notable: bool = True,
+                     registry_prefix: Optional[str] = None) -> Optional[str]:
     """Short revision string for a plugin, or None if it cannot be determined.
 
     Cached per process, which also means the "unresolved" log line is emitted
@@ -123,7 +145,8 @@ def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
     if from_env:
         return from_env.strip()[:_REVISION_CHARS]
 
-    plugin_dir = _locate_plugin_dir(plugin_type=plugin_type, identifier=identifier)
+    plugin_dir = _locate_plugin_dir(plugin_type=plugin_type, identifier=identifier,
+                                    registry_prefix=registry_prefix)
     revision = None
     if plugin_dir is not None:
         revision = _git_revision(plugin_dir) or _content_revision(plugin_dir)
@@ -139,12 +162,13 @@ def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
     return revision
 
 
-def _locate_plugin_dir(plugin_type: str, identifier: str) -> Optional[Path]:
+def _locate_plugin_dir(plugin_type: str, identifier: str,
+                       registry_prefix: Optional[str] = None) -> Optional[Path]:
     try:
         from brainscore_core.plugin_management import import_plugin as _import_plugin
         from brainscore_core.plugin_management.import_plugin import ImportPlugin
         importer = ImportPlugin(library_root='brainscore_vision', plugin_type=plugin_type,
-                                identifier=identifier)
+                                identifier=identifier, registry_prefix=registry_prefix)
         # locate_plugin scans every plugin directory and warns about each one
         # missing an __init__.py. Those are pre-existing repo issues, not
         # anything this lookup can act on, and they would appear in every

--- a/tests/test_model_helpers/activations/test_cache_key.py
+++ b/tests/test_model_helpers/activations/test_cache_key.py
@@ -260,3 +260,36 @@ class TestExtractorIntegration:
         assert result == 'ASSEMBLY'
         extractor._from_paths_stored.assert_not_called()
         extractor._from_paths.assert_called_once()
+
+
+class TestStimulusSetRevisionResolution:
+    """Papale2025-style stimulus sets: registered under stimulus_set_registry
+    (not data_registry), and reaching the extractor as a screen-converted
+    derivative. Both had to be handled for the pilot benchmark's stimuli to
+    carry a revision at all."""
+
+    def test_base_stimulus_set_resolves(self, revisioning_on, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        result = stimulus_set_cache_identifier('Papale2025_stim_test')
+        assert result.startswith('Papale2025_stim_test@'), result
+
+    def test_screen_converted_identifier_resolves(self, revisioning_on, monkeypatch):
+        """place_on_screen rewrites to `<base>--target<deg>--source<deg>`."""
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        result = stimulus_set_cache_identifier('Papale2025_stim_test--target8.00--source8.00')
+        assert result.startswith('Papale2025_stim_test--target8.00--source8.00@'), result
+
+    def test_visual_degrees_stay_in_the_key(self, revisioning_on, monkeypatch):
+        """Different degrees mean different activations -- they must not
+        collapse onto one cache entry, even though the revision is shared."""
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        eight = stimulus_set_cache_identifier('Papale2025_stim_test--target8.00--source8.00')
+        four = stimulus_set_cache_identifier('Papale2025_stim_test--target4.00--source8.00')
+        assert eight != four
+        assert eight.rsplit('@', 1)[1] == four.rsplit('@', 1)[1], \
+            "same underlying stimulus set => same revision"
+
+    def test_strip_screen_suffix(self):
+        from brainscore_vision.model_helpers.activations.cache_key import _strip_screen_suffix
+        assert _strip_screen_suffix('X--target8.00--source8.00') == 'X'
+        assert _strip_screen_suffix('X') == 'X'


### PR DESCRIPTION
Stacked on #2472 (Phase 0). Closes the gap that PR surfaced: `Papale2025` — the pilot benchmark — resolved to a **bare** stimulus identifier, so a stimulus set revised in place would not have invalidated the cache.

Companion: `brain-score/result_caching#22` carries the netCDF + manifest format half of Phase 1.

## Two reasons the lookup missed

**1. Wrong registry.** `ImportPlugin` infers its registry name from the plugin directory:

```python
registry_prefix = registry_prefix or self.plugin_type.strip('s')   # 'data' -> data_registry
```

Stimulus sets register in `stimulus_set_registry`, not `data_registry`, so every lookup failed. Verified directly:

```
registry=data_registry          id=Papale2025_stim_test   -> FAILED (AssertionError)
registry=stimulus_set_registry  id=Papale2025_stim_test   -> papale2025
```

**2. The identifier is rewritten before the extractor sees it.** `place_on_screen` (`benchmark_helpers/screen.py:52`) builds:

```python
converted_stimuli_id = f"{stimuli_identifier}--target{target_visual_degrees:.2f}--source{source_degrees_formatted}"
```

So the lookup was searching for `Papale2025_stim_test--target8.00--source8.00`, a derived name no registry contains.

## Fix

Pass `registry_prefix='stimulus_set'` explicitly, and resolve the revision from the **base** identifier while keeping the **full** identifier in the cache key:

```
Papale2025_stim_test                              -> Papale2025_stim_test@73af235ad3c0
Papale2025_stim_test--target8.00--source8.00      -> …--target8.00--source8.00@73af235ad3c0
Papale2025_stim_test--target4.00--source8.00      -> …--target4.00--source8.00@73af235ad3c0
```

That split matters in both directions: the visual degrees change the activations, so they must stay in the key and not collapse onto one entry; but they do not change the underlying stimulus set, so the two share a revision.

## Why this is sufficient for Papale

Its registry pins exact S3 object versions as source literals:

```python
stimulus_set_registry['Papale2025_stim_test'] = lambda: load_stimulus_set_from_s3(
    ...
    csv_version_id="gEGUgT7PJB8z3roRkTiJ6zriSuehd2DI",
    zip_version_id="AGNDfuS5nyIjTuXrM4hWFze.sWM9py2Z")
```

Revising the underlying data therefore requires editing the plugin, which the plugin revision already captures. Resolving the plugin **at all** is what closes the gap — no separate brainio-version plumbing needed, which was the alternative under consideration.

## Tests

`35 passed` (4 new). New coverage: the base identifier resolves; the screen-converted identifier resolves; different visual degrees produce different keys but share a revision; and `_strip_screen_suffix` is a no-op on unsuffixed identifiers.

Still opt-in behind `BRAINSCORE_CACHE_PLUGIN_REVISION` from #2472 — nothing changes for local developers.