### PR TITLE
fix(cache): resolve stimulus revisions by identifier, not registry key

### DIFF
--- a/brainscore_vision/model_helpers/activations/cache_key.py
+++ b/brainscore_vision/model_helpers/activations/cache_key.py
@@ -50,6 +50,7 @@ scoring run. It degrades to exactly the behaviour that shipped before it.
 """
 import hashlib
 import logging
+import re
 import os
 import subprocess
 from functools import lru_cache
@@ -161,6 +162,10 @@ def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
                                         registry_prefix=registry_prefix)
         if plugin_dir is not None:
             break
+    if plugin_dir is None and 'stimulus_set' in registry_prefixes:
+        # The registry key and the set's own identifier often differ; the
+        # extractor only sees the latter. See the function's docstring.
+        plugin_dir = _locate_plugin_dir_by_stimulus_identifier(plugin_type, identifier)
     revision = None
     if plugin_dir is not None:
         revision = _git_revision(plugin_dir) or _content_revision(plugin_dir)
@@ -209,6 +214,41 @@ def _locate_plugin_dir(plugin_type: str, identifier: str,
         # Unregistered identifier, ambiguous registration, or a layout this
         # resolver does not understand. Not fatal — the caller degrades.
         _logger.debug(f"Could not locate {plugin_type} plugin dir for '{identifier}'", exc_info=True)
+        return None
+
+
+def _locate_plugin_dir_by_stimulus_identifier(plugin_type: str, identifier: str) -> Optional[Path]:
+    """Plugin dir whose loader builds a stimulus set carrying ``identifier``.
+
+    A registry *key* and the stimulus set's own ``identifier`` are frequently
+    different, and the extractor only ever sees the latter. 36 of the 154
+    registered sets differ, and none by a rule a string transformation could
+    recover:
+
+        registry['Li2026']                    -> identifier='Li2026_Stimuli'
+        registry['Allen2022_fmri_stim_train'] -> identifier='Allen2022_fMRI_train_Stimuli'
+        registry['Coggan2024_fMRI']           -> identifier='tong.Coggan2024_fMRI'
+        registry['BMD2024.texture_1']         -> identifier='BMD_2024_texture_1'
+
+    So this searches for the identifier as a literal in the loader call rather
+    than as a registry key. Requires a unique match: two plugins naming the same
+    identifier means we cannot say which revision applies, and a wrong revision
+    is worse than none.
+    """
+    try:
+        import brainscore_vision
+        plugins_dir = Path(brainscore_vision.__file__).parent / plugin_type
+        needle = re.compile(r"identifier\s*=\s*['\"]" + re.escape(identifier) + r"['\"]")
+        matches = [init.parent for init in sorted(plugins_dir.glob('*/__init__.py'))
+                   if needle.search(init.read_text(encoding='utf-8', errors='replace'))]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            _logger.debug(f"{identifier!r} is named by {len(matches)} {plugin_type} plugins; "
+                          f"cannot attribute a revision")
+        return None
+    except Exception:
+        _logger.debug(f"identifier-literal lookup failed for {identifier!r}", exc_info=True)
         return None
 
 

--- a/tests/test_model_helpers/activations/test_cache_key.py
+++ b/tests/test_model_helpers/activations/test_cache_key.py
@@ -327,3 +327,58 @@ class TestScreenConvertedIdentifiers:
 
     def test_non_string_identifier_passes_through(self):
         assert cache_key.base_stimulus_identifier(False) is False
+
+
+class TestIdentifierLiteralResolution:
+    """A registry key and the stimulus set's own identifier often differ, and
+    the extractor only ever sees the latter -- 36 of the 154 registered sets.
+
+    This is the gap the first pass at stimulus revisioning left: it resolved
+    `hvm-public` and `MajajHong2015`, where key and identifier coincide, but not
+    `Li2026_Stimuli` (registered under the key `Li2026`), which is the
+    identifier that actually appeared in the cache key that prompted the work.
+    """
+
+    # one per transformation style, none recoverable by a string rule
+    STYLES = {
+        'Li2026_Stimuli': 'li2026',                       # key is 'Li2026'
+        'Allen2022_fMRI_train_Stimuli': 'allen2022_fmri',  # case change + reorder
+        'tong.Coggan2024_fMRI': 'coggan2024_fMRI',         # vendor prefix
+        'BMD_2024_texture_1': 'bmd2024',                   # punctuation moved
+    }
+
+    @pytest.mark.parametrize('identifier,expected_dir', sorted(STYLES.items()))
+    def test_each_style_resolves_to_its_plugin_dir(self, identifier, expected_dir):
+        found = cache_key._locate_plugin_dir_by_stimulus_identifier('data', identifier)
+        assert found is not None, f"{identifier} unresolvable"
+        assert found.name == expected_dir
+
+    @pytest.mark.parametrize('identifier', sorted(STYLES))
+    def test_the_revision_reaches_the_key(self, revisioning_on, monkeypatch, identifier):
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        assert stimulus_set_cache_identifier(identifier).startswith(f'{identifier}@')
+
+    def test_screen_converted_form_also_resolves(self, revisioning_on, monkeypatch):
+        """The build-92 key verbatim."""
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        observed = 'Li2026_Stimuli--target8.00--source11.00'
+        assert stimulus_set_cache_identifier(observed).startswith(f'{observed}@')
+
+    def test_every_registered_identifier_is_uniquely_attributable(self):
+        """One pass over data/, rather than resolving 229 identifiers one at a
+        time. Two plugins naming the same identifier would make the revision
+        ambiguous, and the resolver refuses those -- so this doubles as the
+        assertion that the ambiguous branch is currently unreachable."""
+        import collections, re as _re
+        owners = collections.defaultdict(set)
+        plugins_dir = Path(cache_key.__file__).parents[2] / 'data'
+        for init in sorted(plugins_dir.glob('*/__init__.py')):
+            text = init.read_text(encoding='utf-8', errors='replace')
+            for ident in _re.findall(r"identifier\s*=\s*['\"]([^'\"]+)['\"]", text):
+                owners[ident].add(init.parent.name)
+        ambiguous = {i: sorted(d) for i, d in owners.items() if len(d) > 1}
+        assert owners, "found no identifier literals at all -- the scan is broken"
+        assert ambiguous == {}, f"ambiguous identifiers would key without a revision: {ambiguous}"
+
+    def test_unknown_identifier_still_degrades(self):
+        assert cache_key._locate_plugin_dir_by_stimulus_identifier('data', 'NotAnIdentifier') is None


### PR DESCRIPTION
Follow-up to #2476, which **did not fix the case that motivated it**. I verified `hvm-public` and `MajajHong2015` in that PR and never checked the string actually observed in the build-92 trial.

## The gap

```
Li2026_Stimuli                            -> Li2026_Stimuli          (no revision, on master)
Li2026_Stimuli--target8.00--source11.00   -> ...--source11.00        (no revision, on master)
```

The registry **key** is `Li2026`. The stimulus set's own **identifier** — the only thing the extractor ever sees — is `Li2026_Stimuli`. #2476 resolved by key, so sets whose key and identifier coincide were fixed and the rest were not.

Not an edge case, and not recoverable by munging the string:

```
stimulus_set_registry entries: key == identifier : 116
                               key != identifier :  36
identifier starts with key   :   0 / 36
```

```
registry['Li2026']                    -> identifier='Li2026_Stimuli'
registry['Allen2022_fmri_stim_train'] -> identifier='Allen2022_fMRI_train_Stimuli'   case + reorder
registry['Coggan2024_fMRI']           -> identifier='tong.Coggan2024_fMRI'           vendor prefix
registry['BMD2024.texture_1']         -> identifier='BMD_2024_texture_1'             punctuation moved
```

## The fix

A last-resort lookup that searches for the identifier as a **literal in the loader call** rather than as a registry key. Tried only after both registry prefixes miss, so nothing that already resolved changes.

A unique match is required. Two plugins naming the same identifier makes the revision unattributable, and a wrong revision is worse than none — it silently claims the cache can distinguish revisions it cannot.

```
Li2026_Stimuli                 -> Li2026_Stimuli@e5a78d3d7800     (the commit that added the plugin)
Allen2022_fMRI_train_Stimuli   -> ...@f2ded55ce569
tong.Coggan2024_fMRI           -> ...@4b847c8b0893
BMD_2024_texture_1             -> ...@4b847c8b0893
NotReal                        -> NotReal                          (still degrades)
```

## Tests

One identifier per transformation style, plus the build-92 key verbatim — the assertion that was missing from #2476.

The coverage test scans `data/` in a **single pass** instead of resolving 229 identifiers one at a time (each resolution walks every plugin dir, so the naive version is ~46k file reads). It asserts every literal is uniquely attributable, and currently finds **0 ambiguous** — which is also what makes the resolver's ambiguity branch unreachable today, so the test starts earning its keep the moment someone introduces a collision.

**51 passed** in `test_cache_key.py`. Disabling the fallback fails 5.

## Timing

Same argument as #2476: this changes cache keys, and the activation cache currently holds exactly **2 objects** (190 MiB, both from build 92). Landing it now costs one re-extraction; landing it after a scoring sweep costs re-extracting everything. Worth taking before the recalibration run.