### PR TITLE
feat(cache): guard and document the stimulus-identifier contract

### DIFF
--- a/brainscore_vision/benchmark_helpers/cache_contract.py
+++ b/brainscore_vision/benchmark_helpers/cache_contract.py
@@ -1,0 +1,90 @@
+"""Check that a benchmark's stimulus identifiers can carry a plugin revision.
+
+The shared activation cache keys on ``stimuli_identifier``. An identifier that
+cannot be traced back to a registered plugin cannot carry a revision, and since
+brain-score refuses to write an unrevisioned key to a shared cache, every
+extraction for that stimulus set is recomputed at full cost -- silently, apart
+from one warning line in a scoring log.
+
+That is exactly what happened to the Zerbe rdm and cka variants: the benchmark
+synthesised ``Zerbe2026_fmri_rdm_full_sub-01`` for a merged train+test pool,
+which is not a registered plugin, so caching was disabled for the entire family
+the cache existed to serve.
+
+The rule for a synthesised stimulus set is to name it after the registered set
+it derives from::
+
+    stim.identifier = f"{registered_identifier}--{marker}"
+
+Everything from the first ``--`` on stays in the cache key, so derivatives stay
+distinct from each other; only the part before it is used to look up the
+revision. ``place_on_screen`` already follows this convention, and its suffix
+composes with a benchmark's own marker.
+
+Call :func:`assert_stimulus_identifier_is_cacheable` from a plugin's tests to
+catch this at PR time instead of in a production scoring log.
+"""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+
+__all__ = ['stimulus_identifier_is_cacheable', 'assert_stimulus_identifier_is_cacheable']
+
+
+@contextmanager
+def _revisioning_enabled():
+    """Force revisioning on for the duration of the check.
+
+    Revisioning is opt-in and off by default, and with it off every identifier
+    resolves to itself -- so a check that did not force it on would pass
+    unconditionally, which is worse than no check at all.
+    """
+    from brainscore_vision.model_helpers.activations import cache_key
+
+    var = 'BRAINSCORE_CACHE_PLUGIN_REVISION'
+    previous = os.environ.get(var)
+    os.environ[var] = '1'
+    # the resolver memoises per (plugin_type, identifier); clear so a check
+    # cannot be answered from a lookup made while revisioning was off
+    cache_key._plugin_revision.cache_clear()
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop(var, None)
+        else:
+            os.environ[var] = previous
+        cache_key._plugin_revision.cache_clear()
+
+
+def stimulus_identifier_is_cacheable(stimuli_identifier: str) -> bool:
+    """True if ``stimuli_identifier`` can carry a data-plugin revision."""
+    from brainscore_vision.model_helpers.activations.cache_key import (
+        stimulus_set_cache_identifier)
+
+    with _revisioning_enabled():
+        return stimulus_set_cache_identifier(stimuli_identifier) is not None
+
+
+def assert_stimulus_identifier_is_cacheable(stimuli_identifier: str) -> None:
+    """Raise ``AssertionError`` if this identifier would disable caching.
+
+    :param stimuli_identifier: the value a benchmark assigns to
+        ``stimulus_set.identifier``, exactly as the extractor will see it.
+    """
+    from brainscore_vision.model_helpers.activations.cache_key import (
+        base_stimulus_identifier)
+
+    if stimulus_identifier_is_cacheable(stimuli_identifier):
+        return
+    base = base_stimulus_identifier(stimuli_identifier)
+    raise AssertionError(
+        f"stimulus identifier {stimuli_identifier!r} cannot carry a data-plugin "
+        f"revision, so the shared activation cache will refuse it and every "
+        f"extraction will be recomputed at full cost.\n"
+        f"  looked up: {base!r} -- not a registered data or stimulus_set plugin.\n"
+        f"  If this set is synthesised from a registered one, name it "
+        f"'<registered identifier>--<marker>'; the marker stays in the cache key, "
+        f"the part before it resolves the revision."
+    )

