### PR TITLE
feat(models): add seresnext50_32x4d (timm racm_in1k)

### DIFF
--- a/brainscore_vision/models/seresnext50_32x4d/__init__.py
+++ b/brainscore_vision/models/seresnext50_32x4d/__init__.py
@@ -1,0 +1,13 @@
+from brainscore_vision import model_registry
+from brainscore_vision.model_helpers.brain_transformation import ModelCommitment
+
+from .model import get_layers, get_model
+
+# Explicit behavioural readout: ModelCommitment otherwise defaults to layers[-1],
+# so the choice would silently depend on list order.
+model_registry['seresnext50_32x4d'] = lambda: ModelCommitment(
+    identifier='seresnext50_32x4d',
+    activations_model=get_model('seresnext50_32x4d'),
+    layers=get_layers('seresnext50_32x4d'),
+    behavioral_readout_layer='fc',
+)

--- a/brainscore_vision/models/seresnext50_32x4d/model.py
+++ b/brainscore_vision/models/seresnext50_32x4d/model.py
@@ -1,0 +1,45 @@
+import functools
+
+import timm
+
+from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
+from brainscore_vision.model_helpers.activations.pytorch import load_preprocess_images
+from brainscore_vision.model_helpers.check_submission import check_models
+
+IDENTIFIER = 'seresnext50_32x4d'
+# racm_in1k is the stronger of the two available tags (ImageNet top-1 ~81.3 vs
+# ~79.9 for gluon_in1k).
+TIMM_NAME = 'seresnext50_32x4d.racm_in1k'
+IMAGE_SIZE = 224
+
+
+def get_model(name):
+    assert name == IDENTIFIER
+    model = timm.create_model(TIMM_NAME, pretrained=True)
+    model.eval()
+    # timm reports mean=(0.485, 0.456, 0.406) std=(0.229, 0.224, 0.225) for this
+    # tag, which is what load_preprocess_images already applies by default.
+    preprocessing = functools.partial(load_preprocess_images, image_size=IMAGE_SIZE)
+    wrapper = PytorchWrapper(identifier=IDENTIFIER, model=model, preprocessing=preprocessing)
+    wrapper.image_size = IMAGE_SIZE
+    return wrapper
+
+
+def get_layers(name):
+    assert name == IDENTIFIER
+    # The four residual stages plus the stem, and the classifier for the
+    # behavioural readout.
+    return ['conv1', 'layer1', 'layer2', 'layer3', 'layer4', 'fc']
+
+
+def get_bibtex(model_identifier):
+    return """@inproceedings{hu2018squeeze,
+    title = {Squeeze-and-Excitation Networks},
+    author = {Hu, Jie and Shen, Li and Sun, Gang},
+    booktitle = {Proceedings of the IEEE Conference on Computer Vision and Pattern Recognition},
+    year = {2018},
+}"""
+
+
+if __name__ == '__main__':
+    check_models.check_base_models(__name__)

--- a/brainscore_vision/models/seresnext50_32x4d/region_layer_map/seresnext50_32x4d.json
+++ b/brainscore_vision/models/seresnext50_32x4d/region_layer_map/seresnext50_32x4d.json
@@ -1,0 +1,6 @@
+{
+    "V1": "layer2",
+    "V2": "layer2",
+    "V4": "layer2",
+    "IT": "layer3"
+}

--- a/brainscore_vision/models/seresnext50_32x4d/requirements.txt
+++ b/brainscore_vision/models/seresnext50_32x4d/requirements.txt
@@ -1,0 +1,3 @@
+torch
+torchvision
+timm

--- a/brainscore_vision/models/seresnext50_32x4d/test.py
+++ b/brainscore_vision/models/seresnext50_32x4d/test.py
@@ -1,0 +1,9 @@
+import pytest
+
+import brainscore_vision
+
+
+@pytest.mark.travis_slow
+def test_has_identifier():
+    model = brainscore_vision.load_model('seresnext50_32x4d')
+    assert model.identifier == 'seresnext50_32x4d'


### PR DESCRIPTION
## Model

`seresnext50_32x4d` from timm, tag `seresnext50_32x4d.racm_in1k` — the stronger of the two available tags (~81.3 ImageNet top-1 vs ~79.9 for `gluon_in1k`). 27.6M params, 224x224.

**Squeeze-and-excitation is entirely unrepresented**: zero `seresnext`, `se_resnext`, or `resnest` models are registered today. This adds a real architectural axis (channel attention on top of grouped convolutions) rather than another point near an existing cluster — `convnext`, by comparison, already has 38 entries.

It is also deliberately comparable to `regnety_032` (19.4M, ~82 top-1, screen score 0.3434), so it doubles as a second model for exercising the activation cache end to end.

## Layers

```
['conv1', 'layer1', 'layer2', 'layer3', 'layer4', 'fc']
```

All six verified present on the instantiated graph.

`behavioral_readout_layer='fc'` set **explicitly** — `ModelCommitment` otherwise falls back to `layers[-1]`, which would make the readout silently depend on list order, and the readout drives the behavioural benchmarks.

## Preprocessing

Checked rather than assumed: timm resolves `mean=(0.485, 0.456, 0.406)`, `std=(0.229, 0.224, 0.225)`, `input=(3, 224, 224)` for this tag — exactly what `load_preprocess_images` applies by default, so no override is needed.

## Checks run

- registers in `model_registry`
- `ImportPlugin.locate_plugin()` resolves it (single literal `model_registry['seresnext50_32x4d']` line, which is what discovery greps for)
- every declared layer exists on the module graph
- weights not downloaded locally; the plugin test exercises the real load in CI