### PR TITLE
fix(cache): resolve stimulus-set revisions for the activation cache key

### DIFF
--- a/brainscore_vision/model_helpers/activations/cache_key.py
+++ b/brainscore_vision/model_helpers/activations/cache_key.py
@@ -69,6 +69,10 @@ _IGNORED_DIRS = ('__pycache__', '.git', '.pytest_cache')
 # Opt-in switch. Unset => keys are exactly what they were before this module.
 _ENABLE_VAR = 'BRAINSCORE_CACHE_PLUGIN_REVISION'
 
+# Marks the start of the suffix `benchmark_helpers.screen.place_on_screen`
+# appends: `--target<deg>--source<deg>`. Kept in sync with that f-string.
+_SCREEN_SUFFIX = '--target'
+
 
 def revision_enabled() -> bool:
     """True if cache keys should carry plugin revisions.
@@ -91,27 +95,55 @@ def stimulus_set_cache_identifier(stimuli_identifier: str) -> str:
 
     Stimulus sets reach the extractor through several routes (a registered
     data plugin, a benchmark-local assembly, a screen-converted derivative),
-    so a revision is often unavailable. That is expected rather than notable —
-    an unresolved stimulus set simply keys as it does today.
+    so a revision is sometimes unavailable. That is expected rather than
+    notable — an unresolved stimulus set simply keys as it does today.
+
+    Two of those routes need translating before the plugin resolver can find
+    anything, and both were silently unresolvable until they were fixed:
+    stimulus sets register under ``stimulus_set_registry`` rather than the
+    ``data_registry`` inferred from the directory name, and a screen-converted
+    set carries a suffix that is not registered at all.
     """
     return _with_revision(stimuli_identifier, plugin_type='data',
-                          env_var='BRAINSCORE_DATA_PLUGIN_SHA', unresolved_is_notable=False)
+                          env_var='BRAINSCORE_DATA_PLUGIN_SHA', unresolved_is_notable=False,
+                          registry_prefixes=('stimulus_set', 'data'),
+                          lookup_identifier=base_stimulus_identifier(stimuli_identifier))
 
 
-def _with_revision(identifier, plugin_type: str, env_var: str, unresolved_is_notable: bool):
+def base_stimulus_identifier(stimuli_identifier: str) -> str:
+    """The registered stimulus set a screen-converted identifier derives from.
+
+    ``place_on_screen`` renames its output to
+    ``<identifier>--target<deg>--source<deg>``, which is not a registered
+    plugin, so resolving the suffixed name finds nothing. Rescaling is a pure
+    function of the source images plus the two degree values already in the
+    key, so the revision of the set they came from is what needs tracking.
+    """
+    if not isinstance(stimuli_identifier, str):
+        return stimuli_identifier
+    return stimuli_identifier.split(_SCREEN_SUFFIX)[0]
+
+
+def _with_revision(identifier, plugin_type: str, env_var: str, unresolved_is_notable: bool,
+                   registry_prefixes: tuple = (None,), lookup_identifier: Optional[str] = None):
     if not revision_enabled():
         return identifier
     if not identifier or not isinstance(identifier, str):
         # `stimuli_identifier` is False when the caller disables storing.
         return identifier
-    revision = _plugin_revision(plugin_type=plugin_type, identifier=identifier, env_var=env_var,
-                               unresolved_is_notable=unresolved_is_notable)
+    revision = _plugin_revision(plugin_type=plugin_type,
+                                identifier=lookup_identifier or identifier, env_var=env_var,
+                                unresolved_is_notable=unresolved_is_notable,
+                                registry_prefixes=registry_prefixes)
+    # The revision is appended to the *full* identifier: the screen suffix
+    # carries the degree conversion, which changes the activations.
     return f"{identifier}@{revision}" if revision else identifier
 
 
 @lru_cache(maxsize=None)
 def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