--- a/brainscore_vision/benchmark_helpers/test_cache_contract.py
+++ b/brainscore_vision/benchmark_helpers/test_cache_contract.py
@@ -1,0 +1,90 @@
+"""Tests for the activation-cache stimulus-identifier contract.
+
+Regression guard for the Zerbe rdm/cka family, which lost caching entirely
+because the benchmark synthesised an identifier that no registered plugin
+matched. See :mod:`brainscore_vision.benchmark_helpers.cache_contract`.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from brainscore_vision.benchmark_helpers.cache_contract import (
+    assert_stimulus_identifier_is_cacheable, stimulus_identifier_is_cacheable)
+
+
+class TestCacheableCheck:
+    def test_registered_set_is_cacheable(self):
+        assert stimulus_identifier_is_cacheable('Hebart2023') is True
+
+    def test_unregistered_name_is_not(self):
+        assert stimulus_identifier_is_cacheable('NotARegisteredStimulusSet') is False
+
+    def test_derivative_of_a_registered_set_is_cacheable(self):
+        """The `--<marker>` convention: marker stays in the key, base resolves."""
+        assert stimulus_identifier_is_cacheable('Zerbe2026_fmri_stim_full--rdm-sub-01') is True
+
+    def test_screen_suffix_composes_with_a_marker(self):
+        """place_on_screen appends to whatever it is given, so both stack."""
+        assert stimulus_identifier_is_cacheable(
+            'Zerbe2026_fmri_stim_full--rdm-sub-01--target8.00--source9.20') is True
+
+    def test_derivative_of_an_unregistered_base_is_not(self):
+        """The convention must not manufacture revisions for unknown sets."""
+        assert stimulus_identifier_is_cacheable('NotRegistered--marker') is False
+
+    def test_the_exact_pre_fix_name_is_rejected(self):
+        """`Zerbe2026_fmri_rdm_full_sub-01` is what silently disabled caching."""
+        assert stimulus_identifier_is_cacheable('Zerbe2026_fmri_rdm_full_sub-01') is False
+
+
+class TestAssertionMessage:
+    def test_raises_with_actionable_guidance(self):
+        with pytest.raises(AssertionError) as exc:
+            assert_stimulus_identifier_is_cacheable('Zerbe2026_fmri_rdm_full_sub-01')
+        message = str(exc.value)
+        assert 'recomputed at full cost' in message
+        assert '<registered identifier>--<marker>' in message
+
+    def test_passes_silently_when_cacheable(self):
+        assert_stimulus_identifier_is_cacheable('Hebart2023')  # must not raise
+
+
+class TestCheckIsNotVacuous:
+    """The check forces revisioning on. Without that it would pass for every
+    identifier, since revisioning is opt-in and off by default -- a green test
+    that guarantees nothing."""
+
+    def test_still_detects_with_revisioning_unset(self, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_CACHE_PLUGIN_REVISION', raising=False)
+        assert stimulus_identifier_is_cacheable('NotARegisteredStimulusSet') is False
+
+    def test_restores_the_env_var_it_borrowed(self, monkeypatch):
+        monkeypatch.setenv('BRAINSCORE_CACHE_PLUGIN_REVISION', '0')
+        stimulus_identifier_is_cacheable('Hebart2023')
+        assert os.environ['BRAINSCORE_CACHE_PLUGIN_REVISION'] == '0'
+
+    def test_leaves_no_var_behind_when_there_was_none(self, monkeypatch):
+        monkeypatch.delenv('BRAINSCORE_CACHE_PLUGIN_REVISION', raising=False)
+        stimulus_identifier_is_cacheable('Hebart2023')
+        assert 'BRAINSCORE_CACHE_PLUGIN_REVISION' not in os.environ
+
+
+class TestLaionFmriIdentifiers:
+    """Every stimulus identifier the laion_fmri benchmarks synthesise.
+
+    Kept in sync with the three `stim.identifier = ...` assignments in
+    benchmarks/laion_fmri/benchmark.py.
+    """
+
+    PREFIX = 'Zerbe2026_fmri'
+
+    @pytest.mark.parametrize('identifier', [
+        f'{PREFIX}_stim_full--rdm-sub-01',          # merged tau pool, per subject
+        f'{PREFIX}_stim_full--tau-train-sub-01',    # ridge split, persubject pool
+        f'{PREFIX}_stim_full--tau-test',            # ridge split, shared pool
+        f'{PREFIX}_stim_full--ood-test',
+    ])
+    def test_synthesised_identifiers_are_cacheable(self, identifier):
+        assert_stimulus_identifier_is_cacheable(identifier)

--- a/brainscore_vision/benchmark_helpers/test_cache_contract.py
+++ b/brainscore_vision/benchmark_helpers/test_cache_contract.py
@@ -6,7 +6,9 @@ matched. See :mod:`brainscore_vision.benchmark_helpers.cache_contract`.
 """
 from __future__ import annotations
 
