### PR TITLE
fix(cache): refuse to cache when a plugin revision cannot be resolved

### DIFF
--- a/brainscore_vision/model_helpers/activations/cache_key.py
+++ b/brainscore_vision/model_helpers/activations/cache_key.py
@@ -42,11 +42,17 @@ Resolution order, per plugin:
    cache on every unrelated commit.
 3. A content hash of the plugin directory, for installs that are not a git
    checkout.
-4. Nothing. The identifier is returned unchanged, which reproduces the
-   pre-existing (revision-blind) key, and a warning is logged.
+4. Nothing. Caching is then refused for that request: the public helpers
+   return ``None`` and a warning is logged.
 
-Step 4 is deliberately not an error: this module must never be able to fail a
-scoring run. It degrades to exactly the behaviour that shipped before it.
+Step 4 used to return the bare identifier, reproducing the revision-blind key.
+That was safe while the cache was per-container and discarded, but on the shared
+S3 backend it writes one entry that is served across every revision of the
+plugin -- the exact failure this module exists to prevent. Refusing to cache
+costs one recomputation; a stale hit costs a wrong score that looks normal.
+
+Refusing is still not an error: this module must never fail a scoring run, so
+the caller computes uncached rather than raising.
 """
 import hashlib
 import logging
@@ -88,16 +94,21 @@ def revision_enabled() -> bool:
 def model_cache_identifier(identifier: str) -> str:
     """Model identifier with its plugin revision appended, for cache keying."""
     return _with_revision(identifier, plugin_type='models',
-                          env_var='BRAINSCORE_MODEL_PLUGIN_SHA', unresolved_is_notable=True)
+                          env_var='BRAINSCORE_MODEL_PLUGIN_SHA')
 
 
 def stimulus_set_cache_identifier(stimuli_identifier: str) -> str:
     """Stimulus-set identifier with its data-plugin revision appended.
 
+    Returns None when revisioning is enabled but no revision can be resolved,
+    which the caller must treat as "do not cache this request".
+
     Stimulus sets reach the extractor through several routes (a registered
     data plugin, a benchmark-local assembly, a screen-converted derivative),
-    so a revision is sometimes unavailable. That is expected rather than
-    notable — an unresolved stimulus set simply keys as it does today.
+    so a revision is sometimes unavailable. Degrading to an unrevisioned key
+    was safe while the cache was per-container and thrown away; on the shared
+    S3 cache it means one stimulus set is served across plugin revisions, so
+    the unresolved case now disables caching instead.
 
     Two of those routes need translating before the plugin resolver can find
     anything, and both were silently unresolvable until they were fixed:
@@ -106,7 +117,7 @@ def stimulus_set_cache_identifier(stimuli_identifier: str) -> str:
     set carries a suffix that is not registered at all.
     """
     return _with_revision(stimuli_identifier, plugin_type='data',
-                          env_var='BRAINSCORE_DATA_PLUGIN_SHA', unresolved_is_notable=False,
+                          env_var='BRAINSCORE_DATA_PLUGIN_SHA',
                           registry_prefixes=('stimulus_set', 'data'),
                           lookup_identifier=base_stimulus_identifier(stimuli_identifier))
 
@@ -125,7 +136,7 @@ def base_stimulus_identifier(stimuli_identifier: str) -> str:
     return stimuli_identifier.split(_SCREEN_SUFFIX)[0]
 
 
-def _with_revision(identifier, plugin_type: str, env_var: str, unresolved_is_notable: bool,
+def _with_revision(identifier, plugin_type: str, env_var: str,
                    registry_prefixes: tuple = (None,), lookup_identifier: Optional[str] = None):
     if not revision_enabled():
         return identifier
@@ -134,16 +145,21 @@ def _with_revision(identifier, plugin_type: str, env_var: str, unresolved_is_not
         return identifier
     revision = _plugin_revision(plugin_type=plugin_type,
                                 identifier=lookup_identifier or identifier, env_var=env_var,
-                                unresolved_is_notable=unresolved_is_notable,
                                 registry_prefixes=registry_prefixes)
+    # Revisioning is only ever enabled alongside the shared S3 cache (the
+    # orchestrator sets both together), and there an unrevisioned key is served
+    # across plugin revisions -- exactly the failure this module exists to
+    # prevent. Refuse to key rather than write one; the caller computes
+    # uncached. `_plugin_revision` logs the refusal, once per plugin.
+    if not revision:
+        return None
     # The revision is appended to the *full* identifier: the screen suffix
     # carries the degree conversion, which changes the activations.
-    return f"{identifier}@{revision}" if revision else identifier
+    return f"{identifier}@{revision}"
 
 
 @lru_cache(maxsize=None)
 def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
-                     unresolved_is_notable: bool = True,
                      registry_prefixes: tuple = (None,)) -> Optional[str]:
     """Short revision string for a plugin, or None if it cannot be determined.
 
