### PR TITLE
fix(cowley2026): add url and doi to BIBTEX

### DIFF
--- a/brainscore_vision/benchmarks/cowley2026/benchmark.py
+++ b/brainscore_vision/benchmarks/cowley2026/benchmark.py
@@ -16,7 +16,9 @@ BIBTEX = """@article{cowley2026compact,
   number={8111},
   pages={947--954},
   year={2026},
-  publisher={Nature Publishing Group}}"""
+  publisher={Nature Publishing Group},
+  doi={10.1038/s41586-026-10150-1},
+  url={https://doi.org/10.1038/s41586-026-10150-1}}"""
 
 # no object categories -> plain random CV splits, not object_name stratification
 pls_metric = lambda: load_metric('pls', crossvalidation_kwargs=dict(stratification_coord=None))


### PR DESCRIPTION
Adds `url` and `doi` to the Cowley2026 `BIBTEX`.

`reference_from_bibtex` in `brainscore_core/submission/database.py` looks up `entry.fields['url']`. The bibtex had no `url`, so the lookup raised `KeyError`, the bare `except Exception` swallowed it, and the function returned `None`. The benchmark type was therefore created with a null reference and shows no citation on the leaderboard.

The DOI is `10.1038/s41586-026-10150-1`, matching the volume, issue, and pages already in the entry.

Note that this does not repair the existing row. The reference is only attached inside the `if created:` block when the benchmark type is first inserted, so the already-created `Cowley2026.V4-pls` needs a separate database fix.
