### PR TITLE
Include preprocessing fingerprint in activation cache key

### DIFF
--- a/brainscore_vision/model_helpers/activations/core.py
+++ b/brainscore_vision/model_helpers/activations/core.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import cv2
+import re
 import tempfile
 from typing import Dict, Tuple, List, Union
 
@@ -10,6 +11,7 @@ from collections import OrderedDict
 from multiprocessing.pool import ThreadPool
 
 import numpy as np
+from PIL import Image
 from tqdm.auto import tqdm
 import xarray as xr
 
@@ -25,6 +27,97 @@ class Defaults:
     batch_size = 64
 
 
+# Preprocessing resolution, for the stored-activations cache key
+# ---------------------------------------------------------------
+# `_from_paths_stored` keys on the model identifier, which says nothing about
+# the resolution the model is fed. Two commitments that share an identifier but
+# bind a different `image_size` into their preprocessing therefore collide: the
+# second is served the first one's activations, no preprocessing runs, and the
+# benchmark returns a plausible score for a resolution the model never saw.
+#
+# The resolution is measured by *calling* the preprocessing once, rather than by
+# reading `wrapper.image_size`. That attribute is informative only -- nothing in
+# the framework consults it -- and plugins exist whose preprocessing produces
+# something other than what the attribute claims. Only the shape and dtype go
+# into the key: the shared cache is served by a fleet whose image changes, and a
+# fingerprint sensitive to torch or platform differences would orphan it.
+
+# Key component used when no resolution could be measured. Keeping such a
+# request cacheable under a marked key is no worse than the behaviour before
+# this existed, and it stays visible in the filename.
+NO_RESOLUTION = 'unprobed'
+
+# Neither square nor a common model input size, so a preprocessing that hands
+# its input back unchanged cannot be mistaken for one that resizes.
+_PROBE_IMAGE_SHAPE = (137, 211, 3)  # height, width, RGB
+
+# The component goes into a filename and into a `,`-joined parameter list, so
+# anything that is not digits, `x`, `-` and the dtype name is refused.
+_RESOLUTION_FORMAT = re.compile(r'^\d+(x\d+)*-\w+$')
+
+_logger = logging.getLogger(__name__)
+_probe_image_path = None
+
+
+def _probe_image():
+    """Path to the synthetic probe image, written once per process."""
+    global _probe_image_path
+    if _probe_image_path is None or not os.path.isfile(_probe_image_path):
+        pixels = np.random.RandomState(0).randint(0, 256, _PROBE_IMAGE_SHAPE, dtype=np.uint8)
+        directory = tempfile.mkdtemp(prefix='brainscore-resolution-probe-')
+        path = os.path.join(directory, 'probe.png')
+        Image.fromarray(pixels).save(path)
+        _probe_image_path = path
+    return _probe_image_path
+
+
+def probe_preprocessing_resolution(preprocess, probe_paths=None):
+    """Measure what `preprocess` feeds the model, as a cache-key component.
+
+    Calls `preprocess` the way `_get_batch_activations` does -- with a list of
+    image file paths -- and reports the shape and dtype of what comes back, e.g.
+    ``'3x224x224-float32'``. The batch dimension is left out: it is the number of
+    probe images, not a property of the model.
+
+    :param preprocess: the extractor's preprocessing callable.
+    :param probe_paths: image paths to probe with; defaults to a single
+        synthetic image. Only useful for asserting that the batch dimension
+        stays out of the result.
+    :return: the key component, or `NO_RESOLUTION` if nothing could be measured.
+
+    Never raises. This runs while an extractor is being constructed, for every
+    model in the registry; a preprocessing that cannot be probed must cost a
+    coarser cache key, never a model that cannot be instantiated.
+    """
+    try:
+        paths = list(probe_paths) if probe_paths is not None else [_probe_image()]
+        preprocessed = preprocess(paths)
+        # Two containers occur in the wild: a stacked array whose first axis is
+        # the batch, and a list of per-image tensors (omnivore_*). An element of
+        # the latter carries the non-batch shape already.
+        if isinstance(preprocessed, (list, tuple)):
+            if len(preprocessed) == 0:
+                return NO_RESOLUTION
+            sample, leading_axis_is_batch = preprocessed[0], False
+        else:
+            sample, leading_axis_is_batch = preprocessed, True
+        shape = getattr(sample, 'shape', None)
+        dtype = getattr(sample, 'dtype', None)
+        # A preprocessing that is the identity (`preprocessing=None`, see
+        # `__init__`) hands back the paths it was given, so `sample` is a str
+        # and there is no resolution to speak of.
+        if shape is None or dtype is None:
+            return NO_RESOLUTION
+        dimensions = tuple(shape)[1:] if leading_axis_is_batch else tuple(shape)
+        # `torch.float32` and numpy's `float32` must not key differently.
+        component = 'x'.join(str(int(d)) for d in dimensions) + '-' + str(dtype).replace('torch.', '')
+        return component if _RESOLUTION_FORMAT.match(component) else NO_RESOLUTION
+    except Exception as e:  # noqa: BLE001 - a failed probe must not fail a run
+        _logger.debug(f"Could not probe the preprocessing resolution ({type(e).__name__}: {e}), "
+                      f"caching under `{NO_RESOLUTION}`")
+        return NO_RESOLUTION
+
+
 class ActivationsExtractorHelper:
     def __init__(self, get_activations, preprocessing, identifier=False, batch_size=Defaults.batch_size):
         """
@@ -36,6 +129,9 @@ class ActivationsExtractorHelper:
         self.identifier = identifier
         self.get_activations = get_activations
         self.preprocess = preprocessing or (lambda x: x)
+        # Probed once here rather than per request: it costs a few milliseconds
+        # and cannot change for the life of the extractor.
+        self._resolution = probe_preprocessing_resolution(self.preprocess)
         self._stimulus_set_hooks = {}
         self._batch_activations_hooks = {}
         self._microsaccade_helper = MicrosaccadeHelper()
@@ -100,6 +196,9 @@ class ActivationsExtractorHelper:
             fnc = functools.partial(self._from_paths_stored,
                                     identifier=cache_identifier,
                                     stimuli_identifier=cache_stimuli_identifier,
+                                    # getattr: extractors built with `__new__`
+                                    # never ran `__init__` and have no probe.
+                                    resolution=getattr(self, '_resolution', None) or NO_RESOLUTION,
                                     require_variance=require_variance)
         else:
             self._logger.debug(f"self.identifier `{self.identifier}` or stimuli_identifier {stimuli_identifier} "
@@ -122,8 +221,15 @@ class ActivationsExtractorHelper:
         return activations
 
     @store_xarray(identifier_ignore=['stimuli_paths', 'layers'], combine_fields={'layers': 'layer'})
-    def _from_paths_stored(self, identifier, layers, stimuli_identifier,
+    def _from_paths_stored(self, identifier, layers, stimuli_identifier, resolution,
                            stimuli_paths, number_of_trials: int = 1, require_variance: bool = False):
+        """`resolution` is used *only* to build the cache key -- like `identifier`
+        and `stimuli_identifier`, it is not forwarded into `_from_paths`. It sits
+        behind `stimuli_identifier` on purpose: `brainscore_vision.score_model`
+        prints a cache-cleanup hint globbing
+        `identifier=...,stimuli_identifier=*.pkl`, which a component inserted
+        ahead of `stimuli_identifier` would silently stop matching.
+        """
         return self._from_paths(layers=layers, stimuli_paths=stimuli_paths, require_variance=require_variance)
 
     def _from_paths(self, layers, stimuli_paths, require_variance: bool = False):

--- a/tests/test_model_helpers/activations/test_preprocessing_resolution.py
+++ b/tests/test_model_helpers/activations/test_preprocessing_resolution.py
@@ -1,0 +1,219 @@
+"""The preprocessing resolution as part of the stored-activations cache key.
+
+Two properties are under test. First, the component must actually distinguish
+what it claims to: two commitments sharing an identifier but preprocessing to
+different resolutions must not share a cache entry. Second, measuring it must
+never be able to fail a scoring run -- the probe runs while an extractor is
+being constructed, so anything it cannot measure degrades to `NO_RESOLUTION`
+rather than raising.
+
+These use stub preprocessing callables and a stub extractor rather than real
+models: the point is the call path and the key, and loading models here would
+make the suite unrunnable locally.
+"""
+import fnmatch
+import functools
+import inspect
+import os
+import unittest.mock as mock
+
+import numpy as np
+import pytest
+import torch
+
+from brainscore_vision.model_helpers.activations.core import (
+    ActivationsExtractorHelper, NO_RESOLUTION, _probe_image, probe_preprocessing_resolution)
+from brainscore_vision.model_helpers.activations.pytorch import load_preprocess_images
+from result_caching import get_function_identifier
+
+
+def preprocessing_at(image_size):
+    """The idiom 519 of the 552 image plugins use, at a chosen resolution."""
+    return functools.partial(load_preprocess_images, image_size=image_size)
+
+
+def build_extractor(preprocessing, identifier='alexnet'):
+    """A real extractor -- `__init__` runs, so the probe runs."""
+    return ActivationsExtractorHelper(get_activations=mock.Mock(), preprocessing=preprocessing,
+                                      identifier=identifier)
+
+
+def unwrap_stored():
+    """`store_xarray` wraps without `functools.wraps`, so the decorated method
+    reports `(*args, **kwargs)`. The undecorated function and the storage that
+    holds `identifier_ignore` are reachable through the closure."""
+    cells = [cell.cell_contents for cell in ActivationsExtractorHelper._from_paths_stored.__closure__]
+    function = next(c for c in cells if inspect.isfunction(c))
+    storage = next(c for c in cells if hasattr(c, 'identifier_ignore'))
+    return function, storage
+
+
+class TestComponentDistinguishesResolutions:
+    """The reason the component exists: same identifier, different input size."""
+
+    def test_same_resolution_same_component(self):
+        """Guards against a probe that is not deterministic -- a component that
+        varied per call would key every request separately and disable the cache."""
+        assert (probe_preprocessing_resolution(preprocessing_at(224))
+                == probe_preprocessing_resolution(preprocessing_at(224)))
+
+    def test_different_resolution_different_component(self):
+        assert (probe_preprocessing_resolution(preprocessing_at(224))
+                != probe_preprocessing_resolution(preprocessing_at(64)))
+
+    def test_component_reports_shape_and_dtype(self):
+        assert probe_preprocessing_resolution(preprocessing_at(224)) == '3x224x224-float32'
+
+    def test_component_is_filename_safe(self):
+        """It is spliced into a path and into a `,`-joined parameter list."""
+        component = probe_preprocessing_resolution(preprocessing_at(224))
+        assert not (set(component) & set('/\\:,; '))
+
+
+class TestWhatGoesIntoTheComponent:
+
+    def test_batch_dimension_is_not_in_the_component(self):
+        """The leading axis is the number of probe images, not a property of the
+        model, so probing with one or two images must give the same answer."""
+        preprocess, image = preprocessing_at(224), _probe_image()
+        one = probe_preprocessing_resolution(preprocess, probe_paths=[image] * 1)
+        two = probe_preprocessing_resolution(preprocess, probe_paths=[image] * 2)
+        assert one == two == '3x224x224-float32'
+
+    def test_dtype_is_normalised_across_frameworks(self):
+        """`str(torch.float32)` is `'torch.float32'`, numpy's is `'float32'`.
+        Unnormalised, two plugins at the same resolution would key differently."""
+        as_torch = probe_preprocessing_resolution(lambda paths: torch.zeros(len(paths), 3, 224, 224))
+        as_numpy = probe_preprocessing_resolution(
+            lambda paths: np.zeros((len(paths), 3, 224, 224), dtype=np.float32))
+        assert as_torch == as_numpy == '3x224x224-float32'
+
+    def test_list_container_is_unwrapped(self):
+        """`omnivore_*` returns a list of per-image tensors rather than a stacked
+        array; the resolution is in there and must still be found."""
+        preprocess = lambda paths: [torch.zeros(3, 1, 224, 224) for _ in paths]
+        assert probe_preprocessing_resolution(preprocess) == '3x1x224x224-float32'
+
+    def test_list_element_shape_is_already_non_batch(self):
+        """The list length is the batch, so no axis may be dropped from the element."""
+        preprocess = lambda paths: [torch.zeros(3, 224, 224) for _ in paths]
+        assert probe_preprocessing_resolution(preprocess) == '3x224x224-float32'
+
+
+class TestProbeFailureFallsBackToTheSentinel:
+    """`NO_RESOLUTION` rather than an exception or a silently absent component:
+    the key stays as good as it was before this existed, and the filename shows
+    where the coverage ends.
+    """
+
+    def test_identity_preprocessing_is_unprobed(self):
+        """`preprocessing=None` becomes `lambda x: x` in `__init__`, so the probe
+        gets its own paths back. Five plugins do this (`pixels`, `gabor_filter_*`);
+        they apply their resolution inside `get_activations` instead."""
+        extractor = build_extractor(preprocessing=None)
+        assert extractor._resolution == NO_RESOLUTION
+
+    def test_raising_preprocessing_is_unprobed(self):
+        def preprocess(paths):
+            raise RuntimeError("this plugin cannot be probed")
+        assert probe_preprocessing_resolution(preprocess) == NO_RESOLUTION
+
+    def test_probe_never_raises_out_of_init(self):
+        """The constructor runs for every model in the registry; a preprocessing
+        that cannot be probed must not be a model that cannot be built."""
+        def preprocess(paths):
+            raise RuntimeError("this plugin cannot be probed")
+        extractor = build_extractor(preprocessing=preprocess)
+        assert extractor._resolution == NO_RESOLUTION
+
+    @pytest.mark.parametrize('preprocess,reason', [
+        (lambda paths: paths, "identity, elements are str"),
+        (lambda paths: [], "empty batch"),
+        (lambda paths: np.zeros(4), "only a batch axis, no resolution left"),
+        (lambda paths: 'not an array', "no shape at all"),
+    ])
+    def test_unmeasurable_results_are_unprobed(self, preprocess, reason):
+        assert probe_preprocessing_resolution(preprocess) == NO_RESOLUTION, reason
+
+
+class TestComponentReachesTheCacheKey:
+    """A component that never arrives at `_from_paths_stored` keys nothing."""
+
+    def _extractor_with_mocked_store(self, preprocessing):
+        extractor = build_extractor(preprocessing)
+        extractor._from_paths_stored = mock.Mock(return_value='ASSEMBLY')
+        extractor._from_paths = mock.Mock(return_value='ASSEMBLY')
+        return extractor
+
+    def _resolution_passed_by(self, preprocessing):
+        extractor = self._extractor_with_mocked_store(preprocessing)
+        result = extractor.from_paths(stimuli_paths=['x.png'], layers=['fc'],
+                                      stimuli_identifier='Papale2025')
+        assert result == 'ASSEMBLY', "the returned assembly must be untouched"
+        return extractor._from_paths_stored.call_args[1]['resolution']
+
+    def test_different_resolutions_reach_the_stored_call_differently(self):
+        """The collision from the issue, at the boundary that actually keys."""
+        assert self._resolution_passed_by(preprocessing_at(224)) == '3x224x224-float32'
+        assert self._resolution_passed_by(preprocessing_at(64)) == '3x64x64-float32'
+
+    def test_sentinel_reaches_the_stored_call(self):
+        assert self._resolution_passed_by(None) == NO_RESOLUTION
+
+    def test_resolution_is_not_ignored_when_building_the_key(self):
+        """`identifier_ignore` decides what `store_xarray` leaves out of the key.
+        Listing `resolution` there would make the whole change a no-op."""
+        _, storage = unwrap_stored()
+        assert 'resolution' not in storage.identifier_ignore
+
+    def test_extractor_built_without_init_still_keys(self):
+        """`test_cache_key.py` stubs extractors with `__new__`, so `__init__` never
+        runs and there is no probed attribute. Reading it must not raise."""
+        extractor = ActivationsExtractorHelper.__new__(ActivationsExtractorHelper)
+        extractor.identifier = 'alexnet'
+        extractor._logger = mock.Mock()
+        extractor._from_paths_stored = mock.Mock(return_value='ASSEMBLY')
+        extractor._from_paths = mock.Mock(return_value='ASSEMBLY')
+        extractor._reduce_paths = lambda paths: paths
+        extractor._expand_paths = lambda a, original_paths: a
+        extractor.from_paths(stimuli_paths=['x.png'], layers=['fc'],
+                             stimuli_identifier='Papale2025')
+        assert extractor._from_paths_stored.call_args[1]['resolution'] == NO_RESOLUTION
+
+
+class TestPublicSignaturesUnchanged:
+    """Only the private `_from_paths_stored` gains a parameter. Plugins call the
+    public methods -- five of them via `super().from_paths(*args, **kwargs)`.
+    """
+
+    @pytest.mark.parametrize('method,parameters', [
+        ('from_paths', ['self', 'stimuli_paths', 'layers', 'stimuli_identifier', 'require_variance']),
+        ('from_stimulus_set', ['self', 'stimulus_set', 'layers', 'stimuli_identifier', 'require_variance']),
+        ('__call__', ['self', 'stimuli', 'layers', 'stimuli_identifier', 'number_of_trials',
+                      'require_variance']),
+    ])
+    def test_public_signature_is_untouched(self, method, parameters):
+        signature = inspect.signature(getattr(ActivationsExtractorHelper, method))
+        assert list(signature.parameters) == parameters
+
+    def test_resolution_sits_behind_stimuli_identifier(self):
+        """Position is load-bearing: `brainscore_vision.score_model` prints a
+        cache-cleanup hint globbing `identifier=...,stimuli_identifier=*.pkl`,
+        and `result_caching` orders key parameters by signature position. A
+        component ahead of `stimuli_identifier` makes that hint match nothing.
+        """
+        function, _ = unwrap_stored()
+        parameters = list(inspect.signature(function).parameters)
+        assert parameters.index('resolution') == parameters.index('stimuli_identifier') + 1
+
+    def test_cleanup_hint_glob_still_matches_the_stored_filename(self):
+        """The consequence of that position, measured rather than asserted: build
+        the name `result_caching` would store under and match it against the glob
+        `brainscore_vision.score_model` prints. Kept as a literal here because it
+        is built inline in an f-string there and cannot be imported."""
+        function, _ = unwrap_stored()
+        key_arguments = dict(identifier='alexnet', stimuli_identifier='hvm-public',
+                             resolution='3x224x224-float32', number_of_trials=1,
+                             require_variance=False)
+        filename = os.path.basename(get_function_identifier(function, key_arguments)) + '.pkl'
+        assert fnmatch.fnmatch(filename, 'identifier=alexnet,stimuli_identifier=*.pkl')


### PR DESCRIPTION
The stored-activation key was built from identifier, stimuli_identifier, number_of_trials and require_variance only. Preprocessing resolution is bound into the preprocessing closure and could not reach the key, so two extractors sharing an identifier but differing in input resolution served each other's cached activations silently.

Probe the preprocessing callable once per extractor with a synthetic image and pass the resulting shape/dtype fingerprint as an explicit parameter of _from_paths_stored. Extractors whose preprocessing cannot be probed key on 'unprobed'.

Fixes #2503