### PR TITLE
fix(models): scope the ViT activation-cache disable to the model's own calls

### DIFF
--- a/brainscore_vision/model_helpers/activations/pytorch.py
+++ b/brainscore_vision/model_helpers/activations/pytorch.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 import logging
+import os
 import numpy as np
 from PIL import Image
 
@@ -176,3 +177,49 @@ def torchvision_preprocess(preprocess_type="imagenet", **kwargs):
         ])
     else:
         raise ValueError(f"Unknown preprocess_type '{preprocess_type}'")
+
+
+class _CacheDisabledExtractorCall:
+    """Wraps an extractor so activation caching is off only for *its* calls.
+
+    Some models cannot use the stored-activation cache: `combine_fields`
+    accumulates layers into one entry, and merging a rank-2 transformer block
+    (``channel``, ``embedding``) with a rank-1 classifier (``channel``,
+    ``channel_x``, ``channel_y``) raises, because the neuroid coordinate schemes
+    differ. See brain-score/vision#1232 and the follow-up issue.
+
+    The workaround those plugins used was to set ``RESULTCACHING_DISABLE`` at
+    model-construction time and never restore it. That is process-global: in a
+    session scoring several models, every model loaded afterwards also ran
+    uncached, silently. Scoping it to the call restores the variable afterwards,
+    including when the extraction raises.
+    """
+
+    def __init__(self, wrapper, disable_value):
+        self._wrapper = wrapper
+        self._disable_value = disable_value
+
+    def __call__(self, *args, **kwargs):
+        previous = os.environ.get('RESULTCACHING_DISABLE')
+        os.environ['RESULTCACHING_DISABLE'] = self._disable_value
+        try:
+            return self._wrapper(*args, **kwargs)
+        finally:
+            # restore, including the "was unset" case -- assigning '' would
+            # leave a value that `_match_identifier` treats as "disable nothing",
+            # which is right, but the variable should simply not be there.
+            if previous is None:
+                os.environ.pop('RESULTCACHING_DISABLE', None)
+            else:
+                os.environ['RESULTCACHING_DISABLE'] = previous
+
+    def __getattr__(self, item):
+        # everything else -- identifier, image_size, layers -- passes through
+        return getattr(self._wrapper, item)
+
+
+def disable_activation_caching(wrapper):
+    """Return `wrapper` with activation caching disabled for its own calls only."""
+    return _CacheDisabledExtractorCall(
+        wrapper, 'brainscore_vision.model_helpers.activations.core.'
+                 'ActivationsExtractorHelper._from_paths_stored')

--- a/brainscore_vision/models/blur_timm_models/model.py
+++ b/brainscore_vision/models/blur_timm_models/model.py
@@ -9,7 +9,8 @@ import numpy as np
 import torchvision.transforms as T
 from PIL import Image
 
-from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
+from brainscore_vision.model_helpers.activations.pytorch import (
+    PytorchWrapper, disable_activation_caching)
 
 # Disable SSL verification 
 ssl._create_default_https_context = ssl._create_unverified_context
@@ -67,10 +68,6 @@ def get_model(model_id:str):
     timm_model_name = config["timm_model_name"]
     is_vit = config["is_vit"]
     
-    # Temporary fix for vit models
-    # See https://github.com/brain-score/vision/pull/1232
-    if is_vit:
-        os.environ['RESULTCACHING_DISABLE'] = 'brainscore_vision.model_helpers.activations.core.ActivationsExtractorHelper._from_paths_stored'
 
     
     # Initialize model
@@ -90,4 +87,9 @@ def get_model(model_id:str):
     wrapper = PytorchWrapper(
         identifier=model_id, model=model, preprocessing=preprocessing
     )
+    # ViT layer sets cannot share a cache entry: merging a rank-2 block with
+    # a rank-1 classifier raises on mismatched neuroid coords (#1232). Scope the
+    # disable to this model's own calls rather than leaking it process-wide.
+    if is_vit:
+        wrapper = disable_activation_caching(wrapper)
     return wrapper

