### PR TITLE
ci: pass PR title and changed files through env in scoring workflow

### DIFF
--- a/.github/workflows/score_new_plugins.yml
+++ b/.github/workflows/score_new_plugins.yml
@@ -62,16 +62,18 @@ jobs:
       - name: Get plugin info
         id: getpluginfo
         run: |
-          echo "PLUGIN_INFO='$(python -c 'from brainscore_core.plugin_management.parse_plugin_changes import get_scoring_info; get_scoring_info("${{ env.CHANGED_FILES }}", "brainscore_vision")')'"  >> $GITHUB_OUTPUT
+          echo "PLUGIN_INFO='$(python -c 'import os; from brainscore_core.plugin_management.parse_plugin_changes import get_scoring_info; get_scoring_info(os.environ["CHANGED_FILES"], "brainscore_vision")')'"  >> $GITHUB_OUTPUT
 
       - name: Check if only metadata changed
         id: check_metadata_only
+        env:
+          PLUGIN_INFO: ${{ steps.getpluginfo.outputs.PLUGIN_INFO }}
         run: |
-          MODIFIES_PLUGINS=$(echo ${{ steps.getpluginfo.outputs.PLUGIN_INFO }} | jq -r '.modifies_plugins')
+          MODIFIES_PLUGINS=$(echo "$PLUGIN_INFO" | jq -r '.modifies_plugins')
           echo "modifies_plugins=${MODIFIES_PLUGINS}" >> $GITHUB_OUTPUT
           
           # filter out metadata.yml
-          non_metadata=$(echo "${{ env.CHANGED_FILES }}" | tr ' ' '\n' | grep -Ev "metadata\.ya?ml" || true)
+          non_metadata=$(echo "$CHANGED_FILES" | tr ' ' '\n' | grep -Ev "metadata\.ya?ml" || true)
 
           if [ -z "$non_metadata" ] && [ "$MODIFIES_PLUGINS" = "true" ]; then
             echo "only_metadata=true" >> $GITHUB_OUTPUT
@@ -85,11 +87,11 @@ jobs:
         if: steps.check_metadata_only.outputs.modifies_plugins == 'true'
         run: |
           # extract plugin directories from changed files
-          plugin_dirs=$(echo "${{ env.CHANGED_FILES }}" | tr ' ' '\n' | grep -E 'brainscore_vision/(models|benchmarks)/' | awk -F'/' '{print $1"/"$2"/"$3}' | sort | uniq | paste -sd, - || echo "")
+          plugin_dirs=$(echo "$CHANGED_FILES" | tr ' ' '\n' | grep -E 'brainscore_vision/(models|benchmarks)/' | awk -F'/' '{print $1"/"$2"/"$3}' | sort | uniq | paste -sd, - || echo "")
           echo "PLUGIN_DIRS=${plugin_dirs}" >> $GITHUB_OUTPUT
           
           # determine plugin type from directory structure
-          plugin_type=$(echo "${{ env.CHANGED_FILES }}" | tr ' ' '\n' | grep -E 'brainscore_vision/(models|benchmarks)/' | grep -o -E '(models|benchmarks)' | head -n 1 || echo "")
+          plugin_type=$(echo "$CHANGED_FILES" | tr ' ' '\n' | grep -E 'brainscore_vision/(models|benchmarks)/' | grep -o -E '(models|benchmarks)' | head -n 1 || echo "")
           echo "PLUGIN_TYPE=${plugin_type}" >> $GITHUB_OUTPUT
           
           echo "Derived plugin directories: ${plugin_dirs}" 1>&2
@@ -105,7 +107,7 @@ jobs:
           
           # check if metadata.yml is in the PR changes
           metadata_in_pr=false
-          if echo "${{ env.CHANGED_FILES }}" | grep -q "metadata.yml"; then
+          if echo "$CHANGED_FILES" | grep -q "metadata.yml"; then
             metadata_in_pr=true
             echo "Metadata changes found in PR" 1>&2
           fi
@@ -139,8 +141,10 @@ jobs:
       - name: Check if scoring needed
         if: steps.check_metadata_only.outputs.only_metadata == 'false'
         id: scoringneeded
+        env:
+          PLUGIN_INFO: ${{ steps.getpluginfo.outputs.PLUGIN_INFO }}
         run: |
-          echo "RUN_SCORING=$(jq -r '.run_score' <<< ${{ steps.getpluginfo.outputs.PLUGIN_INFO }})" >> $GITHUB_OUTPUT
+          echo "RUN_SCORING=$(jq -r '.run_score' <<< "$PLUGIN_INFO")" >> $GITHUB_OUTPUT
 
       - name: Check for automerge-web label
         if: steps.check_metadata_only.outputs.only_metadata == 'false'
@@ -155,14 +159,17 @@ jobs:
 
       - name: Update PLUGIN_INFO based on label
         if: steps.check_metadata_only.outputs.only_metadata == 'false'
