### PR TITLE
fix(cache): let synthesised stimulus sets resolve a data revision

### DIFF
--- a/brainscore_vision/benchmarks/laion_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/laion_fmri/benchmark.py
@@ -287,9 +287,9 @@ def load_assembly(
         except (KeyError, AttributeError):
             subs_in_assembly = []
         sub_tag = "+".join(subs_in_assembly) if subs_in_assembly else "all"
-        stim.identifier = f"{dataset_prefix}_{split}_{side}_{sub_tag}"
+        stim.identifier = f"{dataset_prefix}_stim_full--{split}-{side}-{sub_tag}"
     else:
-        stim.identifier = f"{dataset_prefix}_{split}_{side}"
+        stim.identifier = f"{dataset_prefix}_stim_full--{split}-{side}"
     stim.stimulus_paths = {
         sid: full_stim.stimulus_paths[sid]
         for sid in stim["stimulus_id"]
@@ -585,7 +585,13 @@ def load_full_assembly_one_subject(
         subset="stimulus_id"
     ).reset_index(drop=True)
     stim = StimulusSet(merged)
-    stim.identifier = f"{dataset_prefix}_rdm_full_{sub_id}"
+    # `<registered set>--<marker>`: the marker keeps this distinct from the
+    # split-specific sets in the cache key, while `{dataset_prefix}_stim_full`
+    # stays resolvable so the key can carry a data-plugin revision. A bare
+    # synthesised name resolves to nothing, and caching is refused for anything
+    # unrevisioned -- which silently disabled the cache for every rdm/cka
+    # variant in run 99.
+    stim.identifier = f"{dataset_prefix}_stim_full--rdm-{sub_id}"
     stim.stimulus_paths = {
         **train_stim.stimulus_paths,
         **test_stim.stimulus_paths,

--- a/brainscore_vision/model_helpers/activations/cache_key.py
+++ b/brainscore_vision/model_helpers/activations/cache_key.py
@@ -76,9 +76,12 @@ _IGNORED_DIRS = ('__pycache__', '.git', '.pytest_cache')
 # Opt-in switch. Unset => keys are exactly what they were before this module.
 _ENABLE_VAR = 'BRAINSCORE_CACHE_PLUGIN_REVISION'
 
-# Marks the start of the suffix `benchmark_helpers.screen.place_on_screen`
-# appends: `--target<deg>--source<deg>`. Kept in sync with that f-string.
-_SCREEN_SUFFIX = '--target'
+# Separates a registered stimulus set from any derivative marker appended to it.
+# `benchmark_helpers.screen.place_on_screen` appends `--target<deg>--source<deg>`;
+# benchmarks that synthesise a stimulus set (a merged train+test pool, a
+# per-subject slice) use the same convention so the registered set they came
+# from stays recoverable for revisioning.
+_DERIVED_SEPARATOR = '--'
 
 
 def revision_enabled() -> bool:
@@ -125,15 +128,23 @@ def stimulus_set_cache_identifier(stimuli_identifier: str) -> str:
 def base_stimulus_identifier(stimuli_identifier: str) -> str:
     """The registered stimulus set a screen-converted identifier derives from.
 
-    ``place_on_screen`` renames its output to
-    ``<identifier>--target<deg>--source<deg>``, which is not a registered
-    plugin, so resolving the suffixed name finds nothing. Rescaling is a pure
-    function of the source images plus the two degree values already in the
-    key, so the revision of the set they came from is what needs tracking.
+    Two things produce derivative names, and neither is a registered plugin, so
+    resolving them directly finds nothing:
+
+    * ``place_on_screen`` renames its output to
+      ``<identifier>--target<deg>--source<deg>``. Rescaling is a pure function of
+      the source images plus the two degree values already in the key.
+    * a benchmark that synthesises a stimulus set -- a merged train+test pool, a
+      per-subject slice -- names it ``<registered set>--<marker>``.
+
+    In both cases the content is derived from the registered set, so that set's
+    plugin revision is what needs tracking. Everything from the first ``--``
+    onwards stays in the *key* (it distinguishes the derivatives from each
+    other); it is stripped only for the revision lookup.
     """
     if not isinstance(stimuli_identifier, str):
         return stimuli_identifier
-    return stimuli_identifier.split(_SCREEN_SUFFIX)[0]
+    return stimuli_identifier.split(_DERIVED_SEPARATOR)[0]
 
 
 def _with_revision(identifier, plugin_type: str, env_var: str,

--- a/tests/test_model_helpers/activations/test_cache_key.py
+++ b/tests/test_model_helpers/activations/test_cache_key.py
@@ -333,6 +333,43 @@ class TestStimulusSetResolution:
         assert stimulus_set_cache_identifier('NotARegisteredStimulusSet') is None
 
 
+class TestDerivedStimulusIdentifiers:
+    """A synthesised stimulus set names itself `<registered set>--<marker>` so the
+    registered set stays resolvable.
+
+    Run 99 regression: the laion_fmri benchmarks used bare synthesised names
+    (`Zerbe2026_fmri_rdm_full_sub-01`), which resolve to nothing. Once an
+    unresolved revision refuses to cache, that silently disabled the cache for
+    every rdm and cka variant -- the exact family the shared cache exists for.
+    """
+
+    def test_marker_is_stripped_for_the_revision_lookup(self, revisioning_on, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        result = stimulus_set_cache_identifier('Zerbe2026_fmri_stim_full--rdm-sub-01')
+        assert result is not None, "a derivative of a registered set must be cacheable"
+        assert result.startswith('Zerbe2026_fmri_stim_full--rdm-sub-01@')
+
+    def test_marker_stays_in_the_key(self, revisioning_on, monkeypatch):
+        """Stripping it from the key would collide rdm with the ridge splits."""
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        rdm = stimulus_set_cache_identifier('Zerbe2026_fmri_stim_full--rdm-sub-01')
+        ridge = stimulus_set_cache_identifier('Zerbe2026_fmri_stim_full--tau-train-sub-01')
+        assert rdm != ridge
+        assert 'rdm-sub-01' in rdm and 'tau-train-sub-01' in ridge
+
+    def test_a_screen_suffix_layered_on_top_still_resolves(self, revisioning_on, monkeypatch):
+        """place_on_screen appends to whatever it is given, so both markers stack."""
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        result = stimulus_set_cache_identifier(
+            'Zerbe2026_fmri_stim_full--rdm-sub-01--target8.00--source9.20')
+        assert result is not None and '@' in result
+
+    def test_an_unregistered_base_is_still_refused(self, revisioning_on, monkeypatch):
+        """Generalising the split must not invent revisions for unknown sets."""
+        monkeypatch.delenv('BRAINSCORE_DATA_PLUGIN_SHA', raising=False)
+        assert stimulus_set_cache_identifier('NotRegisteredAtAll--marker') is None
+
+
 class TestScreenConvertedIdentifiers:
     """`place_on_screen` renames its output to
     `<id>--target<deg>--source<deg>`, which is not a registered plugin."""
@@ -357,12 +394,14 @@ class TestScreenConvertedIdentifiers:
         assert eight != ten
         assert eight.startswith('hvm-public--target8.00--source11.00@')
 
-    def test_suffix_constant_matches_screen_py(self):
-        """_SCREEN_SUFFIX duplicates a literal from screen.py's f-string."""
+    def test_separator_still_prefixes_the_screen_suffix(self):
+        """Base resolution splits on _DERIVED_SEPARATOR, so place_on_screen's
+        appended suffix has to keep starting with it -- otherwise a screened
+        stimulus set stops resolving and silently loses its cache."""
         from brainscore_vision.benchmark_helpers import screen
         source = Path(screen.__file__).read_text()
-        assert f'{cache_key._SCREEN_SUFFIX}{{target_visual_degrees:.2f}}' in source, \
-            "place_on_screen's suffix changed; update _SCREEN_SUFFIX"
+        assert f'{cache_key._DERIVED_SEPARATOR}target{{target_visual_degrees:.2f}}' in source, \
+            "place_on_screen's suffix no longer starts with _DERIVED_SEPARATOR"
 
     def test_non_string_identifier_passes_through(self):
         assert cache_key.base_stimulus_identifier(False) is False


### PR DESCRIPTION
Follow-up to #2487, which I got half right.

## What #2487 broke

Refusing to cache an unresolvable revision is correct. But it turned off caching for **every Zerbe rdm and cka variant** — the exact family the shared cache was built for, and the one behind the CKA request. Run 99 logged six refusals:

```
Refusing to cache: could not resolve a data revision for 'Allen2022_fmri_surface_full'
Refusing to cache: could not resolve a data revision for 'Zerbe2026_fmri_rdm_full_sub-01'
                                                    ... sub-03, sub-05, sub-06, sub-07
```

Those names are synthesised at runtime for a merged train+test pool:

```python
stim.identifier = f"{dataset_prefix}_rdm_full_{sub_id}"
```

They are not registered plugins, so they can never resolve a revision. `base_stimulus_identifier` only stripped `place_on_screen`'s `--target...` suffix, so it couldn't recover a registered set either. Net effect: a correctness fix that removed the primary use case.

## The fix

The synthesised sets are built from a registered stimulus set — `load_stimulus_set(f"{dataset_prefix}_stim_full")`, a few lines above in the same function — and that one resolves fine:

```
Zerbe2026_fmri_stim_full -> Zerbe2026_fmri_stim_full@45652ce8b1a9
```

So two changes:

1. Base resolution generalises from the `--target` screen suffix to any `--<marker>` derivative.
2. The three laion_fmri synthesised identifiers become `{prefix}_stim_full--<marker>`.

The marker stays in the **key**, so rdm and the ridge splits remain distinct entries — only the revision lookup strips it. `place_on_screen` suffixes layer on top and still resolve, since both use the same separator.

## Verified

```
CACHED   Zerbe2026_fmri_stim_full--rdm-sub-01        -> ...@45652ce8b1a9
CACHED   ...rdm-sub-03 / sub-05 / sub-06 / sub-07    -> ...@45652ce8b1a9
CACHED   Zerbe2026_fmri_stim_full--tau-train-sub-01  -> ...@45652ce8b1a9

NotRegisteredAtAll--marker                           -> None
NotRegisteredAtAll                                   -> None
```

Refusal still applies to genuinely unregistered sets, so #2487's guarantee is intact — the generalised split does not invent revisions for unknown sets, which is its own test.

91 tests pass across `test_cache_key`, `laion_fmri`, and `test_db_contract`.

`TestScreenConvertedIdentifiers::test_suffix_constant_matches_screen_py` is rewritten rather than deleted: it guarded against `place_on_screen`'s suffix drifting away from the constant, and that risk is unchanged — it now asserts the appended suffix still *starts with* the separator.

## Not in this PR

`Allen2022_fmri_surface_full` is the same class of bug (`f'{dataset_prefix}_full'`, also synthesised), but its registered base is not mechanically derivable from the dataset prefix — Allen2022 registers `Allen2022_fmri_stim_train` / `_stim_test` and the synthesised set is a merge of both. Left refusing, which is correct behaviour and merely uncached, for a change that can pick the anchor deliberately.

## Note

Cache keys for the Zerbe family change, so any entries written under the old bare names are orphaned. There are none — they were being refused, which is what prompted this.