### PR TITLE
fix(memory): stop the rdm branch discarding the calibrated fixed cost

### DIFF
--- a/brainscore_vision/benchmark_helpers/memory.py
+++ b/brainscore_vision/benchmark_helpers/memory.py
@@ -561,7 +561,12 @@ def preallocate_memory(
         # Overhead ≈ 2× activation_gb (scales with features, not n_stimuli²).
         # Validated across alexnet/resnet50/ViT on Allen2022_fmri.IT-rdm.
         rdm_overhead_gb = 2 * activation_gb
-        total_estimated_gb = activation_gb + rdm_overhead_gb  # = 3 × activation_gb
+        # + the calibrated fixed cost, which this branch used to drop on the
+        # floor: it is the only branch that can be reached with a non-None
+        # fixed_benchmark_cost_gb and not add it, so 19 of the 88 measured
+        # entries (0.4-2.0 GB each, all the *-rdm* keys) were never applied.
+        total_estimated_gb = (activation_gb + rdm_overhead_gb          # = 3 x activation_gb
+                              + (fixed_benchmark_cost_gb or 0.0))
         formula_type = 'rdm'
     elif fixed_benchmark_cost_gb is not None and ridge_large_feature:
         # Both predictors apply. Take the max — they measure complementary

--- a/tests/test_plugin_management/test_memory_precheck.py
+++ b/tests/test_plugin_management/test_memory_precheck.py
@@ -879,3 +879,73 @@ class TestProbeLayerUsesBenchmarkRegion(unittest.TestCase):
         del inner._layer_model
         model.layer_model = inner
         self.assertEqual(_get_probe_layer(model, 'V1'), 'features.2')
+
+
+class TestFixedCostReachesEveryFormula(unittest.TestCase):
+    """A measured fixed cost must survive whichever formula branch is chosen.
+
+    The rdm branch used to compute ``activation + 2*activation`` and return,
+    silently discarding ``fixed_benchmark_cost_gb``. It is the only branch that
+    can be reached with a non-None fixed cost without adding it, so every
+    ``*-rdm*`` key in benchmark_costs.json -- 19 of the 88 entries, 0.4-2.0 GB
+    each -- was measured, shipped, loaded, and then dropped on the floor.
+
+    Written as a property over identifier shapes rather than a single rdm
+    assertion: the branch order is subtle enough that the next formula added
+    could reintroduce this, and only the shapes below select a branch that is
+    reachable with a non-None fixed cost.
+    """
+
+    # identifier -> the formula branch it selects
+    SHAPES = {
+        'test.IT-pls': 'pls',
+        'test.IT-reverse_pls': 'pls',
+        'test.IT-rdm': 'rdm',
+        'test.IT-rdm-pearson': 'rdm',
+        'test.IT-ridgecv': 'calibrated',
+        'test.IT-ridge': 'calibrated',
+    }
+    FIXED_GB = 5.0
+
+    def _estimate(self, identifier, fixed_cost):
+        bm = _make_neural_benchmark(n_stimuli=10)
+        bm._identifier = identifier
+        model = _make_model(num_features=512)
+        with patch('psutil.virtual_memory') as mock_vm:
+            mock_vm.return_value.available = 512 * (1024 ** 3)
+            return preallocate_memory(model, bm, raise_if_oom=False,
+                                      fixed_benchmark_cost_gb=fixed_cost)
+
+    def test_a_supplied_fixed_cost_is_never_discarded(self):
+        """The measured cost is a floor on the estimate.
+
+        Stated as a floor rather than "is added" because the ridge branch
+        takes ``max(activation + fixed, activation * factor)`` -- the two
+        predictors measure complementary things. A floor is the invariant both
+        semantics satisfy, and it is what the rdm branch violated: 3x a 20 KB
+        activation array is nowhere near a measured 5 GB.
+        """
+        for identifier, expected_formula in self.SHAPES.items():
+            with self.subTest(identifier=identifier):
+                with_cost = self._estimate(identifier, self.FIXED_GB)
+                self.assertEqual(with_cost.formula_type, expected_formula)
+                self.assertGreaterEqual(
+                    with_cost.total_estimated_gb, self.FIXED_GB,
+                    msg=f"{identifier} ({expected_formula}) discarded the fixed cost")
+
+    def test_the_estimate_is_monotonic_in_the_fixed_cost(self):
+        """A larger measured cost can never produce a smaller estimate."""
+        for identifier in self.SHAPES:
+            with self.subTest(identifier=identifier):
+                totals = [self._estimate(identifier, c).total_estimated_gb
+                          for c in (0.0, 1.0, 5.0, 20.0)]
+                self.assertEqual(totals, sorted(totals), msg=f"{identifier}: {totals}")
+
+    def test_it_is_reported_on_the_estimate(self):
+        """Whatever a branch does with it, the value must be visible for
+        telemetry -- this is what gets written as preflight_estimate_gb's
+        provenance."""
+        for identifier in self.SHAPES:
+            with self.subTest(identifier=identifier):
+                est = self._estimate(identifier, self.FIXED_GB)
+                self.assertEqual(est.fixed_benchmark_cost_gb, self.FIXED_GB)


### PR DESCRIPTION
Found while working out how to refit the memory overhead tables after #2475.

## The bug

`benchmark_costs.json` holds **88** measured per-benchmark fixed costs. **19** of them — every `*-rdm*` key — were measured, shipped, loaded, and then discarded:

```python
rdm_overhead_gb = 2 * activation_gb
total_estimated_gb = activation_gb + rdm_overhead_gb   # fixed cost never added
formula_type = 'rdm'
```

```
Zerbe2026_fmri.V2-rdm-pearson          1.97 GB
Allen2022_fmri_surface_4subj.V2-rdm    1.82 GB
Allen2022_fmri_surface_4subj.IT-rdm    1.54 GB
Allen2022_fmri_4subj.IT-rdm            1.44 GB
...                                    (19 total, 0.4-2.0 GB each)
```

Branch order makes rdm the only place this can happen: the three branches after it are guarded by `fixed_benchmark_cost_gb is not None`, so `ridge_large_feature` / `ridge_formula` / `fallback` are never reached with a value to drop, and the pls branch already adds `(fixed_benchmark_cost_gb or 0.0)`.

## Evidence it matters, independent of #2475

From the Li2026 backfill (build 85, 740 jobs with both a preflight and a peak), rdm was the worst-predicted formula:

| benchmark | formula | n | p50 est | p50 peak | ratio |
| --- | --- | --- | --- | --- | --- |
| `Li2026_V4-rdm` | rdm | 92 | 0.98 | 5.44 | 5.54 |
| `Li2026_V1-rdm` | rdm | 92 | 1.12 | 5.23 | 4.66 |
| `Li2026_V2-rdm` | rdm | 95 | 1.12 | 5.07 | 4.51 |
| **`Li2026_IT-rdm`** | rdm | 92 | **1.12** | **4.46** | **3.98** |

The IT row is the load-bearing one. IT is the region whose layer the preflight already probed correctly (that is what #2475 fixes for the others), so its +3.34 GB residual **cannot** be attributed to the layer bug — a genuine fixed cost is missing.

Corroborating, from the same run: `compact_resnet50_robust_V4` reports **88 features** and `hmax` **400**, and both still peaked at ~8 GB. When the activation array is ~0.001 GB and the peak is 8 GB, essentially all of it is benchmark scaffolding, and a formula with no fixed-cost term cannot see any of it.

## The guard

Stated as a **floor** (`total >= fixed`) across the identifier shapes that select each reachable branch, not as "the cost is added" — the ridge branch takes `max(activation + fixed, activation * factor)` because the two predictors measure complementary things. A floor is the invariant both semantics satisfy, and it is exactly what rdm violated: 3x a 20 KB activation array is nowhere near a measured 5 GB. A second test pins monotonicity in the fixed cost, so a future branch cannot make a larger measured cost yield a smaller estimate.

**83 passed** across `tests/test_plugin_management`. Reverting the one-line change fails both rdm subtests — my first draft of the test asserted strict addition and correctly failed on the ridge `max()` branch, which is why it is a floor.

## Direction of the change

Estimates go **up** by 0.4-2.0 GB for 19 rdm benchmarks. That is the same direction as #2475, and both are corrections to a formula that has been measurably under-predicting. Worth noting explicitly against the retry work: the tier escalation path plus `plan_retry` now handles an underestimate, so neither change is load-bearing for safety — but the calibration tables were fitted against these biased estimates and will need refitting (see #2475's note). Order matters: **#2475, then this, then re-run `scripts/mem_profile_suite.py --calibrate`.**