+        env:
+          PLUGIN_INFO_RAW: ${{ steps.getpluginfo.outputs.PLUGIN_INFO }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           if [[ "$has_automerge_web" == "true" ]]; then
-            BS_UID="$(echo '${{ github.event.pull_request.title }}' | sed -E 's/.*\(user:([^)]+)\).*/\1/')"
-            BS_PUBLIC="$(echo '${{ github.event.pull_request.title }}' | sed -E 's/.*\(public:([^)]+)\).*/\1/')"
-            PLUGIN_INFO=$(echo ${{ steps.getpluginfo.outputs.PLUGIN_INFO }} | tr -d "'" | jq -c ". + {user_id: \"$BS_UID\", public: \"$BS_PUBLIC\"}")
+            BS_UID="$(printf '%s' "$PR_TITLE" | sed -E 's/.*\(user:([^)]+)\).*/\1/')"
+            BS_PUBLIC="$(printf '%s' "$PR_TITLE" | sed -E 's/.*\(public:([^)]+)\).*/\1/')"
+            PLUGIN_INFO=$(echo "$PLUGIN_INFO_RAW" | tr -d "'" | jq -c ". + {user_id: \"$BS_UID\", public: \"$BS_PUBLIC\"}")
             echo "PLUGIN_INFO=${PLUGIN_INFO}" >> $GITHUB_ENV
           else
-            echo "PLUGIN_INFO=$(echo ${{ steps.getpluginfo.outputs.PLUGIN_INFO }} | tr -d "'")" >> $GITHUB_ENV
+            echo "PLUGIN_INFO=$(echo "$PLUGIN_INFO_RAW" | tr -d "'")" >> $GITHUB_ENV
           fi
 
       - name: Write PLUGIN_INFO to a json file


### PR DESCRIPTION
Following up on the report I sent Kartik privately, opening it here as asked.

## What

`score_new_plugins.yml` interpolates `${{ github.event.pull_request.title }}` and `${{ env.CHANGED_FILES }}` directly into `run:` scripts. Both are attacker controlled. The title is free text; `CHANGED_FILES` is built from `git diff --name-only`, so it carries filenames taken from the pull request.

GitHub substitutes those expressions as literal text into the script before bash runs, so a value that closes the surrounding quotes is executed rather than read.

## Verified rather than assumed

Both tested locally on reconstructions of these exact shell lines. Nothing was run against Brain-Score infrastructure.

**PR title.** In the `Update PLUGIN_INFO based on label` step:

```
BS_UID="$(echo '${{ github.event.pull_request.title }}' | sed ...)"
```

A title of `x'; touch /tmp/title_pwn; echo 'y (user:bob) (public:True)` closed the quote and the `touch` ran, while the `sed` still produced a plausible `BS_UID`, so the log looks normal afterwards. Titles have no character restrictions.

**Filename.** In `Get plugin info`. Worth noting git's quoting is less protective than it looks: it quotes and escapes a path containing a double quote, so that payload fails, but it leaves single quotes, backticks and `$( )` untouched. A file named `a'; touch bsx_marker; echo 'b.py` closed the `python -c` string and ran. Python then raises a SyntaxError, but only after the injected command has executed, so the failure reads as a malformed filename. This one is bounded, since filenames cannot contain `/`.

## Why it is worth fixing

`Configure AWS Credentials` runs earlier in the same job, so anything executing in these steps does so with those credentials already in the environment.

The workflow is `pull_request_target` on closed with `if: merged == true`, so a PR has to be merged first and an outside contributor cannot self-label. The route that remains is a brain-score.org submission, which arrives already carrying `automerge-web`.

## The change

Nine interpolation sites moved into `env:` blocks and referenced as shell variables, which GitHub does not evaluate as script. `PLUGIN_INFO` is a step output rather than an environment variable, so the steps consuming it get explicit `env:` entries. `CHANGED_FILES` is already in `$GITHUB_ENV`. No behaviour change otherwise, and the YAML validates.

## Also worth a look

`brain-score/language` has the same pattern in `plugin_submission_orchestrator.yml`: `PR_TITLE="${{ github.event.pull_request.title }}"` at lines 251, 823, 868, 1044 and 1080, and `CHANGED_FILES` at line 106. The double-quoted form is injectable the same way, which I also confirmed locally. Happy to send a matching PR there if useful.

Separately and unrelated to injection: `hmarr/auto-approve-action@v3.1.0` and `plm9606/automerge_actions@1.2.2` in `automerge_plugin-only_prs.yml` are mutable tags rather than commit SHAs, and the second is handed `WORKFLOW_TOKEN`. Left out of this PR to keep it focused, but happy to pin them in a follow-up.

I used AI tooling while investigating and drafting this; the findings were reproduced and verified by hand before opening.