### PR TITLE
feat(benchmarks): Zerbe2026 linear-CKA variants with inter-subject ceiling

### DIFF
--- a/brainscore_vision/benchmark_helpers/multi_subject.py
+++ b/brainscore_vision/benchmark_helpers/multi_subject.py
@@ -380,6 +380,8 @@ class MultiSubjectNeuralBenchmark(BenchmarkBase):
         score.attrs["sem"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0
         )
+        # the recorder reads attrs['error'], not 'sem'; absent means a NULL column
+        score.attrs["error"] = score.attrs["sem"]
         return score
 
     def __call__(self, candidate) -> Score:
@@ -415,6 +417,8 @@ class MultiSubjectNeuralBenchmark(BenchmarkBase):
         ceiling.attrs["sem"] = (
             float(ceil_values.std(ddof=1) / np.sqrt(len(ceil_values))) if len(ceil_values) > 1 else 0.0
         )
+        # the recorder reads attrs['error'], not 'sem'; absent means a NULL column
+        ceiling.attrs["error"] = ceiling.attrs["sem"]
         score.attrs["ceiling"] = ceiling
         for sub_id, s in zip(self._subjects, per_subject_scores):
             score.attrs[sub_id] = s

--- a/brainscore_vision/benchmarks/laion_fmri/__init__.py
+++ b/brainscore_vision/benchmarks/laion_fmri/__init__.py
@@ -33,7 +33,7 @@ explicitly here.
 """
 
 from brainscore_vision import benchmark_registry
-from .benchmark import LAIONfMRI, LAIONfMRIRSA
+from .benchmark import LAIONfMRI, LAIONfMRICKA, LAIONfMRIRSA
 
 # ── Per-subject pool ridgecv variants (HEADLINE) ──────────────────────────
 # Each subject's 5,833-image pool (1,121 shared + 4,712 subject-unique).
@@ -66,3 +66,10 @@ benchmark_registry['Zerbe2026_fmri.V1-rdm-pearson'] = lambda: LAIONfMRIRSA('V1')
 benchmark_registry['Zerbe2026_fmri.V2-rdm-pearson'] = lambda: LAIONfMRIRSA('V2')
 benchmark_registry['Zerbe2026_fmri.V4-rdm-pearson'] = lambda: LAIONfMRIRSA('V4')
 benchmark_registry['Zerbe2026_fmri.IT-rdm-pearson'] = lambda: LAIONfMRIRSA('IT')
+
+# Linear CKA -- rides the same activation cache entry as the ridge/RSA variants
+# above, so these cost no additional forward pass once any Zerbe variant has run.
+benchmark_registry['Zerbe2026_fmri.V1-cka'] = lambda: LAIONfMRICKA('V1')
+benchmark_registry['Zerbe2026_fmri.V2-cka'] = lambda: LAIONfMRICKA('V2')
+benchmark_registry['Zerbe2026_fmri.V4-cka'] = lambda: LAIONfMRICKA('V4')
+benchmark_registry['Zerbe2026_fmri.IT-cka'] = lambda: LAIONfMRICKA('IT')

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -18,7 +18,7 @@ child `TrainTestNeuralBenchmark` and aggregates with mean + per-fold detail in a
 from __future__ import annotations
 
 import gc
-from typing import Callable, Sequence
+from typing import Callable, Optional, Sequence
 
 import numpy as np
 import pandas as pd
@@ -728,6 +728,7 @@ class _MultiSubjectRSABenchmark(BenchmarkBase):
         region: str,
         bibtex: str = BIBTEX,
         peak_aggregation: float = 1.0,
+        parent: Optional[str] = None,
     ):
         if not subjects:
             raise ValueError("_MultiSubjectRSABenchmark requires at least one subject.")
@@ -747,7 +748,7 @@ class _MultiSubjectRSABenchmark(BenchmarkBase):
             identifier=identifier,
             ceiling_func=lambda: self._compute_ceiling(),
             version=version,
-            parent=region,
+            parent=parent or region,
             bibtex=bibtex,
         )
         self.region = _MODEL_REGION_CANONICAL.get(region, region)
@@ -957,6 +958,8 @@ def LAIONfMRICKA(
         # The ceiling holds two assemblies at once (pairwise), against one for
         # scoring -- so the peak is above the shared-pool default of 1.0.
         peak_aggregation=2.0,
+        # sibling of the other Zerbe variants, not of the whole Zerbe node
+        parent=f"{dataset_prefix}.{region}",
     )
     benchmark._unbiased = unbiased
     return benchmark

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -698,6 +698,8 @@ class _MultiSubjectRSABenchmark(BenchmarkBase):
         score.attrs["sem"] = (
             float(values.std(ddof=1) / np.sqrt(len(values))) if len(values) > 1 else 0.0
         )
+        # the recorder reads attrs['error'], not 'sem'; absent means a NULL column
+        score.attrs["error"] = score.attrs["sem"]
         return score
 
     def __call__(self, candidate) -> Score:
@@ -734,6 +736,8 @@ class _MultiSubjectRSABenchmark(BenchmarkBase):
         ceiling.attrs["sem"] = (
             float(ceil_values.std(ddof=1) / np.sqrt(len(ceil_values))) if len(ceil_values) > 1 else 0.0
         )
+        # the recorder reads attrs['error'], not 'sem'; absent means a NULL column
+        ceiling.attrs["error"] = ceiling.attrs["sem"]
         score.attrs["ceiling"] = ceiling
         for sub_id, s in zip(self._subjects, per_subject_scores):
             score.attrs[sub_id] = s

--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -631,6 +631,83 @@ def _ncsnr_rsa_ceiler(assembly) -> Score:
     return ceiling
 
 
+def _neutral_ceiler(assembly) -> Score:
+    """Ceiling of 1.0, so a child's ceiled score equals its raw score.
+
+    CKA is ceiled at the wrapper level against an inter-subject estimate that
+    needs more than one subject, so the per-subject children must not apply a
+    ceiling of their own. See :class:`_MultiSubjectCKABenchmark`.
+    """
+    return Score(1.0)
+
+
+def _intersubject_cka_ceiling(subject_ids, load_subject, unbiased: bool = True) -> Score:
+    """Pairwise inter-subject CKA: the empirical upper bound under *this* metric.
+
+    Nili's RSA ceiling compares each subject's RDM against the **mean RDM** across
+    subjects. That has no CKA analogue: CKA compares representations, and
+    representations cannot be averaged across subjects because their voxels have
+    no correspondence. The direct analogue is therefore pairwise --
+    ``mean_{i<j} CKA(subject_i, subject_j)``.
+
+    Holds at most **two** assemblies at once, matching the one-at-a-time discipline
+    :class:`_MultiSubjectRSABenchmark` uses for scoring.
+
+    :param load_subject: ``sub_id -> assembly``. Injected so this is testable
+        without the DUA-gated data.
+    :returns: scalar Score = pairwise mean. ``attrs['error']`` is the SEM over
+        pairs -- set explicitly because ``brainscore_core``'s recorder writes
+        ``BenchmarkInstance.ceiling_error`` from it, only on version creation, so
+        a missing error is a permanent NULL.
+    """
+    metric = load_metric("cka" if unbiased else "cka_biased")
+    ids = list(subject_ids)
+    pair_values, pair_labels = [], []
+    for outer in range(len(ids)):
+        a = load_subject(ids[outer])
+        for inner in range(outer + 1, len(ids)):
+            b = load_subject(ids[inner])
+            pair_values.append(float(metric(a, b)))
+            pair_labels.append(f"{ids[outer]}|{ids[inner]}")
+            del b
+            gc.collect()
+        del a
+        gc.collect()
+
+    if not pair_values:
+        raise ValueError("inter-subject CKA ceiling needs at least two subjects")
+    pairs = np.asarray(pair_values, dtype=np.float64)
+    ceiling = Score(float(pairs.mean()))
+    # 'error' is REQUIRED by the DB recorder; everything below it is extra
+    # metadata the recorder ignores, kept so a future re-normalisation can pick a
+    # different estimate from the stored score object without re-scoring.
+    ceiling.attrs["error"] = (
+        float(pairs.std(ddof=1) / np.sqrt(pairs.size)) if pairs.size > 1 else 0.0
+    )
+    ceiling.attrs["ceiling_method"] = "pairwise_intersubject_cka"
+    ceiling.attrs["ceiling_pairs"] = xr.DataArray(
+        pairs, dims=("pair",), coords={"pair": pair_labels},
+    )
+    # Per-subject leave-one-out: mean CKA of each subject against every other.
+    # NOT a Nili-style lower bound -- Nili's downward bias comes from averaging
+    # N-1 RDMs, which pairwise CKA never does. Stored for reference only.
+    loo = np.array([
+        np.mean([v for lbl, v in zip(pair_labels, pairs) if sid in lbl.split("|")])
+        for sid in ids
+    ], dtype=np.float64)
+    ceiling.attrs["ceiling_variants"] = {
+        "pairwise_intersubject_cka": float(pairs.mean()),
+        "loo_per_subject_mean": float(loo.mean()),
+        # split_half_within_subject: deferred -- needs the unaveraged repetition
+        # assembly, not the averaged scoring assembly.
+        "split_half_within_subject": None,
+    }
+    ceiling.attrs["ceiling_loo_per_subject"] = xr.DataArray(
+        loo, dims=("subject",), coords={"subject": ids},
+    )
+    return ceiling
+
+
 class _MultiSubjectRSABenchmark(BenchmarkBase):
     """Run a per-subject :class:`RSABenchmark`, aggregate ceiled scores across subjects.
 
