### PR TITLE
fix(benchmarks): attach raw score to Cowley2026 combined benchmark

### DIFF
--- a/brainscore_vision/benchmarks/cowley2026/benchmark.py
+++ b/brainscore_vision/benchmarks/cowley2026/benchmark.py
@@ -34,6 +34,7 @@ class _CombinedNeuralBenchmark(BenchmarkBase):
     def __call__(self, candidate):
         scores = [benchmark(candidate) for benchmark in self._sessions]
         combined = Score(np.mean([score.values for score in scores]))
+        combined.attrs[Score.RAW_VALUES_KEY] = Score(np.mean([score.raw.values for score in scores]))
         combined.attrs['ceiling'] = self.ceiling
         combined.attrs['session_scores'] = {b.identifier: float(s.values)
                                              for b, s in zip(self._sessions, scores)}


### PR DESCRIPTION
## Problem

Scoring a model on `Cowley2026.V4-pls` computes fine but fails on the DB write:

```
ERROR root Could not run model ... on benchmark Cowley2026.V4-pls because of 'Score' object has no attribute 'raw'
  File "brainscore_core/submission/database.py", line 394, in update_score
    score_raw = _retrieve_score_center(score.raw)
AttributeError: 'Score' object has no attribute 'raw'
```

`update_score` branches on `'ceiling' in score.attrs`: with a ceiling present it stores both the ceiled and the raw value. `_CombinedNeuralBenchmark.__call__` built a fresh `Score` from the mean of the per-session scores and attached `ceiling`, but never carried `raw` up, so the submission was stored as a failure.

## Fix

Aggregate the per-session raw scores the same way the ceiled scores are aggregated. Per-session `NeuralBenchmark` scores already carry `raw` from `explained_variance`.

## Verification

Fed two synthetic session scores (r = 0.5, 0.6, ceiling 0.8) through `explained_variance` -> the combined aggregation -> `update_score`: `score_raw` 0.55, `score_ceiled` 0.381, matching the means of the session raw and ceiled values. No change to the ceiled score, so the pinned alexnet test value is unaffected.