+import ast
 import os
+from pathlib import Path
 
 import pytest
 
@@ -88,3 +90,69 @@ class TestLaionFmriIdentifiers:
     ])
     def test_synthesised_identifiers_are_cacheable(self, identifier):
         assert_stimulus_identifier_is_cacheable(identifier)
+
+
+class TestNoBenchmarkSynthesisesAnUncacheableIdentifier:
+    """Repo-wide sweep: every synthesised stimulus identifier must derive from a
+    registered set.
+
+    A per-plugin check would only cover the plugin someone thought to write it
+    for. This sweep is what surfaced imagenet_c -- the slowest jobs in the suite
+    -- silently recomputing activations on every run.
+
+    Uses ``ast`` rather than a regex: Python merges adjacent string literals into
+    a single node, so an identifier split across lines for width is read whole. A
+    regex sees only the first fragment and reports a false offender.
+    """
+
+    def _assignments(self):
+        root = Path(__file__).resolve().parent.parent / 'benchmarks'
+        found = []
+        for path in root.rglob('*.py'):
+            if 'data_packaging' in str(path):
+                continue
+            try:
+                tree = ast.parse(path.read_text(errors='replace'))
+            except SyntaxError:  # pragma: no cover - not our contract to enforce
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Assign):
+                    continue
+                for target in node.targets:
+                    if not (isinstance(target, ast.Attribute) and target.attr == 'identifier'):
+                        continue
+                    owner = getattr(target.value, 'id', '') or getattr(target.value, 'attr', '')
+                    if 'stim' not in owner.lower():
+                        continue
+                    if isinstance(node.value, ast.JoinedStr):
+                        # keep placeholder POSITIONS: joining only the constant
+                        # fragments lets separators either side of a placeholder
+                        # merge, so 'a-{x}-{y}' reads as containing '--'
+                        literal = ''.join(
+                            v.value if isinstance(v, ast.Constant) else '{}'
+                            for v in node.value.values)
+                        synthesised = any(isinstance(v, ast.FormattedValue)
+                                          for v in node.value.values)
+                        found.append((path.relative_to(root), owner, literal, synthesised))
+        assert found, "no stimulus identifier assignments found -- has the layout changed?"
+        return found
+
+    def test_every_synthesised_identifier_carries_a_marker(self):
+        offenders = [(str(path), owner, literal)
+                     for path, owner, literal, synthesised in self._assignments()
+                     # a placeholder-free name is a registered set used directly
+                     if synthesised and '--' not in literal]
+        assert not offenders, (
+            "these benchmarks synthesise a stimulus identifier with no "
+            "'--<marker>', so no data-plugin revision resolves, the shared "
+            "activation cache refuses them, and every extraction recomputes at "
+            "full cost:\n"
+            + "\n".join(f"    {p}: {o}.identifier -> {lit!r}" for p, o, lit in offenders)
+            + "\n  Name them '<registered identifier>--<marker>'.")
+
+    def test_the_sweep_actually_finds_the_known_assignments(self):
+        """A sweep that silently matches nothing would pass forever."""
+        paths = {str(p) for p, _o, _l, _s in self._assignments()}
+        for expected in ('laion_fmri/benchmark.py', 'allen2022_fmri/benchmark.py',
+                         'imagenet_c/benchmark.py'):
+            assert expected in paths, f"sweep no longer sees {expected}"