@@ -750,6 +827,139 @@ class _MultiSubjectRSABenchmark(BenchmarkBase):
                 score, reason="single-subject RSA wrapper; nothing to resample at this layer",
             )
         return score
+
+
+class _MultiSubjectCKABenchmark(_MultiSubjectRSABenchmark):
+    """RSA wrapper, re-ceiled against inter-subject CKA.
+
+    The children score with :func:`_neutral_ceiler`, so the aggregate returned by
+    the parent is on the **raw** scale. This class then divides by the pairwise
+    inter-subject ceiling, which requires more than one subject and therefore
+    cannot live in a per-subject child.
+
+    DB contract preserved exactly (``brainscore_core.submission.database``):
+
+    - ``attrs['raw']`` -- scalar, unchanged from the parent  -> ``score_raw``
+    - ``attrs['ceiling']`` -- scalar, ``.item()``-able       -> ``BenchmarkInstance.ceiling``
+    - ``ceiling.attrs['error']`` -- float                    -> ``ceiling_error``
+    - ``attrs['error']`` -- rescaled by 1/ceiling            -> ``Score.error``
+    - ``comment`` -- never written here (CharField max 1000; the variant metadata
+      would overflow it and fail the write, not truncate)
+
+    Everything else the recorder ignores and carries along in the stored object.
+    """
+
+    def _load_subject_assembly(self, sub_id):
+        child = self._factory(sub_id)
+        assembly = child._assembly          # LazyLoad materialises here
+        _release(child)
+        return assembly
+
+    def _compute_ceiling(self) -> Score:
+        return _intersubject_cka_ceiling(
+            self._subjects, self._load_subject_assembly, unbiased=self._unbiased,
+        )
+
+    def __call__(self, candidate) -> Score:
+        raw_scale = super().__call__(candidate)     # children are neutrally ceiled
+        ceiling = self._compute_ceiling()
+        ceiling_value = float(ceiling.values)
+        if not np.isfinite(ceiling_value) or ceiling_value <= 0:
+            raise ValueError(f"inter-subject CKA ceiling is not usable: {ceiling_value}")
+
+        score = Score(float(raw_scale.values) / ceiling_value)
+        for key, value in raw_scale.attrs.items():
+            score.attrs[key] = value
+        # 'raw' stays the unceiled aggregate the parent computed.
+        score.attrs["ceiling"] = ceiling
+        # First-order propagation: dividing by a constant scales the error.
+        if raw_scale.attrs.get("error") is not None:
+            score.attrs["error"] = float(raw_scale.attrs["error"]) / ceiling_value
+        return score
+
+
+def _passthrough(assembly):
+    """Identity, so RSABenchmark's two-stage pipeline applies a *direct* metric.
+
+    RSABenchmark computes ``similarity(rdm(model), rdm(neural))``. CKA compares
+    representation matrices directly and never forms an RDM, so the transform
+    stage is skipped rather than replaced. Nothing else about the benchmark
+    changes -- same assembly, same per-subject loop, same ceiling.
+    """
+    return assembly
+
+
+def LAIONfMRICKA(
+    region: str,
+    dataset_prefix: str = "Zerbe2026_fmri",
+    subjects: tuple[str, ...] = DEFAULT_SUBJECTS,
+    noise_ceiling_threshold: float = NOISE_CEILING_THRESHOLD,
+    noise_ceiling_coord: str = "nc_12rep",
+    unbiased: bool = True,
+) -> _MultiSubjectRSABenchmark:
+    """Linear-CKA benchmark for one region across all subjects.
+
+    Requested by Yamins (SAB 2026-07-29): does linear CKA predict behavioural
+    metrics better than ridge? Zerbe already carries ridge and RSA variants on
+    the same stimuli, so CKA makes the comparison within-dataset.
+
+    Shares everything with :func:`LAIONfMRIRSA` except the comparison: same
+    assemblies, same shared-pool restriction, same ncsnr ceiling.
+
+    Says nothing about caching, deliberately. Activation reuse is handled entirely
+    upstream by ``@store_xarray`` on ``ActivationsExtractorHelper._from_paths_stored``
+    and is invisible here; this benchmark produces identical scores with the cache
+    on or off (verified at fp32). Any benchmark that had to know about the cache
+    would be a design error.
+
+    ``unbiased=True`` uses the Song et al. estimator. The biased estimator is
+    inflated by high feature dimensionality (0.16 vs -0.005 on independent data
+    at 10k features), which matters here because model layers are far wider than
+    the voxel count.
+    """
+    if "persubject" in dataset_prefix:
+        raise ValueError(
+            "LAIONfMRICKA is only defined for the shared pool, matching "
+            "LAIONfMRIRSA: persubject stimuli differ across subjects."
+        )
+
+    model_region = _MODEL_REGION_CANONICAL.get(region, region)
+    similarity_metric = load_metric("cka" if unbiased else "cka_biased")
+
+    def _build_subject(sub_id):
+        assembly = LazyLoad(
+            lambda sid=sub_id, r=region, dp=dataset_prefix,
+            nct=noise_ceiling_threshold, ncc=noise_ceiling_coord:
+            load_full_assembly_one_subject(
+                sub_id=sid, region=r, dataset_prefix=dp,
+                noise_ceiling_threshold=nct, noise_ceiling_coord=ncc,
+            )
+        )
+        return RSABenchmark(
+            identifier=f"{dataset_prefix}.{region}-cka-{sub_id}",
+            version=1,
+            assembly=assembly,
+            region=model_region,
+            visual_degrees=VISUAL_DEGREES,
+            number_of_trials=1,
+            bibtex=BIBTEX,
+            ceiler=_neutral_ceiler,
+            parent=region,
+            rdm=_passthrough,
+            similarity=similarity_metric,
+        )
+
+    benchmark = _MultiSubjectCKABenchmark(
+        identifier=f"{dataset_prefix}.{region}-cka",
+        subjects=subjects,
+        per_subject_factory=_build_subject,
+        region=region,
+        # The ceiling holds two assemblies at once (pairwise), against one for
+        # scoring -- so the peak is above the shared-pool default of 1.0.
+        peak_aggregation=2.0,
+    )
+    benchmark._unbiased = unbiased
+    return benchmark
 
 
 def LAIONfMRIRSA(

--- a/brainscore_vision/benchmarks/laion_fmri/test.py
+++ b/brainscore_vision/benchmarks/laion_fmri/test.py
@@ -243,6 +243,18 @@ class TestCKAWiring:
         assert benchmark.identifier == identifier
 
     @pytest.mark.parametrize("identifier", _CKA_VARIANTS)
+    def test_parent_is_the_dataset_node(self, identifier):
+        """Parent is written once, at row creation -- a wrong value needs a manual DB fix.
+
+        Must be a sibling of the other Zerbe variants (``Zerbe2026_fmri.IT``), not of
+        the whole Zerbe node (``IT``), which would double Zerbe's weight in the region.
+        """
+        from brainscore_vision import benchmark_registry
+        import brainscore_vision.benchmarks.laion_fmri  # noqa: F401
+        benchmark = benchmark_registry[identifier]()
+        assert benchmark.parent == identifier.rsplit("-cka", 1)[0]
+
+    @pytest.mark.parametrize("identifier", _CKA_VARIANTS)
     def test_rdm_stage_is_bypassed(self, identifier):
         """CKA compares representations directly; forming an RDM first would be wrong."""
         from brainscore_vision import benchmark_registry

--- a/brainscore_vision/benchmarks/laion_fmri/test.py
+++ b/brainscore_vision/benchmarks/laion_fmri/test.py
@@ -1,7 +1,7 @@
 """Tests for the LAION-fMRI benchmark registry and basic load paths.
 
-The headline registry is 20 variants — 8 shared-pool ridge, 8 persubject-pool
-ridge, and 4 shared-pool RSA. Non-headline variants (cluster_k5, per-OOD-category,
+The headline registry is 24 variants — 8 shared-pool ridge, 8 persubject-pool
+ridge, 4 shared-pool RSA, and 4 shared-pool linear CKA. Non-headline variants (cluster_k5, per-OOD-category,
 IT_full) live as factory functions and are exercised separately in
 `usage_examples.ipynb`; they're not registered for the leaderboard so the
 registry tests don't cover them.
@@ -38,15 +38,19 @@ _RSA_VARIANTS = [
     f"Zerbe2026_fmri.{region}-rdm-pearson" for region in _RIDGE_REGIONS
 ]  # 4 (shared pool only — Nili ceiling requires shared stim across subjects)
 
-_ALL_HEADLINE_VARIANTS = _RIDGE_VARIANTS + _RSA_VARIANTS  # 20
+_CKA_VARIANTS = [
+    f"Zerbe2026_fmri.{region}-cka" for region in _RIDGE_REGIONS
+]  # 4 (shared pool only, same restriction as RSA)
+
+_ALL_HEADLINE_VARIANTS = _RIDGE_VARIANTS + _RSA_VARIANTS + _CKA_VARIANTS  # 24
 
 
 class TestRegistry:
-    """The lean registry exposes exactly the 20 headline variants and nothing else."""
+    """The lean registry exposes exactly the 24 headline variants and nothing else."""
 
     def test_variant_count(self):
-        assert len(_ALL_HEADLINE_VARIANTS) == 20, (
-            f"Expected 20 headline variants, got {len(_ALL_HEADLINE_VARIANTS)}. "
+        assert len(_ALL_HEADLINE_VARIANTS) == 24, (
+            f"Expected 24 headline variants, got {len(_ALL_HEADLINE_VARIANTS)}. "
             f"If you added/removed variants in __init__.py, update the lists at "
             f"the top of this file too."
         )
@@ -214,3 +218,53 @@ class TestUncertaintyContract:
         import math
         assert math.isnan(float(score.attrs["error"]))
         assert score.attrs.get("error_nan_reason")
+
+
+class TestCKAWiring:
+    """The CKA variants reuse RSABenchmark with the RDM stage bypassed.
+
+    That is easy to get wrong in a way that still imports, registers and
+    constructs -- so these assert the *wiring*, not just that the identifier
+    resolves. Scoring is covered by the private_access tests above.
+    """
+
+    @pytest.mark.parametrize("identifier", _CKA_VARIANTS)
+    def test_registered(self, identifier):
+        from brainscore_vision import benchmark_registry
+        import brainscore_vision.benchmarks.laion_fmri  # noqa: F401  (populates registry)
+        assert identifier in benchmark_registry
+
+    @pytest.mark.parametrize("identifier", _CKA_VARIANTS)
+    def test_constructs_without_data(self, identifier):
+        """Must not touch the assemblies -- they are LazyLoad."""
+        from brainscore_vision import benchmark_registry
+        import brainscore_vision.benchmarks.laion_fmri  # noqa: F401
+        benchmark = benchmark_registry[identifier]()
+        assert benchmark.identifier == identifier
+
+    @pytest.mark.parametrize("identifier", _CKA_VARIANTS)
+    def test_rdm_stage_is_bypassed(self, identifier):
+        """CKA compares representations directly; forming an RDM first would be wrong."""
+        from brainscore_vision import benchmark_registry
+        import brainscore_vision.benchmarks.laion_fmri  # noqa: F401
+        from brainscore_vision.benchmarks.laion_fmri.benchmark import _passthrough
+        child = benchmark_registry[identifier]()._factory("sub-01")
+        assert child._rdm is _passthrough, "RDM stage must be a pass-through for CKA"
+
+    @pytest.mark.parametrize("identifier", _CKA_VARIANTS)
+    def test_uses_the_unbiased_estimator(self, identifier):
+        """The biased estimator inflates with feature dimensionality (~0.16 vs
+        ~-0.005 on independent data at 10k features), and model layers are far
+        wider than the voxel count -- so registered variants must be unbiased."""
+        from brainscore_vision import benchmark_registry
+        import brainscore_vision.benchmarks.laion_fmri  # noqa: F401
+        child = benchmark_registry[identifier]()._factory("sub-01")
+        assert type(child._similarity).__name__ == "CKA"
+        assert child._similarity._unbiased is True
+
+    def test_persubject_pool_is_refused(self):
+        """Persubject stimuli differ across subjects, so cross-subject
+        comparison is undefined -- same restriction RSA has."""
+        from brainscore_vision.benchmarks.laion_fmri.benchmark import LAIONfMRICKA
+        with pytest.raises(ValueError, match="shared pool"):
+            LAIONfMRICKA("IT", dataset_prefix="Zerbe2026_fmri_persubject")


### PR DESCRIPTION
> **Stacked on #2484.** Base is `kp/ceiling-error`, not `master`. **Merge #2484 first**, then retarget this to `master`. See the merge-order note at the bottom — I lost a PR's contents to exactly this pattern last week.

Draft — the mechanism works end to end on real data, but two decisions are open.

Requested by Yamins (SAB 2026-07-29): does linear CKA predict behavioural metrics better than ridge? Zerbe already carries ridge and RSA variants on the same stimuli, so CKA makes that comparison within-dataset.

## Scope is smaller than it sounds

The metric already existed — `metrics/cka`, registered as `cka` / `cka_cv` / `cka_biased`. Nothing new there. No new benchmark class either: this reuses `RSABenchmark` with the RDM stage bypassed, because CKA compares representations directly and never forms an RDM.

```python
rdm=_passthrough,              # RSABenchmark computes similarity(rdm(model), rdm(neural))
similarity=load_metric("cka"), # CKA needs the raw representations, not RDMs
```

**No cache changes.** Activation reuse is handled upstream by `@store_xarray` and is invisible here — these produce identical scores with the cache on or off.

## Ceiling: pairwise inter-subject CKA

Not the ncsnr proxy the RSA variants use, for two reasons. That ceiler is documented as a bound on how well a model *RDM* can correlate — not the quantity CKA computes — and its inputs are the dataset's published per-voxel reliability rather than anything measured under this metric.

Nili's "each subject vs the mean across subjects" has no CKA analogue either: representations cannot be averaged across subjects because their voxels have no correspondence. The direct analogue is `mean_{i<j} CKA(subject_i, subject_j)`, which puts score and ceiling on the same scale by construction.

## First real score — `alexnet`, `Zerbe2026_fmri.IT-cka`

```
ceiled         0.5232639563817907
raw            0.2504352496354321
ceiling        0.4786021406234721   (10 pairs, 0.4216 – 0.5222)
ceiling_error  0.0112129413120552
```

Scored in the same run, unchanged: `Zerbe2026_fmri.IT-rdm-pearson` = **0.3745153062392548**, bit-identical to its previously recorded value. So the `_passthrough` / `_neutral_ceiler` changes are confined to the CKA path.

## The result worth discussing before merge

```
              raw      ceiling   ceiled
CKA          0.2504    0.4786    0.5233
RSA (rdm)    0.2815    0.7518    0.3745
```

Inter-subject agreement is much weaker under CKA than under RDM correlation (0.479 vs 0.752) on identical data. So alexnet's **raw** CKA is *lower* than its raw RSA, while its **ceiled** CKA comes out 40% *higher* — purely because the denominator is smaller. A metric can look better by having a noisier ceiling. That is exactly the comparability question being asked, and it should be a deliberate decision rather than a side effect.

## Open decisions

1. **Registered surface goes 20 -> 24.** The count guard and module docstring move with it. That is a leaderboard change.
2. **Whether CKA should be ceiled at all**, given the above.

## DB contract

Checked against `brainscore_core.submission.database`, since `BenchmarkInstance` is written `if created` only and a mistake is permanent until a version bump:

- `ceiling.item()` scalar -> `BenchmarkInstance.ceiling`
- `ceiling.attrs['error']` set explicitly -> `ceiling_error` (this is what #2484 fixes for the existing benchmarks)
- `raw` scalar -> `score_raw`; `comment` untouched (`CharField(max_length=1_000)` — the variant metadata would fail the write, not truncate; measured `comment_len=89`)

Extra metadata rides along for later re-normalisation without re-scoring: `ceiling_method`, `ceiling_variants`, `ceiling_pairs` (all 10 labelled), `ceiling_loo_per_subject`. Note `loo_per_subject_mean` equals the pairwise mean by construction for equal subject counts — the per-subject vector is the informative part. `split_half_within_subject` is deliberately `None`: it needs the unaveraged repetition assembly, and the scoring assemblies use `average_repetitions=True`.

`peak_aggregation` 1.0 -> 2.0, since the ceiling holds two assemblies at once where scoring holds one.

**25 non-private tests pass.**

## Merge order

#2484 first, then this. If this merges into `kp/ceiling-error` *after* that branch has already gone into `master`, the changes land on a dead branch and never reach `master`. That is precisely how brain-score/result_caching#23 lost its contents last week — merged into a stacked branch nine seconds after the base merged into master.