-                     unresolved_is_notable: bool = True) -> Optional[str]:
+                     unresolved_is_notable: bool = True,
+                     registry_prefixes: tuple = (None,)) -> Optional[str]:
     """Short revision string for a plugin, or None if it cannot be determined.
 
     Cached per process, which also means the "unresolved" log line is emitted
@@ -123,7 +155,12 @@ def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
     if from_env:
         return from_env.strip()[:_REVISION_CHARS]
 
-    plugin_dir = _locate_plugin_dir(plugin_type=plugin_type, identifier=identifier)
+    plugin_dir = None
+    for registry_prefix in registry_prefixes:
+        plugin_dir = _locate_plugin_dir(plugin_type=plugin_type, identifier=identifier,
+                                        registry_prefix=registry_prefix)
+        if plugin_dir is not None:
+            break
     revision = None
     if plugin_dir is not None:
         revision = _git_revision(plugin_dir) or _content_revision(plugin_dir)
@@ -131,32 +168,42 @@ def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
         # An unresolved *model* revision means the cache cannot tell two
         # revisions of the same plugin apart, which is the failure this module
         # exists to prevent -- worth surfacing. An unresolved stimulus set is
-        # routine.
-        log = _logger.warning if unresolved_is_notable else _logger.debug
+        # routine, but logging it at debug is how two resolver bugs went
+        # unnoticed until a cache key was read by hand.
+        log = _logger.warning if unresolved_is_notable else _logger.info
         log(f"Could not resolve a {plugin_type} revision for '{identifier}'; the activation "
             f"cache key cannot distinguish revisions of this plugin. "
             f"Set {env_var} to make it explicit.")
     return revision
 
 
-def _locate_plugin_dir(plugin_type: str, identifier: str) -> Optional[Path]:
+def _locate_plugin_dir(plugin_type: str, identifier: str,
+                       registry_prefix: Optional[str] = None) -> Optional[Path]:
+    """Directory of the plugin registering ``identifier``, or None.
+
+    ``registry_prefix`` overrides the registry name ``ImportPlugin`` would
+    infer from ``plugin_type``. It has to be given for stimulus sets: they
+    live in ``data/`` alongside assemblies but register under
+    ``stimulus_set_registry``, and the inferred ``data_registry`` matches none
+    of the 154 registered sets.
+    """
     try:
         from brainscore_core.plugin_management import import_plugin as _import_plugin
         from brainscore_core.plugin_management.import_plugin import ImportPlugin
-        importer = ImportPlugin(library_root='brainscore_vision', plugin_type=plugin_type,
-                                identifier=identifier)
         # locate_plugin scans every plugin directory and warns about each one
         # missing an __init__.py. Those are pre-existing repo issues, not
         # anything this lookup can act on, and they would appear in every
-        # container log. Silence them for the duration of the scan only.
+        # container log. Silence them for the duration of the scan only --
+        # which means covering the constructor, since that is what scans.
         resolver_logger = logging.getLogger(_import_plugin.__name__)
         previous_level = resolver_logger.level
         resolver_logger.setLevel(logging.ERROR)
         try:
-            dirname = importer.locate_plugin()
+            importer = ImportPlugin(library_root='brainscore_vision', plugin_type=plugin_type,
+                                    identifier=identifier, registry_prefix=registry_prefix)
         finally:
             resolver_logger.setLevel(previous_level)
-        plugin_dir = Path(importer.plugins_dir) / dirname
+        plugin_dir = Path(importer.plugins_dir) / importer.plugin_dirname
         return plugin_dir if plugin_dir.is_dir() else None
     except Exception:
         # Unregistered identifier, ambiguous registration, or a layout this

--- a/tests/test_model_helpers/activations/test_cache_key.py
+++ b/tests/test_model_helpers/activations/test_cache_key.py
@@ -260,3 +260,70 @@ class TestExtractorIntegration:
         assert result == 'ASSEMBLY'
         extractor._from_paths_stored.assert_not_called()
         extractor._from_paths.assert_called_once()
+
+
+class TestStimulusSetResolution:
+    """Both of these resolved to nothing before, so a stimulus set revised in
+    place kept its old cache entry -- the exact failure this module exists to
+    prevent, silently, on the stimulus half of the key."""
+
+    def test_registry_prefix_is_required_to_find_a_stimulus_set(self):
+        """The bug, pinned. ImportPlugin infers the registry name from the
+        directory: 'data'.strip('s') -> data_registry. Stimulus sets register
+        under stimulus_set_registry, so the inferred name matches none of them.
+        """
+        inferred = cache_key._locate_plugin_dir(plugin_type='data', identifier='hvm-public')
+        explicit = cache_key._locate_plugin_dir(plugin_type='data', identifier='hvm-public',
+                                                registry_prefix='stimulus_set')
+        assert inferred is None, "if this resolves, the fallback below is no longer needed"
+        assert explicit is not None and explicit.name == 'majajhong2015'
+
+    def test_a_registered_stimulus_set_gets_a_revision(self, revisioning_on, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        assert stimulus_set_cache_identifier('hvm-public').startswith('hvm-public@')
+
+    def test_an_assembly_named_identifier_still_resolves(self, revisioning_on, monkeypatch):
+        """Some benchmarks pass an identifier that only exists in the
+        data_registry (MajajHong2015's stimulus sets are named 'hvm*'), so the
+        stimulus_set prefix alone is not enough."""
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        assert stimulus_set_cache_identifier('MajajHong2015').startswith('MajajHong2015@')
+
+    def test_unregistered_identifier_is_still_returned_bare(self, revisioning_on, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        assert stimulus_set_cache_identifier('NotARegisteredStimulusSet') == 'NotARegisteredStimulusSet'
+
+
+class TestScreenConvertedIdentifiers:
+    """`place_on_screen` renames its output to
+    `<id>--target<deg>--source<deg>`, which is not a registered plugin."""
+
+    def test_suffix_is_stripped_for_the_lookup(self):
+        assert cache_key.base_stimulus_identifier('hvm-public--target8.00--source11.00') == 'hvm-public'
+
+    def test_converted_set_resolves_to_its_source_revision(self, revisioning_on, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        plain = stimulus_set_cache_identifier('hvm-public')
+        converted = stimulus_set_cache_identifier('hvm-public--target8.00--source11.00')
+        assert '@' in converted, "the observed bug: no revision on a screen-converted set"
+        assert converted.split('@')[1] == plain.split('@')[1]
+
+    def test_the_degree_conversion_stays_in_the_key(self, revisioning_on, monkeypatch):
+        """Rescaling changes the activations, so the suffix must survive into
+        the key -- the revision is appended to the full identifier, not the
+        stripped one."""
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        eight = stimulus_set_cache_identifier('hvm-public--target8.00--source11.00')
+        ten = stimulus_set_cache_identifier('hvm-public--target10.00--source11.00')
+        assert eight != ten
+        assert eight.startswith('hvm-public--target8.00--source11.00@')
+
+    def test_suffix_constant_matches_screen_py(self):
+        """_SCREEN_SUFFIX duplicates a literal from screen.py's f-string."""
+        from brainscore_vision.benchmark_helpers import screen
+        source = Path(screen.__file__).read_text()
+        assert f'{cache_key._SCREEN_SUFFIX}{{target_visual_degrees:.2f}}' in source, \
+            "place_on_screen's suffix changed; update _SCREEN_SUFFIX"
+
+    def test_non_string_identifier_passes_through(self):
+        assert cache_key.base_stimulus_identifier(False) is False


### PR DESCRIPTION
Found by reading a real cache key from the build-92 activation-cache trial.

## The observation

The entry was written under:

```
stimuli_identifier=Li2026_Stimuli--target8.00--source11.00
```

No `@revision`. The **model** half of the key was revisioned as designed; the **stimulus** half silently was not. A stimulus set re-uploaded under the same name would have kept serving activations extracted from the old images — with a normal-looking score.

## Two independent failures, both returning `None`

**1. Wrong registry name.** `ImportPlugin` infers it from the directory:

```python
registry_prefix = registry_prefix or self.plugin_type.strip('s')   # 'data' -> data_registry
```

Stimulus sets live in `data/` but register under **`stimulus_set_registry`** — 154 of them. The inferred `data_registry['hvm-public']` matched nothing, every time.

Now passed explicitly, with `data` as a fallback, because the fallback is load-bearing:

```
data_registry['MajajHong2015']          <- some benchmarks pass this as stimuli_identifier
stimulus_set_registry['hvm-public']     <- the actual stimulus sets
```

`MajajHong2015` resolves only via `data`, `hvm-public` only via `stimulus_set`. Both occur.

**2. The screen suffix.** `place_on_screen` renames its output to `<id>--target<deg>--source<deg>`, which is not a registered plugin. The lookup now strips it — but **the key keeps it**, since rescaling changes the activations:

```
hvm-public--target8.00--source11.00@4b847c8b0893
hvm-public--target10.00--source11.00@4b847c8b0893   different key, same source revision
```

## Two smaller things while in here

- Unresolved stimulus revisions log at **info**, not debug. Genuinely benchmark-local sets are routine and must not warn, but debug is precisely how both bugs above went unnoticed until a key was read by hand.
- The `ImportPlugin` construction moved **inside** the log-silencing block. The constructor is what scans plugin directories and emits the `No __init__.py` warnings, so silencing only the following `locate_plugin()` call suppressed nothing.

## Verification

Against the real registry, not mocks:

| identifier | result |
| --- | --- |
| `hvm-public` | `hvm-public@4b847c8b0893` (via `stimulus_set`) |
| `MajajHong2015` | `MajajHong2015@4b847c8b0893` (via `data` fallback) |
| `hvm-public--target8.00--source11.00` | inherits the source revision |
| `NotARegisteredStimulusSet` | returned bare, no failure |

Many data plugins share `4b847c8b` legitimately — that commit ("Data plugins brainio", #2018) touched 114 files, and most data plugins have not been modified since. Model revisions remain distinct per plugin (`alexnet@ce04678279e9`, `resnet-50-robust@284d8909f74f`), confirming the constructor move did not break path scoping.

**11 new tests, 40 passed.** Reverting the two fixes fails 3 — including `test_registry_prefix_is_required_to_find_a_stimulus_set`, which asserts the *inferred* prefix still finds nothing, so the fallback cannot be quietly dropped later. One test guards the duplicated `--target` literal against `screen.py` drifting.

## Scope

Revisioning is opt-in (`BRAINSCORE_CACHE_PLUGIN_REVISION`), so with it unset nothing here changes any key. Stacks cleanly with #2475 — different files.