### PR TITLE
fix(benchmarks): populate ceiling_error, which the recorder reads as 'error'

### DIFF
--- a/brainscore_vision/benchmark_helpers/multi_subject.py
+++ b/brainscore_vision/benchmark_helpers/multi_subject.py
@@ -380,6 +380,8 @@ class MultiSubjectNeuralBenchmark(BenchmarkBase):
         score.attrs["sem"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0
         )
+        # the recorder reads attrs['error'], not 'sem'; absent means a NULL column
+        score.attrs["error"] = score.attrs["sem"]
         return score
 
     def __call__(self, candidate) -> Score:
@@ -415,6 +417,8 @@ class MultiSubjectNeuralBenchmark(BenchmarkBase):
         ceiling.attrs["sem"] = (
             float(ceil_values.std(ddof=1) / np.sqrt(len(ceil_values))) if len(ceil_values) > 1 else 0.0
         )
+        # the recorder reads attrs['error'], not 'sem'; absent means a NULL column
+        ceiling.attrs["error"] = ceiling.attrs["sem"]
         score.attrs["ceiling"] = ceiling
         for sub_id, s in zip(self._subjects, per_subject_scores):
             score.attrs[sub_id] = s

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -698,6 +698,8 @@ class _MultiSubjectRSABenchmark(BenchmarkBase):
         score.attrs["sem"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0
         )
+        # the recorder reads attrs['error'], not 'sem'; absent means a NULL column
+        score.attrs["error"] = score.attrs["sem"]
         return score
 
     def __call__(self, candidate) -> Score:
@@ -734,6 +736,8 @@ class _MultiSubjectRSABenchmark(BenchmarkBase):
         ceiling.attrs["sem"] = (
             float(ceil_values.std(ddof=1) / np.sqrt(len(ceil_values))) if len(ceil_values) > 1 else 0.0
         )
+        # the recorder reads attrs['error'], not 'sem'; absent means a NULL column
+        ceiling.attrs["error"] = ceiling.attrs["sem"]
         score.attrs["ceiling"] = ceiling
         for sub_id, s in zip(self._subjects, per_subject_scores):
             score.attrs[sub_id] = s


### PR DESCRIPTION
## The bug

**142 of 314** production benchmark instances that have a ceiling have `ceiling_error = NULL` — 45%.

It is not missing data. The multi-subject wrappers already compute exactly the right quantity:

```python
ceiling.attrs["sem"] = float(ceil_values.std(ddof=1) / np.sqrt(len(ceil_values)))
```

That is the SEM across the per-subject ceilings which get averaged into `BenchmarkInstance.ceiling`. But `brainscore_core.submission.database._retrieve_score_error` reads:

```python
if hasattr(score, 'aggregation'): return score.sel(aggregation='error').item()
if 'error' in score.attrs:        return score.attrs['error']
return None
```

`sem` is not `error`, so it returns `None` and the column writes `NULL`.

Affected in production (sample):

```
Allen2022_fmri_surface.IT-rdm     v1  ceiling=0.8485  error=NULL
Allen2022_fmri_surface.V1-rdm     v1  ceiling=0.6438  error=NULL
Zerbe2026_fmri.IT-rdm-pearson     v1  ceiling=0.7518  error=NULL
Zerbe2026_fmri.IT-tau-ridgecv     v1  ceiling=0.7586  error=NULL
```

## The fix

`attrs['error'] = attrs['sem']` at all four sites — two wrappers in `benchmark_helpers/multi_subject.py` (shared, so this covers Allen2022 and anything else built on them) and two in `benchmarks/laion_fmri/benchmark.py`.

Nothing is recomputed. No ceiling value changes. Adding attrs leaves `.item()` scalar, which is what `bench_inst.ceiling = ceiling.item()` requires.

Verified against the real code path — a ceiling built the way the wrappers build it:

```
before: ceiling=0.7400  _retrieve_score_error -> None       (writes NULL)
after : ceiling=0.7400  _retrieve_score_error -> 0.027019
.item() unchanged: True
```

## Deliberately not fixed here

`_ncsnr_ceiling` (the ridgecv path) computes **no dispersion at all** — a median over per-voxel published NC values, storing `raw` and `nc_coord` only. The per-voxel values are available so an error is derivable, but the choice between SEM across voxels (spread of voxel reliability) and SEM across subjects (matching the wrappers) is a science question, not a rename. Worth deciding separately.

## This does not backfill

`BenchmarkInstance` rows are written `if created`:

```python
bench_inst, created = BenchmarkInstance.get_or_create(benchmark=benchmark_type, version=benchmark.version)
if created:
    bench_inst.ceiling_error = _retrieve_score_error(ceiling)
```

So the existing 142 stay `NULL` until their version is bumped (which re-scores everything on them) or the column is populated directly. Both are out of scope here — flagging so the number does not look fixed when it is not.

## Why it went unnoticed

A `NULL` ceiling error is invisible on the leaderboard until someone tries to put error bars on a ceiling. Found while checking the recorder contract for a new benchmark whose ceiling *does* populate the column.