--- a/brainscore_vision/models/scaling_models/model.py
+++ b/brainscore_vision/models/scaling_models/model.py
@@ -7,7 +7,8 @@ import ssl
 import torchvision.models
 import torch
 
-from brainscore_vision.model_helpers.activations.pytorch import PytorchWrapper
+from brainscore_vision.model_helpers.activations.pytorch import (
+    PytorchWrapper, disable_activation_caching)
 from brainscore_vision.model_helpers.activations.pytorch import load_preprocess_images
 
 import timm
@@ -100,10 +101,6 @@ def get_model(model_id:str):
     output_head = config["output_head"]
     is_vit = config["is_vit"]
     
-    # Temporary fix for vit models
-    # See https://github.com/brain-score/vision/pull/1232
-    if is_vit:
-        os.environ['RESULTCACHING_DISABLE'] = 'brainscore_vision.model_helpers.activations.core.ActivationsExtractorHelper._from_paths_stored'
 
     
     # Initialize model
@@ -145,4 +142,9 @@ def get_model(model_id:str):
     wrapper = PytorchWrapper(
         identifier=model_id, model=model, preprocessing=preprocessing
     )
+    # ViT layer sets cannot share a cache entry: merging a rank-2 block with
+    # a rank-1 classifier raises on mismatched neuroid coords (#1232). Scope the
+    # disable to this model's own calls rather than leaking it process-wide.
+    if is_vit:
+        wrapper = disable_activation_caching(wrapper)
     return wrapper


### PR DESCRIPTION
## The leak

`scaling_models/model.py` and `blur_timm_models/model.py` both do this at model-construction time and never restore it:

```python
# Temporary fix for vit models
# See https://github.com/brain-score/vision/pull/1232
if is_vit:
    os.environ['RESULTCACHING_DISABLE'] = '...ActivationsExtractorHelper._from_paths_stored'
```

`RESULTCACHING_DISABLE` is process-global, so **every model loaded afterwards in the same process also runs uncached**, silently. In Batch each job is its own container, so production is unaffected; a local session scoring several models is not.

Surfaced by the per-call outcome logging in `result_caching` 0.5 — build 111 reported `outcome=disabled` for the activation cache on a `scaling_models` ViT while `_ceiling` and `_place_on_screen` stayed enabled, which is the signature of a module-scoped disable rather than `=1`.

## The fix

`disable_activation_caching()` in `model_helpers/activations/pytorch.py` wraps the extractor so the variable is set for that model's own calls and restored in a `finally`. It handles the previously-unset case (pops rather than writing `''`) and restores when extraction raises — `hmax/helpers/pytorch.py:42-45` has the same pattern without the restore-on-raise.

Verified behaviourally:

```
inside call       -> disabled
after call        -> <unset>
prior value kept  -> preexisting
restored on raise -> preexisting
ViT then another model -> second model NOT disabled
```

## The workaround itself is still needed

Reproduced on current master, xarray 2022.3.0:

```
AssertionError: Length of new_levels (5) must be <= self.nlevels (4)
```

Merging a rank-2 transformer block (`channel`, `embedding`) with a rank-1 classifier (`channel`, `channel_x`, `channel_y`) into one cache entry still fails, so removing the disable would break these models. Note #1232 was **closed, not merged** — the env-var workaround is what shipped. Written up properly in #2514.

Enabling the cache by default did not widen the exposure: zero merge errors across 1,006 score rows since Aug 12 (the one merge-shaped failure in the DB is `VOneCORnet-S` from January 2025).

## Tests

`tests/test_model_helpers/activations/` is **19 failed, 260 passed** on this branch and **19 failed, 260 passed** on master — identical, so nothing here is introduced by this change. The pre-existing failures are unrelated (`test_exact_activations`, `test_from_image_path`, `test_from_stimulus_set`) and reproduce on a clean checkout.