@@ -170,15 +186,15 @@ def _plugin_revision(plugin_type: str, identifier: str, env_var: str,
     if plugin_dir is not None:
         revision = _git_revision(plugin_dir) or _content_revision(plugin_dir)
     if not revision:
-        # An unresolved *model* revision means the cache cannot tell two
-        # revisions of the same plugin apart, which is the failure this module
-        # exists to prevent -- worth surfacing. An unresolved stimulus set is
-        # routine, but logging it at debug is how two resolver bugs went
-        # unnoticed until a cache key was read by hand.
-        log = _logger.warning if unresolved_is_notable else _logger.info
-        log(f"Could not resolve a {plugin_type} revision for '{identifier}'; the activation "
-            f"cache key cannot distinguish revisions of this plugin. "
-            f"Set {env_var} to make it explicit.")
+        # Always a warning now: an unresolved revision of either kind disables
+        # caching for the request, so it is never routine. Logged here rather
+        # than at the call site because this function is lru_cached, which is
+        # what keeps it to one line per plugin instead of one per extraction.
+        _logger.warning(
+            f"Refusing to cache: could not resolve a {plugin_type} revision for "
+            f"'{identifier}', so a shared cache key could not distinguish revisions of this "
+            f"plugin. Affected requests are computed without the cache. "
+            f"Set {env_var} to make the revision explicit.")
     return revision
 
 

--- a/brainscore_vision/model_helpers/activations/core.py
+++ b/brainscore_vision/model_helpers/activations/core.py
@@ -86,15 +86,20 @@ class ActivationsExtractorHelper:
     def from_paths(self, stimuli_paths, layers, stimuli_identifier=None, require_variance=None):
         if layers is None:
             layers = ['logits']
-        if self.identifier and stimuli_identifier:
-            # Identifiers alone do not distinguish plugin revisions, so a cache
-            # keyed on them would serve activations from code that no longer
-            # exists. Append a content revision to each. These values are used
-            # *only* to build the cache key -- _from_paths_stored ignores them
-            # otherwise -- so the returned assembly is unaffected.
+        # Identifiers alone do not distinguish plugin revisions, so a cache
+        # keyed on them would serve activations from code that no longer
+        # exists. Append a content revision to each. These values are used
+        # *only* to build the cache key -- _from_paths_stored ignores them
+        # otherwise -- so the returned assembly is unaffected. Either is None
+        # when a revision was required but unresolvable, which means this
+        # request must not be cached at all.
+        cache_identifier = model_cache_identifier(self.identifier) if self.identifier else None
+        cache_stimuli_identifier = (stimulus_set_cache_identifier(stimuli_identifier)
+                                    if stimuli_identifier else None)
+        if cache_identifier and cache_stimuli_identifier:
             fnc = functools.partial(self._from_paths_stored,
-                                    identifier=model_cache_identifier(self.identifier),
-                                    stimuli_identifier=stimulus_set_cache_identifier(stimuli_identifier),
+                                    identifier=cache_identifier,
+                                    stimuli_identifier=cache_stimuli_identifier,
                                     require_variance=require_variance)
         else:
             self._logger.debug(f"self.identifier `{self.identifier}` or stimuli_identifier {stimuli_identifier} "

--- a/tests/test_model_helpers/activations/test_cache_key.py
+++ b/tests/test_model_helpers/activations/test_cache_key.py
@@ -73,23 +73,25 @@ class TestEnvironmentOverride:
         monkeypatch.setenv('BRAINSCORE_MODEL_PLUGIN_SHA', 'a' * 40)
         monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
-            assert stimulus_set_cache_identifier('Papale2025') == 'Papale2025'
+            # None (refuse to cache), and above all never the model's sha
+            assert stimulus_set_cache_identifier('Papale2025') is None
 
 
-class TestDegradesInsteadOfFailing:
-    """None of these may raise, and none may invent a revision."""
+class TestRefusesInsteadOfFailing:
+    """None of these may raise, none may invent a revision, and an unresolved
+    revision must refuse to key rather than degrade to a revision-blind one."""
 
-    def test_unresolvable_plugin_returns_bare_identifier(self, revisioning_on, monkeypatch):
+    def test_unresolvable_plugin_refuses_to_key(self, revisioning_on, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
-            assert model_cache_identifier('nonexistent_model') == 'nonexistent_model'
+            assert model_cache_identifier('nonexistent_model') is None
 
     def test_locate_plugin_raising_is_swallowed(self, revisioning_on, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         from brainscore_core.plugin_management import import_plugin
         with mock.patch.object(import_plugin.ImportPlugin, 'locate_plugin',
                                side_effect=AssertionError("No registrations found")):
-            assert model_cache_identifier('alexnet') == 'alexnet'
+            assert model_cache_identifier('alexnet') is None  # refused, not raised
 
     def test_git_failure_falls_through_to_content_hash(self, revisioning_on, tmp_path, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
@@ -99,12 +101,12 @@ class TestDegradesInsteadOfFailing:
             result = model_cache_identifier('alexnet')
         assert result.startswith('alexnet@') and len(result) == len('alexnet@') + 12
 
-    def test_everything_failing_still_returns_identifier(self, revisioning_on, tmp_path, monkeypatch):
+    def test_everything_failing_refuses_without_raising(self, revisioning_on, tmp_path, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=tmp_path), \
              mock.patch.object(cache_key, '_git_revision', return_value=None), \
              mock.patch.object(cache_key, '_content_revision', return_value=None):
-            assert model_cache_identifier('alexnet') == 'alexnet'
+            assert model_cache_identifier('alexnet') is None
 
     def test_falsy_identifier_passes_through(self, revisioning_on):
         """`stimuli_identifier=False` is how callers disable storing."""
@@ -202,13 +204,19 @@ class TestLogNoise:
         warnings = [r for r in caplog.records if r.levelname == 'WARNING']
         assert len(warnings) == 1, f"expected one warning, got {len(warnings)}"
 
-    def test_unresolved_stimulus_set_does_not_warn(self, revisioning_on, monkeypatch, caplog):
+    def test_unresolved_stimulus_set_warns_because_it_disables_caching(
+            self, revisioning_on, monkeypatch, caplog):
+        """This used to be deliberate silence -- unresolvable stimulus sets were
+        routine and keyed bare. Now they refuse to cache, so silence would hide a
+        recomputation nobody asked for."""
         monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
         with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
             with caplog.at_level('WARNING'):
-                stimulus_set_cache_identifier('SomeBenchmarkLocalStimuli')
-        assert [r for r in caplog.records if r.levelname == 'WARNING'] == [], \
-            "unresolvable stimulus sets are routine; warning on them is log noise"
+                for _ in range(25):
+                    stimulus_set_cache_identifier('SomeBenchmarkLocalStimuli')
+        warnings = [r for r in caplog.records if r.levelname == 'WARNING']
+        assert len(warnings) == 1, f"expected one warning per plugin, got {len(warnings)}"
+        assert 'Refusing to cache' in warnings[0].message
 
 
 class TestExtractorIntegration:
@@ -242,6 +250,37 @@ class TestExtractorIntegration:
         kwargs = extractor._from_paths_stored.call_args[1]
         assert kwargs['identifier'] == 'alexnet@' + 'a' * 12
         assert kwargs['stimuli_identifier'] == 'Papale2025@' + 'b' * 12
+
+    def test_unresolvable_revision_bypasses_the_cache_entirely(self, revisioning_on, monkeypatch):
+        """The whole point of refusing: no stored call, so nothing is written
+        under a key that cannot distinguish plugin revisions.
+
+        Regression guard for build 98, which wrote a 369 MB unrevisioned entry
+        for Allen2022_fmri_surface_full to the shared S3 cache.
+        """
+        monkeypatch.delenv('BRAINSCORE_MODEL_PLUGIN_SHA', raising=False)
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        extractor = self._stub_extractor()
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None), \
+             mock.patch.object(cache_key, '_locate_plugin_dir_by_stimulus_identifier',
+                               return_value=None):
+            result = extractor.from_paths(stimuli_paths=['x.png'], layers=['fc'],
+                                          stimuli_identifier='Allen2022_fmri_surface_full')
+        extractor._from_paths_stored.assert_not_called()
+        extractor._from_paths.assert_called_once()
+        assert result == 'ASSEMBLY', "refusing to cache must still return the assembly"
+
+    def test_revisioning_off_still_caches_on_bare_identifiers(self, monkeypatch):
+        """Local developers keep their warm caches: with revisioning unset an
+        unresolvable plugin must NOT disable caching."""
+        monkeypatch.delenv('BRAINSCORE_CACHE_PLUGIN_REVISION', raising=False)
+        extractor = self._stub_extractor()
+        with mock.patch.object(cache_key, '_locate_plugin_dir', return_value=None):
+            extractor.from_paths(stimuli_paths=['x.png'], layers=['fc'],
+                                 stimuli_identifier='SomethingUnresolvable')
+        kwargs = extractor._from_paths_stored.call_args[1]
+        assert kwargs['identifier'] == 'alexnet'
+        assert kwargs['stimuli_identifier'] == 'SomethingUnresolvable'
 
     def test_model_identifier_attribute_is_not_mutated(self, revisioning_on, monkeypatch):
         """Only the cache key carries the revision; self.identifier is used
@@ -289,9 +328,9 @@ class TestStimulusSetResolution:
         monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
         assert stimulus_set_cache_identifier('MajajHong2015').startswith('MajajHong2015@')
 
-    def test_unregistered_identifier_is_still_returned_bare(self, revisioning_on, monkeypatch):
+    def test_unregistered_identifier_refuses_to_key(self, revisioning_on, monkeypatch):
         monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
-        assert stimulus_set_cache_identifier('NotARegisteredStimulusSet') == 'NotARegisteredStimulusSet'
+        assert stimulus_set_cache_identifier('NotARegisteredStimulusSet') is None
 
 
 class TestScreenConvertedIdentifiers:


### PR DESCRIPTION
## What happened

Build 98 wrote 30 objects to the shared S3 activation cache. 14 of the 15 distinct stimulus keys carried a plugin revision. One did not:

```
UNREVISIONED  369.0MiB  stimuli_identifier=Allen2022_fmri_surface_full--target8.00--source8.40
```

with this in the log:

> Could not resolve a data revision for `Allen2022_fmri_surface_full`; the activation cache key cannot distinguish revisions of this plugin.

That entry will be served for any future revision of the Allen2022 data plugin, and the resulting score will look entirely normal — the failure this module was written to prevent.

The revisioning interlock did not catch it because it only asserts `BRAINSCORE_CACHE_PLUGIN_REVISION=1` is *set*, not that each plugin actually *resolves* a revision. So this is a gap in the guarantee rather than a violated check.

## Why it was written that way

Degrading to the bare identifier was correct when the cache was per-container and thrown away: an unresolvable stimulus set just keyed as it always had, and the old comment said so explicitly. The shared, long-lived S3 backend changes the consequence — one unrevisioned key now outlives the code that produced it.

## The change

`model_cache_identifier` / `stimulus_set_cache_identifier` return `None` when revisioning is enabled and no revision resolves. `from_paths` treats `None` as "do not cache" and takes the uncached path.

Refusing costs one recomputation. A stale hit costs a wrong score that looks normal.

Verified on the exact build-98 identifiers:

```
Allen2022_fmri_surface_full--target8.00--source8.40  -> None            (warns)
Allen2022_fMRI_test_Stimuli--target8.00--source8.40  -> ...@f2ded55ce569
Hebart2023                                           -> ...@4b847c8b0893
model regnety_032                                    -> ...@6365eb5f442a
```

## Not a regression for local development

Revisioning is off by default, so warm local caches keyed on bare identifiers behave exactly as before — an unresolvable plugin does **not** disable caching there. Covered by `test_revisioning_off_still_caches_on_bare_identifiers`.

## Log volume

The refusal is logged inside the `lru_cache`d `_plugin_revision`, so it stays at one line per plugin rather than one per extraction. My first attempt logged from the uncached caller and produced 26 warnings for 26 calls; the existing `test_unresolved_model_warns_once_not_per_call` caught it.

## Test changes

Four tests asserted the old degrade-gracefully contract and now assert refusal. `TestDegradesInsteadOfFailing` is renamed `TestRefusesInsteadOfFailing` — the "must never raise" half of its purpose is unchanged and still asserted.

`test_unresolved_stimulus_set_does_not_warn` inverted: unresolved stimulus sets were deliberately silent because they were routine. They now disable caching, so silence would hide a recomputation nobody asked for.

Two new integration tests, the first mutation-checked (restoring the bare-identifier fallback fails it):
- `test_unresolvable_revision_bypasses_the_cache_entirely` — asserts `_from_paths_stored` is never called and the assembly still comes back
- `test_revisioning_off_still_caches_on_bare_identifiers`

Also removes `unresolved_is_notable`, which stopped changing any behaviour once both plugin types refuse, and corrects the module docstring, which documented the fallback this removes.

53 tests pass.

## Follow-up, not in this PR

The 369 MB unrevisioned object is still in the bucket and should be deleted. `brainscore-storage` has versioning enabled, so a plain delete only writes a delete marker — purging it needs explicit `VersionId` deletion.