### PR TITLE
docs(cache): drop a wrong count from the stimulus-revision rationale

### DIFF
--- a/brainscore_vision/model_helpers/activations/cache_key.py
+++ b/brainscore_vision/model_helpers/activations/cache_key.py
@@ -190,7 +190,7 @@ def _locate_plugin_dir(plugin_type: str, identifier: str,
     infer from ``plugin_type``. It has to be given for stimulus sets: they
     live in ``data/`` alongside assemblies but register under
     ``stimulus_set_registry``, and the inferred ``data_registry`` matches none
-    of the 154 registered sets.
+    of the registered sets.
     """
     try:
         from brainscore_core.plugin_management import import_plugin as _import_plugin
@@ -221,9 +221,9 @@ def _locate_plugin_dir_by_stimulus_identifier(plugin_type: str, identifier: str)
     """Plugin dir whose loader builds a stimulus set carrying ``identifier``.
 
     A registry *key* and the stimulus set's own ``identifier`` are frequently
-    different, and the extractor only ever sees the latter. 36 of the 154
-    registered sets differ, and none by a rule a string transformation could
-    recover:
+    different, and the extractor only ever sees the latter -- roughly a quarter
+    of registered sets differ, and a string transformation recovers almost none
+    of them (only ``Li2026`` happens to be a prefix of its identifier):
 
         registry['Li2026']                    -> identifier='Li2026_Stimuli'
         registry['Allen2022_fmri_stim_train'] -> identifier='Allen2022_fMRI_train_Stimuli'

--- a/tests/test_model_helpers/activations/test_cache_key.py
+++ b/tests/test_model_helpers/activations/test_cache_key.py
@@ -331,7 +331,7 @@ class TestScreenConvertedIdentifiers:
 
 class TestIdentifierLiteralResolution:
     """A registry key and the stimulus set's own identifier often differ, and
-    the extractor only ever sees the latter -- 36 of the 154 registered sets.
+    the extractor only ever sees the latter -- roughly a quarter of registered sets.
 
     This is the gap the first pass at stimulus revisioning left: it resolved
     `hvm-public` and `MajajHong2015`, where key and identifier coincide, but not


### PR DESCRIPTION
Comments and one test docstring only — no behaviour change. **51 passed.**

## The wrong claims

#2476/#2478 shipped this rationale in `cache_key.py` and in the test that guards it:

> 36 of the 154 registered sets differ, and **none by a rule a string transformation could recover**

Both halves are wrong.

**The count.** The scan behind it ran against a working tree **46 commits behind master**, which did not contain the `li2026` data plugin — the very example the docstring cites. Re-scanning at `origin/master`:

```
stimulus_set_registry entries : 155
  key == identifier            : 116
  key != identifier            :  37
  identifier starts with key   :   1   (Li2026 -> Li2026_Stimuli)
```

An independent audit counted 38. The figure moves with how a registration block is delimited, so a precise number never belonged in a docstring. Replaced with **"roughly a quarter"**.

**The stronger error.** `Li2026` **is** a prefix of `Li2026_Stimuli`, so "none by a rule a string transformation could recover" is false as written — and it was false about the one example the docstring leans on.

## What is unchanged

The fix in #2478 is still correct. A prefix rule would recover exactly **one** case out of ~37, and nothing recovers:

```
Coggan2024_fMRI      -> tong.Coggan2024_fMRI
BMD2024.texture_1    -> BMD_2024_texture_1
Allen2022_fmri_stim_train -> Allen2022_fMRI_train_Stimuli
```

So resolving by identifier literal remains the right approach. Only the justifying prose was overstated.

## Why this is worth a PR

The claim is load-bearing prose sitting next to the code it justifies, and it is repeated in the test's docstring — so anyone reasoning about whether the identifier-literal lookup is necessary would have read a false premise, and a plausible "simplification" to a prefix rule would look better supported than it is.

Found by an external audit of the work log, not by me. The same false statistic has been corrected in the Obsidian write-up.