### PR TITLE
fix(memory): probe the layer the benchmark records from, not IT

### DIFF
--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -312,10 +312,19 @@ def _is_ridge_benchmark(benchmark) -> bool:
     return ident.endswith('-ridge') or ident.endswith('-ridgecv')
 
 
-def _get_probe_layer(model):
+def _get_probe_layer(model, region: Optional[str] = None):
     """
-    Return the committed layer string for the model's primary recording region,
-    or None if it cannot be determined without triggering expensive layer selection.
+    Return the committed layer string to probe for memory estimation.
+
+    ``region`` is the region the benchmark actually records from, and it is
+    tried first. Without it this fell back to an IT-first preference, so a V1
+    benchmark was sized using IT's layer -- on AlexNet that is ``features.12``
+    (256x6x6 = 9,216) instead of ``features.2`` (64x27x27 = 46,656), a 5.1x
+    underestimate of the activation array. Build 92 cached [1000, 46656] while
+    its preflight reported 9,216 features for the same V1 benchmark.
+
+    The region was already known at the call site and used by the ``look_at``
+    fallback path below; only the fast path ignored it.
     """
     try:
         # Navigate ModelCommitment → TemporalAligned → LayerMappedModel
@@ -329,9 +338,11 @@ def _get_probe_layer(model):
         if rmap is None:
             return None
 
-        # Prefer IT, then any committed region.
+        # The benchmark's own region first; the descending fallback only
+        # applies when the caller could not tell us which region is recorded.
+        candidates = ([region] if region else []) + ['IT', 'V4', 'V2', 'V1']
         # Use dict.__contains__ to avoid triggering lazy RegionLayerMap.__getitem__
-        for candidate_region in ['IT', 'V4', 'V2', 'V1']:
+        for candidate_region in candidates:
             if dict.__contains__(rmap, candidate_region):
                 layers = dict.__getitem__(rmap, candidate_region)
                 if layers is not None:
@@ -467,7 +478,7 @@ def preallocate_memory(
     # ------------------------------------------------------------------ #
     _am = getattr(model, 'activations_model', None)
     _extractor = getattr(_am, '_extractor', None) if _am else None
-    probe_layer = _get_probe_layer(model) if _extractor is not None else None
+    probe_layer = _get_probe_layer(model, region) if _extractor is not None else None
 
     if _extractor is not None and probe_layer is not None:
         # Fast path: call _from_paths directly — no attach_stimulus_set_meta

--- a/tests/test_plugin_management/test_memory_precheck.py
+++ b/tests/test_plugin_management/test_memory_precheck.py
@@ -815,3 +815,67 @@ class TestAvailableMemoryIsContainerAware(unittest.TestCase):
         with self._patch_cgroup(values), \
              patch.object(mem.psutil, 'virtual_memory', return_value=host):
             self.assertLess(mem.available_memory_gb(), 1.5)
+
+
+class TestProbeLayerUsesBenchmarkRegion(unittest.TestCase):
+    """The preflight must size the layer the benchmark actually records from.
+
+    Regression from build 92: the cache was written with shape [1000, 46656]
+    (AlexNet ``features.2``, the V1 layer) while the preflight for the same
+    Li2026.V1-ridgecv benchmark reported ``features=9216`` (``features.12``,
+    the IT layer) -- a 5.1x underestimate of the activation array, because
+    _get_probe_layer preferred IT regardless of the benchmark's region.
+
+    The region was already available at the call site and already used by the
+    look_at fallback; only the fast path ignored it.
+    """
+
+    # the real map recorded on both build-92 scores
+    LAYER_MAP = {'V1': 'features.2', 'V2': 'features.7',
+                 'V4': 'features.7', 'IT': 'features.12'}
+
+    def _model(self):
+        from brainscore_vision.benchmark_helpers import memory as mem
+        model = MagicMock()
+        inner = MagicMock()
+        inner.region_layer_map = dict(self.LAYER_MAP)
+        del inner._layer_model            # stop MagicMock auto-creating it
+        model.layer_model = inner
+        return model
+
+    def test_each_region_probes_its_own_layer(self):
+        from brainscore_vision.benchmark_helpers.memory import _get_probe_layer
+        model = self._model()
+        for region, expected in self.LAYER_MAP.items():
+            self.assertEqual(_get_probe_layer(model, region), expected,
+                             f"region {region} must probe {expected}")
+
+    def test_v1_no_longer_probes_the_it_layer(self):
+        """The specific defect: V1 was sized with features.12."""
+        from brainscore_vision.benchmark_helpers.memory import _get_probe_layer
+        self.assertEqual(_get_probe_layer(self._model(), 'V1'), 'features.2')
+        self.assertNotEqual(_get_probe_layer(self._model(), 'V1'), 'features.12')
+
+    def test_unknown_region_keeps_the_it_first_fallback(self):
+        """Callers that cannot supply a region must behave as before."""
+        from brainscore_vision.benchmark_helpers.memory import _get_probe_layer
+        self.assertEqual(_get_probe_layer(self._model(), None), 'features.12')
+        self.assertEqual(_get_probe_layer(self._model()), 'features.12')
+
+    def test_region_absent_from_the_map_falls_back(self):
+        from brainscore_vision.benchmark_helpers.memory import _get_probe_layer
+        model = MagicMock()
+        inner = MagicMock()
+        inner.region_layer_map = {'IT': 'features.12'}
+        del inner._layer_model
+        model.layer_model = inner
+        self.assertEqual(_get_probe_layer(model, 'V1'), 'features.12')
+
+    def test_list_valued_layer_map_takes_the_first(self):
+        from brainscore_vision.benchmark_helpers.memory import _get_probe_layer
+        model = MagicMock()
+        inner = MagicMock()
+        inner.region_layer_map = {'V1': ['features.2', 'features.5']}
+        del inner._layer_model
+        model.layer_model = inner
+        self.assertEqual(_get_probe_layer(model, 'V1'), 'features.2')


### PR DESCRIPTION
Found while investigating a discrepancy in the activation-cache trial (build 92).

## The observation

The cache was written with shape **`[1000, 46656]`** for `Li2026.V1-rdm`, while the preflight for `Li2026.V1-ridgecv` — same model, same region — reported **`features=9216`**.

Both scores record the identical committed map:

```
layers: {'V1': 'features.2', 'V2': 'features.7', 'V4': 'features.7', 'IT': 'features.12'}
```

On AlexNet, `features.2` is 64x27x27 = **46,656** and `features.12` is 256x6x6 = **9,216**. The preflight was sizing the **IT** layer for a **V1** benchmark — a **5.1x** underestimate of the activation array.

## Cause

```python
# Prefer IT, then any committed region.
for candidate_region in ['IT', 'V4', 'V2', 'V1']:
```

`_get_probe_layer` preferred IT unconditionally. The benchmark's `region` was already computed at the call site and already used by the `look_at` fallback a few lines below — only the fast extractor path ignored it. Now passed in and tried first; the descending order remains for callers that genuinely cannot supply a region.

## This likely explains the preflight underestimation we measured

From the Li2026 backfill (2026-08-04), estimate vs actual peak:

| formula | mean est | mean actual |
| --- | --- | --- |
| `rdm` | 1.41 GB | **6.52 GB** |
| `ridge_large_feature` | 3.07 GB | **10.61 GB** |

3.5–4.6x under, the same order as this layer error.

## Consequence for #2444 — please read before merging

`_BENCHMARK_SCAFFOLDING_OVERHEAD_GB` was fitted as `p50(real_peak) - p50(formula_estimate)` **with the estimate computed from the wrong layer**, so those constants partly absorb this bug. The pattern in the table is telling — within every family the overhead decreases from V1 to IT:

```
family                                V1      V2      V4      IT    monotonic?
Allen2022_fmri_surface-ridge        12.4     4.7     3.8     3.6      YES
Zerbe2026_fmri-tau-ridgecv          42.0    15.8    13.7    13.7      YES
Zerbe2026_fmri-rdm-pearson          19.0    11.8    11.8    10.5      YES
Zerbe2026_fmri-ood-ridgecv             -    16.5    14.4    13.7      YES
Allen2022_fmri_surface-rdm           6.4     2.9     3.0     2.7      no (0.1 GB inversion)
```

That is what a layer-driven bias looks like: largest where the true layer has the most features, smallest at IT where the estimate and reality already agreed. The IT values are plausibly the *genuine* scaffolding; the V1 excess is largely this error.

**Caveat, stated because it matters:** larger V1 assemblies (more voxels/neuroids) would also produce a V1-heavy pattern, so this is consistent evidence rather than proof. Either way the base estimate changes with this fix, so **the table needs refitting before it can be trusted** — otherwise V1/V2/V4 benchmarks will now over-estimate and escalate tiers unnecessarily. I have deliberately left the table untouched rather than guess new constants.

## Tests

`55 passed` in `test_memory_precheck.py`, `85 passed` across `test_plugin_management`. Five new tests: each region probes its own layer; V1 specifically no longer probes `features.12`; an absent region keeps the IT-first fallback; a region missing from the map falls back; list-valued map entries take the first. Verified load-bearing — reverting the one-line preference fails 2 of them.

## Follow-up

Refitting the scaffolding table wants a fresh measurement run with this fix in place, comparing `preflight_estimate_gb` against `max_memory_gb` in `brainscore_resource_usage` per benchmark. Worth pairing with #2474 (dual ridge for Papale/Gifford/Hebart), since that changes peak memory for those same benchmarks and the two together would otherwise need two refits.