--- a/brainscore_vision/benchmarks/allen2022_fmri/benchmark.py
+++ b/brainscore_vision/benchmarks/allen2022_fmri/benchmark.py
@@ -138,7 +138,11 @@ def load_full_assembly(region: str,
     test_stimuli = test.stimulus_set
     combined_stimuli = StimulusSet(pd.concat([train_stimuli, test_stimuli], ignore_index=True))
     combined_stimuli.stimulus_paths = {**train_stimuli.stimulus_paths, **test_stimuli.stimulus_paths}
-    combined_stimuli.identifier = f'{dataset_prefix}_full'
+    # `<registered set>--<marker>`: `{dataset_prefix}_train` is a registered
+    # dataset, so the revision resolves; the marker keeps this merged pool
+    # distinct from the train/test sets in the cache key. A bare synthesised
+    # name resolves to nothing and caching is refused for the whole family.
+    combined_stimuli.identifier = f'{dataset_prefix}_train--full'
     combined.attrs['stimulus_set'] = combined_stimuli
 
     return combined

--- a/brainscore_vision/benchmarks/allen2022_fmri_surface/benchmark.py
+++ b/brainscore_vision/benchmarks/allen2022_fmri_surface/benchmark.py
@@ -138,7 +138,11 @@ def load_full_assembly(region: str,
     test_stimuli = test.stimulus_set
     combined_stimuli = StimulusSet(pd.concat([train_stimuli, test_stimuli], ignore_index=True))
     combined_stimuli.stimulus_paths = {**train_stimuli.stimulus_paths, **test_stimuli.stimulus_paths}
-    combined_stimuli.identifier = f'{dataset_prefix}_full'
+    # `<registered set>--<marker>`: `{dataset_prefix}_train` is a registered
+    # dataset, so the revision resolves; the marker keeps this merged pool
+    # distinct from the train/test sets in the cache key. A bare synthesised
+    # name resolves to nothing and caching is refused for the whole family.
+    combined_stimuli.identifier = f'{dataset_prefix}_train--full'
     combined.attrs['stimulus_set'] = combined_stimuli
 
     return combined

--- a/brainscore_vision/benchmarks/imagenet_c/benchmark.py
+++ b/brainscore_vision/benchmarks/imagenet_c/benchmark.py
@@ -159,6 +159,7 @@ class Imagenet_C_Individual(BenchmarkBase):
         self.stimulus_set = stimulus_set[stimulus_set['noise_level'] == noise_level]
         self.noise_level = noise_level
         self.noise_type = noise_type
+        self.noise_category = noise_category
         self.benchmark_name = f'Hendrycks2019-{noise_category}-{noise_type}-{noise_level}-top1'
         self._similarity_metric = load_metric('accuracy')
         ceiling = Score(1)
@@ -171,7 +172,13 @@ class Imagenet_C_Individual(BenchmarkBase):
         candidate.start_task(BrainModel.Task.label, 'imagenet')
         stimulus_set = self.stimulus_set[
             list(set(self.stimulus_set.columns) - {'synset'})].copy().reset_index()  # do not show label
-        stimulus_set.identifier = f'{self.benchmark_name}-{len(stimulus_set)}samples'
+        # `<registered set>--<marker>`: this subset is synthesised, so it must be
+        # named after `imagenet_c.<category>` (the set it is filtered from) or no
+        # data-plugin revision resolves and caching is refused for every
+        # ImageNet-C benchmark -- the slowest jobs in the suite.
+        stimulus_set.identifier = (f'imagenet_c.{self.noise_category}'
+                                   f'--{self.noise_type}-{self.noise_level}'
+                                   f'-{len(stimulus_set)}samples')
         predictions = candidate.look_at(stimulus_set, number_of_trials=NUMBER_OF_TRIALS)
         score = self._similarity_metric(
             predictions.sortby('filename'),

--- a/brainscore_vision/benchmarks/laion_fmri/test.py
+++ b/brainscore_vision/benchmarks/laion_fmri/test.py
@@ -220,6 +220,49 @@ class TestUncertaintyContract:
         assert score.attrs.get("error_nan_reason")
 
 
+class TestStimulusIdentifierConvention:
+    """Every synthesised stimulus identifier must derive from a registered set.
+
+    A bare synthesised name resolves to no plugin, so the shared activation
+    cache refuses it and every extraction is recomputed at full cost. That
+    silently disabled caching for the whole rdm/cka family once before.
+
+    This reads the assignments out of benchmark.py rather than restating them,
+    so a new or edited identifier cannot drift past the check.
+    """
+
+    def _identifier_templates(self):
+        import re
+        from pathlib import Path
+        from brainscore_vision.benchmarks.laion_fmri import benchmark as bm
+        source = Path(bm.__file__).read_text()
+        templates = re.findall(r'stim\.identifier\s*=\s*f"([^"]+)"', source)
+        assert templates, "no stim.identifier assignments found -- has benchmark.py moved?"
+        return templates
+
+    def test_every_synthesised_identifier_derives_from_a_registered_set(self):
+        for template in self._identifier_templates():
+            assert '--' in template, (
+                f"synthesised stimulus identifier {template!r} has no '--<marker>'. "
+                f"It will not resolve a data-plugin revision, so caching is refused "
+                f"and every extraction recomputes. Name it "
+                f"'<registered identifier>--<marker>'.")
+            base = template.split('--')[0]
+            assert base == '{dataset_prefix}_stim_full', (
+                f"identifier {template!r} resolves against {base!r}, which is not the "
+                f"registered stimulus set this benchmark loads "
+                f"(load_stimulus_set(f'{{dataset_prefix}}_stim_full'))")
+
+    def test_the_resolved_identifiers_are_actually_cacheable(self):
+        from brainscore_vision.benchmark_helpers.cache_contract import (
+            assert_stimulus_identifier_is_cacheable)
+        for template in self._identifier_templates():
+            concrete = (template.replace('{dataset_prefix}', 'Zerbe2026_fmri')
+                                .replace('{split}', 'tau').replace('{side}', 'train')
+                                .replace('{sub_tag}', 'sub-01').replace('{sub_id}', 'sub-01'))
+            assert_stimulus_identifier_is_cacheable(concrete)
+
+
 class TestCKAWiring:
     """The CKA variants reuse RSABenchmark with the RDM stage bypassed.
 

--- a/docs/source/modules/developer_clarifications.rst
+++ b/docs/source/modules/developer_clarifications.rst
@@ -26,6 +26,49 @@ anyone interested in contributing to Brain-Score's codebase or scientific workin
     `result_caching` by simply setting the environment flag `RESULTCACHING_DISABLE` to `1`. Please see the link above
     for more detailed documentation.
 
+    Note that `RESULTCACHING_DISABLE=1` disables *every* cached function, not just activations -- including
+    `place_on_screen`. To disable only the activation cache (for example, to check that a score is unaffected by
+    caching), name the module instead::
+
+        RESULTCACHING_DISABLE=brainscore_vision.model_helpers.activations
+
+    In production scoring, activations are additionally cached to a *shared* S3 bucket so a second metric on the same
+    model and stimuli reuses the forward pass instead of repeating it. Because that cache is long-lived and shared,
+    its keys carry a content revision of the model plugin and of the stimulus-set plugin: a plugin can be revised
+    while keeping the same identifier, and without a revision the cache would serve activations produced by code that
+    no longer exists. If a revision cannot be resolved, brain-score **refuses to cache** that request rather than
+    write an ambiguous key -- correct, but it means the work is recomputed every time. See item 4.
+
+4. **Naming a stimulus set so it can be cached**
+
+    Benchmarks often build a stimulus set at runtime rather than using a registered one directly -- a merged
+    train+test pool, a per-subject slice, a filtered subset. Such a name is not a registered plugin, so no revision
+    can be resolved for it, so the shared activation cache refuses it and every extraction is recomputed at full
+    cost. The only symptom is one warning line in a scoring log.
+
+    Name a synthesised stimulus set after the registered set it derives from::
+
+        stim.identifier = f"{registered_identifier}--{marker}"
+
+    Everything from the first ``--`` onward stays in the cache key, so derivatives remain distinct from one another;
+    only the part before it is used to look up the revision. `place_on_screen` already follows this convention
+    (appending ``--target<deg>--source<deg>``), and its suffix composes with a benchmark's own marker.
+
+    For example, a benchmark that loads `Zerbe2026_fmri_stim_full` and builds a per-subject merged pool from it
+    should name that pool ``Zerbe2026_fmri_stim_full--rdm-sub-01``, not ``Zerbe2026_fmri_rdm_full_sub-01``. The
+    second form resolves to nothing and disabled caching for an entire benchmark family until it was caught.
+
+    Assert this in your plugin's tests so it is caught at PR time rather than in a production scoring log::
+
+        from brainscore_vision.benchmark_helpers.cache_contract import (
+            assert_stimulus_identifier_is_cacheable)
+
+        def test_stimulus_identifier_is_cacheable():
+            assert_stimulus_identifier_is_cacheable("MyData_stim_full--my-variant")
+
+    This only matters for stimulus sets a benchmark *synthesises*. A benchmark that uses a registered stimulus set
+    directly already resolves.
+
 3. **Model Mapping Procedure**
 
     In general, there are different methods that are used in the Brain-Score code to instruct the model to "begin recording",


### PR DESCRIPTION
## Why

A benchmark that *synthesises* a stimulus set — a merged train+test pool, a per-subject slice — gives it a name that matches no registered plugin. No revision resolves, so the shared activation cache refuses the key (#2487) and every extraction is recomputed at full cost. The only symptom is one warning line in a scoring log.

This is not hypothetical. `Zerbe2026_fmri_rdm_full_sub-01` silently disabled caching for the entire rdm and cka family — the family the shared cache exists to serve — and it was found by reading S3 keys, not by any test. #2488 fixed the instance; this stops the next one.

## What

**`assert_stimulus_identifier_is_cacheable(identifier)`** in `benchmark_helpers/cache_contract.py`, for plugin authors to call from their own tests:

```python
from brainscore_vision.benchmark_helpers.cache_contract import (
    assert_stimulus_identifier_is_cacheable)

def test_stimulus_identifier_is_cacheable():
    assert_stimulus_identifier_is_cacheable("MyData_stim_full--my-variant")
```

It **forces revisioning on for the duration of the check**, which is the part that makes it worth anything: revisioning is opt-in and off by default, and with it off every identifier resolves to itself — so a check without that would pass unconditionally. It also clears the resolver's `lru_cache` so a lookup made while revisioning was off can't answer the check, and restores the env var it borrowed (both asserted).

The failure message names what was looked up and what to do:

```
stimulus identifier 'Zerbe2026_fmri_rdm_full_sub-01' cannot carry a data-plugin
revision, so the shared activation cache will refuse it and every extraction
will be recomputed at full cost.
  looked up: 'Zerbe2026_fmri_rdm_full_sub-01' -- not a registered data or stimulus_set plugin.
  If this set is synthesised from a registered one, name it
  '<registered identifier>--<marker>'; the marker stays in the cache key,
  the part before it resolves the revision.
```

**A drift guard over laion_fmri** that reads the `stim.identifier` assignments out of `benchmark.py` by regex rather than restating them, then asserts each derives from `{dataset_prefix}_stim_full` and actually resolves. Restating the strings is what let the old `_SCREEN_SUFFIX` guard drift, so this one can't. Mutation-checked — restoring the pre-#2488 bare name fails both of its tests.

**Docs** — `developer_clarifications.rst` gains the convention as item 4, and its existing Result Caching entry is corrected: it predates the shared S3 cache entirely and recommends `RESULTCACHING_DISABLE=1` without noting that this also disables `place_on_screen`. That specific trap shifted ridgecv scores ~1.5% and produced a false "cache is unsafe" reading during this work, so it is now called out with the module-scoped form.

The documented example and counter-example are both executed and behave as written.

## Scope

Only applies to *synthesised* stimulus sets. A benchmark using a registered set directly already resolves, and needs nothing.

108 tests pass across `benchmark_helpers`, `laion_fmri`, and `test_cache_key`.